### PR TITLE
Tcp handles

### DIFF
--- a/src/main/kotlin/io/libp2p/core/transport/tcp/TcpTransport.kt
+++ b/src/main/kotlin/io/libp2p/core/transport/tcp/TcpTransport.kt
@@ -2,6 +2,7 @@ package io.libp2p.core.transport.tcp
 
 import io.libp2p.core.Connection
 import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.multiformats.Protocol
 import io.libp2p.core.transport.ConnectionUpgrader
 import io.libp2p.core.transport.Transport
 import io.libp2p.core.types.toCompletableFuture
@@ -26,7 +27,8 @@ class TcpTransport(val upgrader: ConnectionUpgrader) : Transport {
 
     // Checks if this transport can handle this multiaddr. It should return true for multiaddrs containing `tcp` atoms.
     override fun handles(addr: Multiaddr): Boolean {
-        return false
+        return addr.components
+            .any { pair -> pair.first == Protocol.TCP }
     }
 
     // Closes this transport entirely, aborting all ongoing connections and shutting down any listeners.

--- a/src/test/kotlin/io/libp2p/core/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/core/transport/tcp/TcpTransportTest.kt
@@ -1,0 +1,39 @@
+package io.libp2p.core.transport.tcp
+
+import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.transport.ConnectionUpgrader
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class TcpTransportTest {
+
+    companion object {
+        @JvmStatic
+        fun validMultiaddrs() = listOf(
+            "/ip4/1.2.3.4/tcp/1234",
+            "/ip6/fe80::6f77:b303:aa6e:a16/tcp/42"
+        ).map { Multiaddr(it) }
+
+        @JvmStatic
+        fun invalidMultiaddrs() = listOf(
+            "/ip4/1.2.3.4/udp/42",
+            "/unix/a/file/named/tcp"
+        ).map { Multiaddr(it) }
+    }
+
+    private val upgrader = ConnectionUpgrader(emptyList(), emptyList())
+
+    @ParameterizedTest
+    @MethodSource("validMultiaddrs")
+    fun `handles(addr) returns true if addr contains tcp protocol` (addr: Multiaddr) {
+        val tcp = TcpTransport(upgrader)
+        assert(tcp.handles(addr))
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidMultiaddrs")
+    fun `handles(addr) returns false if addr does not contain tcp protocol` (addr: Multiaddr) {
+        val tcp = TcpTransport(upgrader)
+        assert(!tcp.handles(addr))
+    }
+}

--- a/src/test/kotlin/io/libp2p/core/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/core/transport/tcp/TcpTransportTest.kt
@@ -25,14 +25,14 @@ class TcpTransportTest {
 
     @ParameterizedTest
     @MethodSource("validMultiaddrs")
-    fun `handles(addr) returns true if addr contains tcp protocol` (addr: Multiaddr) {
+    fun `handles(addr) returns true if addr contains tcp protocol`(addr: Multiaddr) {
         val tcp = TcpTransport(upgrader)
         assert(tcp.handles(addr))
     }
 
     @ParameterizedTest
     @MethodSource("invalidMultiaddrs")
-    fun `handles(addr) returns false if addr does not contain tcp protocol` (addr: Multiaddr) {
+    fun `handles(addr) returns false if addr does not contain tcp protocol`(addr: Multiaddr) {
         val tcp = TcpTransport(upgrader)
         assert(!tcp.handles(addr))
     }


### PR DESCRIPTION
I had a hard time falling asleep last night, so I decided to poke around at jvm-libp2p and find something simple to do 😄 

This implements `TcpTransport#handles` and adds a test for it.