### PR TITLE
Bugfix in HostImpl Connection Handler Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,28 @@ implementation:
 - [X] multiformats: [multiaddr](https://github.com/multiformats/multiaddr)
 - [X] crypto (RSA, ed25519, secp256k1)
 - [X] [secio](https://github.com/libp2p/specs/pull/106)
-- [ ] [connection bootstrapping](https://github.com/libp2p/specs/pull/168)
-- [ ] mplex as a multiplexer
-- [ ] stream multiplexing
-- [ ] TCP transport (dialing and listening)
-- [ ] identify protocol
-- [ ] [peer ID](https://github.com/libp2p/specs/pull/100)
+- [X] [connection bootstrapping](https://github.com/libp2p/specs/pull/168)
+- [X] mplex as a multiplexer
+- [X] stream multiplexing
+- [X] TCP transport (dialing and listening)
+- [X] Identify protocol
+- [X] Ping protocol
+- [X] [peer ID](https://github.com/libp2p/specs/pull/100)
 
 We are explicitly leaving out the peerstore, DHT, pubsub, connection manager,
 etc. and other subsystems or concepts that are internal to implementations and
 do not impact the ability to hold communications with other libp2p processes.
+
+## Adding as a dependency to your Gradle project:
+
+```
+   repositories {
+       jcenter()
+   }
+
+   implementation 'io.libp2p:jvm-libp2p-minimal:0.1.0-RELEASE'
+```
+
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,16 @@
 import com.google.protobuf.gradle.proto
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
+import com.jfrog.bintray.gradle.BintrayExtension
+import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.net.URL
+
+// To publish the release artifact to JFrog Bintray repo run the following :
+// ./gradlew bintrayUpload -PbintrayUser=<user> -PbintrayApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.0.1-SNAPSHOT"
+version = "0.1.0-RELEASE"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {
@@ -16,11 +22,13 @@ plugins {
     `build-scan`
 
     `maven-publish`
+    id("com.jfrog.bintray") version "1.8.1"
+    id("org.jetbrains.dokka") version "0.9.18"
 }
 
 repositories {
+    jcenter()
     mavenCentral()
-    maven("https://jitpack.io")
 }
 
 val log4j2Version = "2.11.2"
@@ -32,13 +40,11 @@ dependencies {
     compile("com.google.guava:guava:27.1-jre")
     compile("org.bouncycastle:bcprov-jdk15on:1.61")
     compile("org.bouncycastle:bcpkix-jdk15on:1.61")
-    compile("com.github.multiformats:java-multiaddr:v1.3.1")
     compile("com.google.protobuf:protobuf-java:3.6.1")
-    compile("com.google.protobuf:protobuf-java:3.6.1")
+    compile("commons-codec:commons-codec:1.13")
 
     compile("org.apache.logging.log4j:log4j-api:${log4j2Version}")
     compile("org.apache.logging.log4j:log4j-core:${log4j2Version}")
-
 
     testCompile("org.junit.jupiter:junit-jupiter-api:5.4.2")
     testCompile("org.junit.jupiter:junit-jupiter-params:5.4.2")
@@ -105,6 +111,24 @@ val sourcesJar by tasks.registering(Jar::class) {
     from(sourceSets.main.get().allSource)
 }
 
+val dokka by tasks.getting(DokkaTask::class) {
+    outputFormat = "html"
+    outputDirectory = "$buildDir/dokka"
+    jdkVersion = 8
+    reportUndocumented = false
+    externalDocumentationLink {
+        url = URL("https://netty.io/4.1/api/")
+    }
+}
+
+val dokkaJar by tasks.creating(Jar::class) {
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles Kotlin docs with Dokka"
+    archiveClassifier.set("javadoc")
+    from(tasks.dokka)
+    dependsOn(tasks.dokka)
+}
+
 publishing {
     repositories {
         maven {
@@ -116,6 +140,24 @@ publishing {
         register("mavenJava", MavenPublication::class) {
             from(components["java"])
             artifact(sourcesJar.get())
+            artifact(dokkaJar)
         }
     }
+}
+
+fun findProperty(s: String) = project.findProperty(s) as String?
+
+bintray {
+    user = findProperty("bintrayUser")
+    key = findProperty("bintrayApiKey")
+    publish = true
+    setPublications("mavenJava")
+    setConfigurations("archives")
+    pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
+        userOrg = "libp2p"
+        repo = "jvm-libp2p"
+        name = "io.libp2p"
+        setLicenses("Apache-2.0", "MIT")
+        vcsUrl = "https://github.com/libp2p/jvm-libp2p"
+    })
 }

--- a/src/main/kotlin/io/libp2p/host/HostImpl.kt
+++ b/src/main/kotlin/io/libp2p/host/HostImpl.kt
@@ -70,7 +70,7 @@ class HostImpl(
     }
 
     override fun removeConnectionHandler(handler: ConnectionHandler) {
-        connectionHandlers += handler
+        connectionHandlers -= handler
     }
 
     override fun <TController> newStream(protocol: String, peer: PeerId, vararg addr: Multiaddr): StreamPromise<TController> {

--- a/src/test/java/io/libp2p/tools/p2pd/P2PDDht.java
+++ b/src/test/java/io/libp2p/tools/p2pd/P2PDDht.java
@@ -1,11 +1,11 @@
 package io.libp2p.tools.p2pd;
 
 import com.google.protobuf.ByteString;
-import io.ipfs.cid.Cid;
-import io.ipfs.multiaddr.MultiAddress;
+import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.tools.p2pd.libp2pj.DHT;
 import io.libp2p.tools.p2pd.libp2pj.Peer;
 import io.libp2p.tools.p2pd.libp2pj.PeerInfo;
+import io.libp2p.tools.p2pd.libp2pj.util.Cid;
 import p2pd.pb.P2Pd;
 
 import java.util.List;
@@ -142,7 +142,7 @@ public class P2PDDht implements DHT {
     private static PeerInfo fromResp(P2Pd.PeerInfo pi) {
         return new PeerInfo(new Peer(pi.getId().toByteArray()),
                 pi.getAddrsList().stream()
-                        .map(addr -> new MultiAddress(addr.toByteArray()))
+                        .map(addr -> new Multiaddr(addr.toByteArray()))
                         .collect(Collectors.toList()));
     }
 

--- a/src/test/java/io/libp2p/tools/p2pd/P2PDHost.java
+++ b/src/test/java/io/libp2p/tools/p2pd/P2PDHost.java
@@ -1,7 +1,7 @@
 package io.libp2p.tools.p2pd;
 
 import com.google.protobuf.ByteString;
-import io.ipfs.multiaddr.MultiAddress;
+import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.tools.p2pd.libp2pj.DHT;
 import io.libp2p.tools.p2pd.libp2pj.Host;
 import io.libp2p.tools.p2pd.libp2pj.Peer;
@@ -58,10 +58,10 @@ public class P2PDHost implements Host {
     }
 
     @Override
-    public List<MultiAddress> getListenAddresses() {
+    public List<Multiaddr> getListenAddresses() {
         try {
             return identify().get().getAddrsList().stream()
-                    .map(bs -> new MultiAddress(bs.toByteArray()))
+                    .map(bs -> new Multiaddr(bs.toByteArray()))
                     .collect(Collectors.toList());
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -78,7 +78,7 @@ public class P2PDHost implements Host {
     }
 
     @Override
-    public CompletableFuture<Void> connect(List<MultiAddress> peerAddresses, Peer peerId) {
+    public CompletableFuture<Void> connect(List<Multiaddr> peerAddresses, Peer peerId) {
         return daemonExecutor.executeWithDaemon(handler -> {
             CompletableFuture<P2Pd.Response> resp = handler.call(P2Pd.Request.newBuilder()
                             .setType(P2Pd.Request.Type.CONNECT)
@@ -135,19 +135,19 @@ public class P2PDHost implements Host {
 
     @Override
     public CompletableFuture<Closeable> listen(MuxerAdress muxerAdress, Supplier<StreamHandler<MuxerAdress>> handlerFactory) {
-        MultiAddress listenMultiaddr;
+        Multiaddr listenMultiaddr;
         SocketAddress listenAddr;
         ControlConnector connector;
         if (daemonExecutor.getAddress() instanceof InetSocketAddress) {
             connector = new TCPControlConnector();
             int port = 46666 + counter.incrementAndGet();
             listenAddr = new InetSocketAddress("127.0.0.1", port);
-            listenMultiaddr = new MultiAddress("/ip4/127.0.0.1/tcp/46666");
+            listenMultiaddr = new Multiaddr("/ip4/127.0.0.1/tcp/46666");
         } else if (daemonExecutor.getAddress() instanceof DomainSocketAddress) {
             connector = new UnixSocketControlConnector();
             String path = "/tmp/p2pd.client." + counter.incrementAndGet();
             listenAddr = new DomainSocketAddress(path);
-            listenMultiaddr = new MultiAddress("/unix" + path);
+            listenMultiaddr = new Multiaddr("/unix" + path);
 
         } else {
             throw new IllegalStateException();

--- a/src/test/java/io/libp2p/tools/p2pd/libp2pj/DHT.java
+++ b/src/test/java/io/libp2p/tools/p2pd/libp2pj/DHT.java
@@ -1,6 +1,6 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
-import io.ipfs.cid.Cid;
+import io.libp2p.tools.p2pd.libp2pj.util.Cid;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
  * Created by Anton Nashatyrev on 21.12.2018.
  */
 public interface DHT {
+
 
     CompletableFuture<PeerInfo> findPeer(Peer peerId);
 

--- a/src/test/java/io/libp2p/tools/p2pd/libp2pj/Host.java
+++ b/src/test/java/io/libp2p/tools/p2pd/libp2pj/Host.java
@@ -1,6 +1,6 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
-import io.ipfs.multiaddr.MultiAddress;
+import io.libp2p.core.multiformats.Multiaddr;
 
 import java.io.Closeable;
 import java.util.List;
@@ -14,9 +14,9 @@ public interface Host extends Muxer {
 
     Peer getMyId();
 
-    List<MultiAddress> getListenAddresses();
+    List<Multiaddr> getListenAddresses();
 
-    CompletableFuture<Void> connect(List<MultiAddress> peerAddresses, Peer peerId);
+    CompletableFuture<Void> connect(List<Multiaddr> peerAddresses, Peer peerId);
 
     @Override
     CompletableFuture<Void> dial(MuxerAdress muxerAdress, StreamHandler<MuxerAdress> handler);

--- a/src/test/java/io/libp2p/tools/p2pd/libp2pj/PeerInfo.java
+++ b/src/test/java/io/libp2p/tools/p2pd/libp2pj/PeerInfo.java
@@ -1,6 +1,7 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
-import io.ipfs.multiaddr.MultiAddress;
+
+import io.libp2p.core.multiformats.Multiaddr;
 
 import java.util.List;
 
@@ -9,9 +10,9 @@ import java.util.List;
  */
 public class PeerInfo {
     private final Peer id;
-    private final List<MultiAddress> adresses;
+    private final List<Multiaddr> adresses;
 
-    public PeerInfo(Peer id, List<MultiAddress> adresses) {
+    public PeerInfo(Peer id, List<Multiaddr> adresses) {
         this.id = id;
         this.adresses = adresses;
     }
@@ -20,7 +21,7 @@ public class PeerInfo {
         return id;
     }
 
-    public List<MultiAddress> getAdresses() {
+    public List<Multiaddr> getAdresses() {
         return adresses;
     }
 

--- a/src/test/java/io/libp2p/tools/p2pd/libp2pj/Transport.java
+++ b/src/test/java/io/libp2p/tools/p2pd/libp2pj/Transport.java
@@ -1,6 +1,6 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
-import io.ipfs.multiaddr.MultiAddress;
+import io.libp2p.core.multiformats.Multiaddr;
 
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
@@ -9,25 +9,25 @@ import java.util.function.Supplier;
 /**
  * Created by Anton Nashatyrev on 10.12.2018.
  */
-public interface Transport extends Connector<Transport.Listener, MultiAddress> {
+public interface Transport extends Connector<Transport.Listener, Multiaddr> {
 
 
     @Override
-    CompletableFuture<Void> dial(MultiAddress multiaddress,
-                                 StreamHandler<MultiAddress> dialHandler);
+    CompletableFuture<Void> dial(Multiaddr multiaddress,
+                                 StreamHandler<Multiaddr> dialHandler);
 
     @Override
-    CompletableFuture<Listener> listen(MultiAddress multiaddress,
-                                       Supplier<StreamHandler<MultiAddress>> handlerFactory);
+    CompletableFuture<Listener> listen(Multiaddr multiaddress,
+                                       Supplier<StreamHandler<Multiaddr>> handlerFactory);
 
     interface Listener extends Closeable {
 
         @Override
         void close();
 
-        MultiAddress getLocalMultiaddress();
+        Multiaddr getLocalMultiaddress();
 
-        default CompletableFuture<MultiAddress> getPublicMultiaddress() {
+        default CompletableFuture<Multiaddr> getPublicMultiaddress() {
             return CompletableFuture.completedFuture(getLocalMultiaddress());
         }
     }

--- a/src/test/java/io/libp2p/tools/p2pd/libp2pj/util/Cid.java
+++ b/src/test/java/io/libp2p/tools/p2pd/libp2pj/util/Cid.java
@@ -1,0 +1,8 @@
+package io.libp2p.tools.p2pd.libp2pj.util;
+
+public class Cid {
+
+    public byte[] toBytes() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -101,9 +101,8 @@ class MultiaddrTest {
         fun toBytesParams() = listOf(
             Arguments.of("/ip4/127.0.0.1/udp/1234", "047f000001910204d2".fromHex()),
             Arguments.of("/ip4/127.0.0.1/tcp/4321", "047f0000010610e1".fromHex()),
-            Arguments.of("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f000001910204d2047f0000010610e1".fromHex())
-            // TODO below fails due to Base32.decode() bug
-//            Arguments.of("/onion/aaimaq4ygg2iegci:80", "bc030010c0439831b48218480050".fromHex())
+            Arguments.of("/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f000001910204d2047f0000010610e1".fromHex()),
+            Arguments.of("/onion/aaimaq4ygg2iegci:80", "bc030010c0439831b48218480050".fromHex())
         )
     }
 


### PR DESCRIPTION
Resolves #51.

Resolves a bug found in HostImpl#removeConnectionHandler, where the function would attempt to add the passed handler to the connectionHandlers list, instead of attempting to remove the passed object from the list.