### PR TITLE
Several updates to Noise PR

### DIFF
--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
@@ -1,0 +1,38 @@
+package io.libp2p.security.noise
+
+import com.southernstorm.noise.protocol.CipherState
+import io.libp2p.etc.types.toByteArray
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.MessageToMessageCodec
+import org.apache.logging.log4j.LogManager
+
+private val logger = LogManager.getLogger(NoiseXXSecureChannel::class.java.name)
+
+class NoiseXXCodec(val aliceCipher: CipherState, val bobCipher: CipherState) : MessageToMessageCodec<ByteBuf, ByteBuf>() {
+
+    override fun encode(ctx: ChannelHandlerContext, msg: ByteBuf, out: MutableList<Any>) {
+        val plainLength = msg.readableBytes()
+        val buf = ByteArray(plainLength + aliceCipher.macLength)
+        msg.readBytes(buf, 0, plainLength)
+        val length = aliceCipher.encryptWithAd(null, buf, 0, buf, 0, plainLength)
+        logger.debug("encrypt length: $length")
+        out += Unpooled.wrappedBuffer(
+            Unpooled.buffer().writeShort(length),
+            Unpooled.wrappedBuffer(buf, 0, length))
+        logger.trace("channel outbound handler write: $msg")
+    }
+
+    override fun decode(ctx: ChannelHandlerContext, msg: ByteBuf, out: MutableList<Any>) {
+        val length = msg.readShort().toInt()
+        val buf = msg.toByteArray()
+        logger.debug("decrypt length: $length")
+        val decryptLen = bobCipher.decryptWithAd(null, buf, 0, buf, 0, length)
+        out += Unpooled.wrappedBuffer(buf, 0, decryptLen)
+    }
+
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+        logger.error(cause.message)
+    }
+}

--- a/src/test/kotlin/io/libp2p/security/noise/NoiseSecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/noise/NoiseSecureChannelTest.kt
@@ -7,10 +7,12 @@ import io.libp2p.core.crypto.KEY_TYPE
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multistream.Mode
 import io.libp2p.core.multistream.ProtocolMatcher
+import io.libp2p.etc.types.toByteArray
 import io.libp2p.multistream.Negotiator
 import io.libp2p.multistream.ProtocolSelect
 import io.libp2p.tools.TestChannel.Companion.interConnect
 import io.libp2p.tools.TestHandler
+import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.logging.LogLevel
@@ -193,7 +195,8 @@ class NoiseSecureChannelTest {
         // Setup alice's pipeline
         eCh1.pipeline().addLast(object : TestHandler("1") {
             override fun channelRead(ctx: ChannelHandlerContext, msg: Any?) {
-                rec1 = msg as String
+                msg as ByteBuf
+                rec1 = String(msg.toByteArray())
                 logger.debug("==$name== read: $msg")
                 latch.countDown()
             }
@@ -202,7 +205,8 @@ class NoiseSecureChannelTest {
         // Setup bob's pipeline
         eCh2.pipeline().addLast(object : TestHandler("2") {
             override fun channelRead(ctx: ChannelHandlerContext, msg: Any?) {
-                rec2 = msg as String
+                msg as ByteBuf
+                rec2 = String(msg.toByteArray())
                 logger.debug("==$name== read: $msg")
                 latch.countDown()
             }


### PR DESCRIPTION
Several updates to #37:
- decompose Noise Cipher from Handshake classes to make classes code more clear
- avoid allocating max buffers for each message
- plain text should be binary