### PR TITLE
Prevent Secio handshake from blocking on some platforms

### DIFF
--- a/src/main/kotlin/io/libp2p/security/secio/SecioHandshake.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecioHandshake.kt
@@ -60,7 +60,7 @@ class SecioHandshake(
 
     private var state = State.Initial
 
-    val random: SecureRandom = SecureRandom.getInstanceStrong()
+    val random = SecureRandom()
     val nonceSize = 16
     val ciphers = linkedSetOf("AES-128", "AES-256")
     val hashes = linkedSetOf("SHA256", "SHA512")


### PR DESCRIPTION
Move from SecureRandom.getStrongInstance() to SecureRandom()

On some Linux platforms (depending on underlying hardware), SecureRandom.getStrongInstance() will default to reading /dev/random. However, /dev/random can block for an indefinite time - I've
left for 12+hours. Switching to SecureRandom() will read from /dev/urandom, which doesn't block.

This is a long existing and well-known (once you know to look for it) behaviour, which nobody seems to think is sensible. See, for instance, this bug report https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6521844 which offers mitigation in the form of setting system parameters. The shorthand method of doing that is simply to use SecureRandom() instead (as the Bouncycastle libraries do, for example). There's also a good discussion here https://tersesystems.com/blog/2015/12/17/the-right-way-to-use-securerandom/ 
