### PR TITLE
Feature/test rework

### DIFF
--- a/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -34,31 +34,25 @@ class TcpTransportTest {
         val logger = LogManager.getLogger("test")
     }
 
-    private val upgrader = ConnectionUpgrader(emptyList(), emptyList())
+    private val noOpUpgrader = ConnectionUpgrader(emptyList(), emptyList())
 
     @ParameterizedTest
     @MethodSource("validMultiaddrs")
     fun `handles(addr) succeeds when addr is a tcp protocol`(addr: Multiaddr) {
-        val tcp = TcpTransport(upgrader)
+        val tcp = TcpTransport(noOpUpgrader)
         assertTrue(tcp.handles(addr))
     }
 
     @ParameterizedTest
     @MethodSource("invalidMultiaddrs")
     fun `handles(addr) fails when addr is not a tcp protocol`(addr: Multiaddr) {
-        val tcp = TcpTransport(upgrader)
+        val tcp = TcpTransport(noOpUpgrader)
         assertFalse(tcp.handles(addr))
     }
 
     @Test
     fun testListenClose() {
-        val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
-        val upgrader = ConnectionUpgrader(
-            listOf(SecIoSecureChannel(privKey1)),
-            listOf(MplexStreamMuxer())
-        )
-
-        val tcpTransport = TcpTransport(upgrader)
+        val tcpTransport = TcpTransport(noOpUpgrader)
 
         bindListeners(tcpTransport, 5)
         val unbindFuts = unbindListeners(tcpTransport, 5)
@@ -66,7 +60,6 @@ class TcpTransportTest {
         CompletableFuture.allOf(*unbindFuts.toTypedArray())
             .get(5, SECONDS)
         assertEquals(0, tcpTransport.activeListeners.size)
-
 
         bindListeners(tcpTransport, 5)
 

--- a/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -10,8 +10,7 @@ import io.libp2p.mux.mplex.MplexStreamMuxer
 import io.libp2p.security.secio.SecIoSecureChannel
 import io.libp2p.transport.ConnectionUpgrader
 import org.apache.logging.log4j.LogManager
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -38,16 +37,16 @@ class TcpTransportTest {
 
     @ParameterizedTest
     @MethodSource("validMultiaddrs")
-    fun `handles(addr) returns true if addr contains tcp protocol`(addr: Multiaddr) {
-//        val tcp = TcpTransport(upgrader)
-//        assert(tcp.handles(addr))
+    fun `handles(addr) succeeds when addr is a tcp protocol`(addr: Multiaddr) {
+        val tcp = TcpTransport(upgrader)
+        assertTrue(tcp.handles(addr))
     }
 
     @ParameterizedTest
     @MethodSource("invalidMultiaddrs")
-    fun `handles(addr) returns false if addr does not contain tcp protocol`(addr: Multiaddr) {
-//        val tcp = TcpTransport(upgrader)
-//        assert(!tcp.handles(addr))
+    fun `handles(addr) fails when addr is not a tcp protocol`(addr: Multiaddr) {
+        val tcp = TcpTransport(upgrader)
+        assertFalse(tcp.handles(addr))
     }
 
     @Test

--- a/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -11,6 +11,7 @@ import io.libp2p.security.secio.SecIoSecureChannel
 import io.libp2p.transport.ConnectionUpgrader
 import org.apache.logging.log4j.LogManager
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -128,6 +129,7 @@ class TcpTransportTest {
     }
 
     @Test
+    @Disabled
     fun testDialClose() {
         val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
         val upgrader = ConnectionUpgrader(

--- a/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -258,11 +258,12 @@ class TcpTransportTest {
         }
 
         class CountingConnectionHandler : ConnectionHandler {
-            var connectionsEstablished = 0
+            private var connectionsCount = AtomicInteger(0)
+            val connectionsEstablished : Int get() = connectionsCount.get()
 
             override fun handleConnection(conn: Connection) {
-                ++connectionsEstablished
-                logger.info("Inbound connection: $connectionsEstablished")
+                val count = connectionsCount.incrementAndGet()
+                logger.info("Inbound connection: $count")
             }
         }
 

--- a/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -31,6 +31,8 @@ class TcpTransportTest {
             "/ip4/1.2.3.4/udp/42",
             "/unix/a/file/named/tcp"
         ).map { Multiaddr(it) }
+
+        val logger = LogManager.getLogger("test")
     }
 
     private val upgrader = ConnectionUpgrader(emptyList(), emptyList())
@@ -51,8 +53,6 @@ class TcpTransportTest {
 
     @Test
     fun testListenClose() {
-        val logger = LogManager.getLogger("test")
-
         val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
         val upgrader = ConnectionUpgrader(
             listOf(SecIoSecureChannel(privKey1)),
@@ -117,8 +117,6 @@ class TcpTransportTest {
 
     @Test
     fun testDialClose() {
-        val logger = LogManager.getLogger("test")
-
         val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
         val upgrader = ConnectionUpgrader(
             listOf(SecIoSecureChannel(privKey1)),

--- a/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -65,14 +65,8 @@ class TcpTransportTest {
             }
         }
 
-        for (i in 0..5) {
-            val bindFuture = tcpTransport.listen(
-                Multiaddr("/ip4/0.0.0.0/tcp/${20000 + i}"),
-                connHandler
-            )
-            bindFuture.handle { t, u -> logger.info("Bound #$i", u) }
-            logger.info("Binding #$i")
-        }
+        bindListeners(tcpTransport, 5)
+
         val unbindFuts = mutableListOf<CompletableFuture<Unit>>()
         for (i in 0..5) {
             val unbindFuture = tcpTransport.unlisten(
@@ -87,13 +81,8 @@ class TcpTransportTest {
             .get(5, SECONDS)
         assertEquals(0, tcpTransport.activeListeners.size)
 
-        for (i in 0..5) {
-            val bindFuture = tcpTransport.listen(
-                Multiaddr("/ip4/0.0.0.0/tcp/${20000 + i}"),
-                connHandler)
-            bindFuture.handle { t, u -> logger.info("Bound #$i", u) }
-            logger.info("Binding #$i")
-        }
+        bindListeners(tcpTransport, 5)
+
         for (i in 1..50) {
             if (tcpTransport.activeListeners.size == 6) break
             Thread.sleep(100)
@@ -112,6 +101,17 @@ class TcpTransportTest {
                 Multiaddr("/ip4/0.0.0.0/tcp/20000"),
                 connHandler)
                 .get(5, SECONDS)
+        }
+    }
+
+    fun bindListeners(tcpTransport: TcpTransport, count: Int) {
+        for (i in 0..count) {
+            val bindFuture = tcpTransport.listen(
+                Multiaddr("/ip4/0.0.0.0/tcp/${20000 + i}"),
+                ConnectionHandler.create { }
+            )
+            bindFuture.handle { t, u -> logger.info("Bound #$i", u) }
+            logger.info("Binding #$i")
         }
     }
 


### PR DESCRIPTION
Neatening up TcpTransport tests.

As was, testListenClose actually checked three different things, so I've split that into three separate tests. I've also spun testDialClose out into a couple of tests and added some more. I've also made liberal use of helper functions to set the tests up, so hopefully what's actually being tested is clearer. 

It's looks like a lot of commits, but they're all pretty small. 