### PR TITLE
Refactor/security

### DIFF
--- a/src/main/kotlin/io/libp2p/protocol/Identify.kt
+++ b/src/main/kotlin/io/libp2p/protocol/Identify.kt
@@ -19,7 +19,9 @@ open class IdentifyBinding(override val protocol: IdentifyProtocol) : StrictProt
     override val announce = "/ipfs/id/1.0.0"
 }
 
-class IdentifyProtocol(var idMessage: IdentifyOuterClass.Identify? = null) : ProtocolHandler<IdentifyController>() {
+class IdentifyProtocol(var idMessage: IdentifyOuterClass.Identify? = null) :
+    ProtobufProtocolHandler<IdentifyController>(IdentifyOuterClass.Identify.getDefaultInstance()) {
+
     override fun onStartInitiator(stream: Stream): CompletableFuture<IdentifyController> {
         val handler = IdentifyRequesterChannelHandler()
         stream.pushHandler(handler)

--- a/src/main/kotlin/io/libp2p/protocol/ProtobufProtocolHandler.kt
+++ b/src/main/kotlin/io/libp2p/protocol/ProtobufProtocolHandler.kt
@@ -1,0 +1,28 @@
+package io.libp2p.protocol
+
+import com.google.protobuf.MessageLite
+import io.libp2p.core.P2PChannel
+import io.libp2p.core.Stream
+import io.netty.handler.codec.protobuf.ProtobufDecoder
+import io.netty.handler.codec.protobuf.ProtobufEncoder
+import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder
+import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender
+import java.util.concurrent.CompletableFuture
+
+abstract class ProtobufProtocolHandler<out TController>(
+    private val protobufMessagePrototype: MessageLite
+) : ProtocolHandler<TController>() {
+
+    override fun initChannel(ch: P2PChannel): CompletableFuture<out TController> {
+        val stream = ch as Stream
+
+        with(stream) {
+            pushHandler(ProtobufVarint32FrameDecoder())
+            pushHandler(ProtobufVarint32LengthFieldPrepender())
+            pushHandler(ProtobufDecoder(protobufMessagePrototype))
+            pushHandler(ProtobufEncoder())
+        }
+
+        return super.initChannel(ch)
+    }
+}

--- a/src/main/kotlin/io/libp2p/protocol/ProtocolHandler.kt
+++ b/src/main/kotlin/io/libp2p/protocol/ProtocolHandler.kt
@@ -7,7 +7,7 @@ import io.libp2p.core.Stream
 import java.util.concurrent.CompletableFuture
 
 abstract class ProtocolHandler<out TController> : P2PChannelHandler<TController> {
-    final override fun initChannel(ch: P2PChannel): CompletableFuture<out TController> {
+    override fun initChannel(ch: P2PChannel): CompletableFuture<out TController> {
         val stream = ch as Stream
         return if (stream.isInitiator) {
             onStartInitiator(stream)

--- a/src/main/kotlin/io/libp2p/security/SecureChannelError.kt
+++ b/src/main/kotlin/io/libp2p/security/SecureChannelError.kt
@@ -1,0 +1,8 @@
+package io.libp2p.security
+
+open class SecureChannelError : Exception()
+
+open class SecureHandshakeError : SecureChannelError()
+
+class InvalidRemotePubKey : SecureHandshakeError()
+class InvalidInitialPacket : SecureHandshakeError()

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -1,8 +1,6 @@
 package io.libp2p.security.noise
 
 import com.google.protobuf.ByteString
-import com.southernstorm.noise.protocol.CipherState
-import com.southernstorm.noise.protocol.CipherStatePair
 import com.southernstorm.noise.protocol.DHState
 import com.southernstorm.noise.protocol.HandshakeState
 import com.southernstorm.noise.protocol.Noise
@@ -61,7 +59,6 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
 
         return handshakeComplete
     }
-
 }
 
 private class NoiseIoHandshake(
@@ -240,7 +237,7 @@ private class NoiseIoHandshake(
         }
     } // verifyPayload
 
-    private fun unpackKeyAndSignature(payload: ByteArray) : Pair<PubKey, ByteArray> {
+    private fun unpackKeyAndSignature(payload: ByteArray): Pair<PubKey, ByteArray> {
         val noiseMsg = Spipe.NoiseHandshakePayload.parseFrom(payload)
 
         val publicKey = unmarshalPublicKey(noiseMsg.libp2PKey.toByteArray())

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -61,39 +61,16 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         chid = this.hashCode().toString()
         logger.debug(chid)
 
-        val ret = CompletableFuture<SecureChannel.Session>()
-        val resultHandler = object : ChannelInboundHandlerAdapter() {
-            override fun userEventTriggered(ctx: ChannelHandlerContext, evt: Any) {
-                when (evt) {
-                    is SecureChannelInitialized -> {
-                        val session = evt.session as NoiseSecureChannelSession
+        val handshakeComplete = CompletableFuture<SecureChannel.Session>()
 
-                        ret.complete(session)
-                        ctx.pipeline().remove(this)
-                        ctx.pipeline().addLast(NoiseXXCodec(session.aliceCipher, session.bobCipher))
+        ch.pushHandler(handshakeHandlerName + chid, NoiseIoHandshake(handshakeComplete))
 
-                        logger.debug("Reporting secure channel initialized")
-                    }
-                    is SecureChannelFailed -> {
-                        ret.completeExceptionally(evt.exception)
-
-                        ctx.pipeline().remove(handshakeHandlerName)
-                        ctx.pipeline().remove(this)
-
-                        logger.debug("Reporting secure channel failed")
-                    }
-                }
-                ctx.fireUserEventTriggered(evt)
-                ctx.fireChannelActive()
-            }
-        }
-        ch.pushHandler(handshakeHandlerName, NoiseIoHandshake())
-        ch.pushHandler(handshakeHandlerName + "ResultHandler", resultHandler)
-        return ret
+        return handshakeComplete
     }
 
-    inner class NoiseIoHandshake() : SimpleChannelInboundHandler<ByteBuf>() {
-
+    inner class NoiseIoHandshake(
+        private val handshakeComplete: CompletableFuture<SecureChannel.Session>
+    ) : SimpleChannelInboundHandler<ByteBuf>() {
         private val handshakestate: HandshakeState = HandshakeState(protocolName, role.intVal)
         private val logger2 = LogManager.getLogger("$loggerNameParent.$chid.$role")
 
@@ -120,8 +97,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             channelActive(ctx)
 
             if (role == Role.RESP && flagRemoteVerified && !flagRemoteVerifiedPassed) {
-                logger2.error("Responder verification of Remote peer id has failed")
-                ctx.fireUserEventTriggered(SecureChannelFailed(Exception("Responder verification of Remote peer id has failed")))
+                handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
                 return
             }
 
@@ -136,8 +112,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
                     logger2.trace("msg.size:" + msg.size)
                     logger2.trace("Read message size:$payloadLength")
                 } catch (e: Exception) {
-                    logger2.debug("Exception e:" + e.toString())
-                    ctx.fireUserEventTriggered(SecureChannelFailed(e))
+                    handshakeFailed(ctx, e)
                     return
                 }
             }
@@ -177,18 +152,15 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
                 logger2.debug("Split complete")
 
                 // put alice and bob security sessions into the context and trigger the next action
-                val secureChannelInitialized = SecureChannelInitialized(
-                    NoiseSecureChannelSession(
-                        PeerId.fromPubKey(localKey.publicKey()),
-                        PeerId.random(),
-                        localKey.publicKey(),
-                        aliceSplit,
-                        bobSplit
-                    ) as SecureChannel.Session
+                val secureSession = NoiseSecureChannelSession(
+                    PeerId.fromPubKey(localKey.publicKey()),
+                    PeerId.random(),
+                    localKey.publicKey(),
+                    aliceSplit,
+                    bobSplit
                 )
-                ctx.fireUserEventTriggered(secureChannelInitialized)
-//                ctx.fireChannelActive()
-                ctx.channel().pipeline().remove(this)
+
+                handshakeSucceeded(ctx, secureSession)
             }
         }
 
@@ -274,8 +246,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             if (flagRemoteVerifiedPassed) {
                 logger2.debug("Remote verification passed")
             } else {
-                logger2.error("Remote verification failed")
-                ctx.fireUserEventTriggered(SecureChannelFailed(Exception("Responder verification of Remote peer id has failed")))
+                handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
                 return
 //                ctx.fireChannelActive()
                 // throwing exception for early exit of protocol and for application to handle
@@ -284,6 +255,23 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
 
         override fun channelActive(ctx: ChannelHandlerContext) {
             channelRegistered(ctx)
+        }
+
+        private fun handshakeSucceeded(ctx: ChannelHandlerContext, session: NoiseSecureChannelSession) {
+            handshakeComplete.complete(session)
+            ctx.pipeline().remove(this)
+            ctx.pipeline().addLast(NoiseXXCodec(session.aliceCipher, session.bobCipher))
+            ctx.fireChannelActive()
+        } // handshakeSucceeded
+
+        private fun handshakeFailed(ctx: ChannelHandlerContext, cause: String) {
+            handshakeFailed(ctx, Exception(cause))
+        }
+        private fun handshakeFailed(ctx: ChannelHandlerContext, cause: Throwable) {
+            logger2.error(cause.message)
+
+            handshakeComplete.completeExceptionally(cause)
+            ctx.pipeline().remove(this)
         }
 
         private var activated = false

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -79,8 +79,6 @@ private class NoiseIoHandshake(
 
 
     private var activated = false
-    private var flagRemoteVerified = false
-    private var flagRemoteVerifiedPassed = false
     private lateinit var aliceSplit: CipherState
     private lateinit var bobSplit: CipherState
     private lateinit var cipherStatePair: CipherStatePair
@@ -111,11 +109,6 @@ private class NoiseIoHandshake(
         val msg = msg1.toByteArray()
 
         channelActive(ctx)
-
-        if (role == Role.RESP && flagRemoteVerified && !flagRemoteVerifiedPassed) {
-            handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
-            return
-        }
 
         // we always read from the wire when it's the next action to take
         // capture any payloads
@@ -164,7 +157,7 @@ private class NoiseIoHandshake(
             }
         }
 
-        if (handshakestate.action == HandshakeState.SPLIT && flagRemoteVerifiedPassed) {
+        if (handshakestate.action == HandshakeState.SPLIT) {
             cipherStatePair = handshakestate.split()
             aliceSplit = cipherStatePair.sender
             bobSplit = cipherStatePair.receiver
@@ -237,7 +230,6 @@ private class NoiseIoHandshake(
         remotePublicKey: ByteArray
     ) {
         log.debug("Verifying noise static key payload")
-        flagRemoteVerified = true
 
         // the self-signed remote pubkey and signature would be retrieved from the first Noise payload
         val inp = Spipe.NoiseHandshakePayload.parseFrom(payload.copyOfRange(0, payloadLength))
@@ -246,7 +238,7 @@ private class NoiseIoHandshake(
         val remotePubKeyFromMessage = unmarshalPublicKey(data)
         val remoteSignatureFromMessage = inp.noiseStaticKeySignature.toByteArray()
 
-        flagRemoteVerifiedPassed = remotePubKeyFromMessage.verify(
+        val flagRemoteVerifiedPassed = remotePubKeyFromMessage.verify(
             "noise-libp2p-static-key:".toByteArray() + remotePublicKey,
             remoteSignatureFromMessage
         )

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -125,8 +125,6 @@ private class NoiseIoHandshake(
         }
 
         val remotePublicKeyState: DHState = handshakestate.remotePublicKey
-        val remotePublicKey = ByteArray(remotePublicKeyState.publicKeyLength)
-        remotePublicKeyState.getPublicKey(remotePublicKey, 0)
 
         if (payloadLength > 0 && instancePayload == null) {
             // currently, only allow storing a single payload for verification (this should maybe be changed to a queue)
@@ -135,8 +133,8 @@ private class NoiseIoHandshake(
         }
 
         // verify the signature of the remote's noise static public key once the remote public key has been provided by the XX protocol
-        if (!Arrays.equals(remotePublicKey, ByteArray(remotePublicKeyState.publicKeyLength))) {
-            verifyPayload(ctx, instancePayload!!, remotePublicKey)
+        if (remotePublicKeyState.hasPublicKey()) {
+            verifyPayload(ctx, instancePayload!!, remotePublicKeyState)
         }
 
         // after reading messages and setting up state, write next message onto the wire
@@ -223,9 +221,12 @@ private class NoiseIoHandshake(
     private fun verifyPayload(
         ctx: ChannelHandlerContext,
         payload: ByteArray,
-        remotePublicKey: ByteArray
+        remotePublicKeyState: DHState
     ) {
         log.debug("Verifying noise static key payload")
+
+        val remotePublicKey = ByteArray(remotePublicKeyState.publicKeyLength)
+        remotePublicKeyState.getPublicKey(remotePublicKey, 0)
 
         // the self-signed remote pubkey and signature would be retrieved from the first Noise payload
         val inp = Spipe.NoiseHandshakePayload.parseFrom(payload.copyOfRange(0, payload.size))
@@ -244,7 +245,7 @@ private class NoiseIoHandshake(
         } else {
             handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
         }
-    }
+    } // verifyPayload
 
     private fun handshakeSucceeded(ctx: ChannelHandlerContext, session: NoiseSecureChannelSession) {
         handshakeComplete.complete(session)

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -77,9 +77,6 @@ private class NoiseIoHandshake(
     private var instancePayload: ByteArray? = null
 
     private var activated = false
-    private lateinit var aliceSplit: CipherState
-    private lateinit var bobSplit: CipherState
-    private lateinit var cipherStatePair: CipherStatePair
 
     init {
         log.debug("Starting handshake")
@@ -153,9 +150,10 @@ private class NoiseIoHandshake(
         }
 
         if (handshakestate.action == HandshakeState.SPLIT) {
-            cipherStatePair = handshakestate.split()
-            aliceSplit = cipherStatePair.sender
-            bobSplit = cipherStatePair.receiver
+            val cipherStatePair = handshakestate.split()
+
+            val aliceSplit = cipherStatePair.sender
+            val bobSplit = cipherStatePair.receiver
             log.debug("Split complete")
 
             // put alice and bob security sessions into the context and trigger the next action

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.SimpleChannelInboundHandler
 import org.apache.logging.log4j.LogManager
 import spipe.pb.Spipe
-import java.util.Arrays
 import java.util.concurrent.CompletableFuture
 
 private enum class Role(val intVal: Int) { INIT(HandshakeState.INITIATOR), RESP(HandshakeState.RESPONDER) }
@@ -229,28 +228,27 @@ private class NoiseIoHandshake(
         val remotePublicKey = ByteArray(remotePublicKeyState.publicKeyLength)
         remotePublicKeyState.getPublicKey(remotePublicKey, 0)
 
-        val (remotePubKeyFromMessage, remoteSignatureFromMessage) = unpackKeyAndSignature(payload)
+        val (pubKeyFromMessage, signatureFromMessage) = unpackKeyAndSignature(payload)
 
-        val flagRemoteVerifiedPassed = remotePubKeyFromMessage.verify(
+        val verified = pubKeyFromMessage.verify(
             "noise-libp2p-static-key:".toByteArray() + remotePublicKey,
-            remoteSignatureFromMessage
+            signatureFromMessage
         )
 
-        if (flagRemoteVerifiedPassed) {
-            log.debug("Remote verification passed")
-        } else {
+        log.debug("Remote verification is $verified")
+
+        if (!verified) {
             handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
         }
     } // verifyPayload
 
     private fun unpackKeyAndSignature(payload: ByteArray) : Pair<PubKey, ByteArray> {
-        val inp = Spipe.NoiseHandshakePayload.parseFrom(payload.copyOfRange(0, payload.size))
-        // validate the signature
-        val data: ByteArray = inp.libp2PKey.toByteArray()
-        val remotePubKeyFromMessage = unmarshalPublicKey(data)
-        val remoteSignatureFromMessage = inp.noiseStaticKeySignature.toByteArray()
+        val noiseMsg = Spipe.NoiseHandshakePayload.parseFrom(payload)
 
-        return Pair(remotePubKeyFromMessage, remoteSignatureFromMessage)
+        val publicKey = unmarshalPublicKey(noiseMsg.libp2PKey.toByteArray())
+        val signature = noiseMsg.noiseStaticKeySignature.toByteArray()
+
+        return Pair(publicKey, signature)
     } // unpackKeyAndSignature
 
     private fun handshakeSucceeded(ctx: ChannelHandlerContext, session: NoiseSecureChannelSession) {

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -15,6 +15,7 @@ import io.libp2p.core.multistream.ProtocolMatcher
 import io.libp2p.core.security.SecureChannel
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
+import io.libp2p.security.InvalidRemotePubKey
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.SimpleChannelInboundHandler
@@ -214,7 +215,7 @@ private class NoiseIoHandshake(
         log.debug("Remote verification is $verified")
 
         if (!verified) {
-            handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
+            handshakeFailed(ctx, InvalidRemotePubKey())
         }
     } // verifyPayload
 

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -14,23 +14,20 @@ import io.libp2p.core.crypto.unmarshalPublicKey
 import io.libp2p.core.multistream.Mode
 import io.libp2p.core.multistream.ProtocolMatcher
 import io.libp2p.core.security.SecureChannel
-import io.libp2p.etc.events.SecureChannelFailed
-import io.libp2p.etc.events.SecureChannelInitialized
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
-import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.SimpleChannelInboundHandler
 import org.apache.logging.log4j.LogManager
 import spipe.pb.Spipe
 import java.util.Arrays
 import java.util.concurrent.CompletableFuture
 
+private enum class Role(val intVal: Int) { INIT(HandshakeState.INITIATOR), RESP(HandshakeState.RESPONDER) }
+
 class NoiseXXSecureChannel(private val localKey: PrivKey) :
     SecureChannel {
-
-    private enum class Role(val intVal: Int) { INIT(HandshakeState.INITIATOR), RESP(HandshakeState.RESPONDER) }
 
     companion object {
         const val protocolName = "Noise_XX_25519_ChaChaPoly_SHA256"
@@ -44,8 +41,6 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
     private val logger = LogManager.getLogger(loggerNameParent)
     private lateinit var chid: String
 
-    private lateinit var role: Role
-
     private val handshakeHandlerName = "NoiseHandshake"
 
     override val announce = Companion.announce
@@ -56,22 +51,24 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
     }
 
     override fun initChannel(ch: P2PChannel, selectedProtocol: String): CompletableFuture<SecureChannel.Session> {
-        role = if (ch.isInitiator) Role.INIT else Role.RESP
-
         chid = this.hashCode().toString()
         logger.debug(chid)
 
         val handshakeComplete = CompletableFuture<SecureChannel.Session>()
 
-        ch.pushHandler(handshakeHandlerName + chid, NoiseIoHandshake(handshakeComplete))
+        ch.pushHandler(
+            handshakeHandlerName + chid,
+            NoiseIoHandshake(handshakeComplete, if (ch.isInitiator) Role.INIT else Role.RESP)
+        )
 
         return handshakeComplete
     }
 
-    inner class NoiseIoHandshake(
-        private val handshakeComplete: CompletableFuture<SecureChannel.Session>
+    private inner class NoiseIoHandshake(
+        private val handshakeComplete: CompletableFuture<SecureChannel.Session>,
+        private val role: Role
     ) : SimpleChannelInboundHandler<ByteBuf>() {
-        private val handshakestate: HandshakeState = HandshakeState(protocolName, role.intVal)
+        private val handshakestate = HandshakeState(protocolName, role.intVal)
         private val logger2 = LogManager.getLogger("$loggerNameParent.$chid.$role")
 
         private var localNoiseState: DHState

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString
 import com.southernstorm.noise.protocol.DHState
 import com.southernstorm.noise.protocol.HandshakeState
 import com.southernstorm.noise.protocol.Noise
-import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.P2PChannel
 import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.PrivKey
@@ -105,23 +104,23 @@ private class NoiseIoHandshake(
 
         // we always read from the wire when it's the next action to take
         // capture any payloads
-        val payload = ByteArray(msg.size)
-        var payloadLength = 0
-
         if (handshakestate.action == HandshakeState.READ_MESSAGE) {
             log.debug("Noise handshake READ_MESSAGE")
-            payloadLength = handshakestate.readMessage(msg, 0, msg.size, payload, 0)
+
+            val payload = ByteArray(msg.size)
+            val payloadLength = handshakestate.readMessage(msg, 0, msg.size, payload, 0)
+
             log.trace("msg.size:" + msg.size)
             log.trace("Read message size:$payloadLength")
+
+            if (instancePayload == null) {
+                // currently, only allow storing a single payload for verification (this should maybe be changed to a queue)
+                instancePayload = ByteArray(payloadLength)
+                payload.copyInto(instancePayload!!, 0, 0, payloadLength)
+            }
         }
 
         val remotePublicKeyState: DHState = handshakestate.remotePublicKey
-
-        if (payloadLength > 0 && instancePayload == null) {
-            // currently, only allow storing a single payload for verification (this should maybe be changed to a queue)
-            instancePayload = ByteArray(payloadLength)
-            payload.copyInto(instancePayload!!, 0, 0, payloadLength)
-        }
 
         // verify the signature of the remote's noise static public key once the remote public key has been provided by the XX protocol
         if (remotePublicKeyState.hasPublicKey()) {

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -138,22 +138,7 @@ private class NoiseIoHandshake(
         }
 
         if (handshakestate.action == HandshakeState.SPLIT) {
-            val cipherStatePair = handshakestate.split()
-
-            val aliceSplit = cipherStatePair.sender
-            val bobSplit = cipherStatePair.receiver
-            log.debug("Split complete")
-
-            // put alice and bob security sessions into the context and trigger the next action
-            val secureSession = NoiseSecureChannelSession(
-                PeerId.fromPubKey(localKey.publicKey()),
-                PeerId.random(),
-                localKey.publicKey(),
-                aliceSplit,
-                bobSplit
-            )
-
-            handshakeSucceeded(ctx, secureSession)
+            splitHandshake(ctx)
         }
     } // channelRead0
 
@@ -256,6 +241,25 @@ private class NoiseIoHandshake(
 
         return Pair(publicKey, signature)
     } // unpackKeyAndSignature
+
+    private fun splitHandshake(ctx: ChannelHandlerContext) {
+        val cipherStatePair = handshakestate.split()
+
+        val aliceSplit = cipherStatePair.sender
+        val bobSplit = cipherStatePair.receiver
+        log.debug("Split complete")
+
+        // put alice and bob security sessions into the context and trigger the next action
+        val secureSession = NoiseSecureChannelSession(
+            PeerId.fromPubKey(localKey.publicKey()),
+            PeerId.random(),
+            localKey.publicKey(),
+            aliceSplit,
+            bobSplit
+        )
+
+        handshakeSucceeded(ctx, secureSession)
+    } // splitHandshake
 
     private fun handshakeSucceeded(ctx: ChannelHandlerContext, session: NoiseSecureChannelSession) {
         handshakeComplete.complete(session)

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -37,14 +37,12 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         var localStaticPrivateKey25519: ByteArray = ByteArray(32).also { Noise.random(it) }
     }
 
-    private val handshakeHandlerName = "NoiseHandshake"
-
     override val announce = Companion.announce
     override val matcher = ProtocolMatcher(Mode.PREFIX, name = "/noise/$protocolName/0.1.0")
 
     fun initChannel(ch: P2PChannel): CompletableFuture<SecureChannel.Session> {
         return initChannel(ch, "")
-    }
+    } // initChannel
 
     override fun initChannel(
         ch: P2PChannel,
@@ -53,26 +51,24 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         val handshakeComplete = CompletableFuture<SecureChannel.Session>()
 
         ch.pushHandler(
-            handshakeHandlerName,
             NoiseIoHandshake(localKey, handshakeComplete, if (ch.isInitiator) Role.INIT else Role.RESP)
         )
 
         return handshakeComplete
-    }
-}
+    } // initChannel
+} // class NoiseXXSecureChannel
 
 private class NoiseIoHandshake(
     private val localKey: PrivKey,
     private val handshakeComplete: CompletableFuture<SecureChannel.Session>,
     private val role: Role
 ) : SimpleChannelInboundHandler<ByteBuf>() {
-    private val handshakestate = HandshakeState(NoiseXXSecureChannel.protocolName, role.intVal)
+    private val handshakeState = HandshakeState(NoiseXXSecureChannel.protocolName, role.intVal)
 
-    private var localNoiseState: DHState
+    private val localNoiseState = Noise.createDH("25519")
+
     private var sentNoiseKeyPayload = false
-
     private var instancePayload: ByteArray? = null
-
     private var activated = false
 
     init {
@@ -80,11 +76,11 @@ private class NoiseIoHandshake(
 
         // configure the localDHState with the private
         // which will automatically generate the corresponding public key
-        localNoiseState = Noise.createDH("25519")
         localNoiseState.setPrivateKey(NoiseXXSecureChannel.localStaticPrivateKey25519, 0)
-        handshakestate.localKeyPair.copyFrom(localNoiseState)
-        handshakestate.start()
-    }
+
+        handshakeState.localKeyPair.copyFrom(localNoiseState)
+        handshakeState.start()
+    } // init
 
     override fun channelActive(ctx: ChannelHandlerContext) {
         if (activated) return
@@ -95,26 +91,27 @@ private class NoiseIoHandshake(
         if (role == Role.INIT) {
             sendNoiseStaticKeyAsPayload(ctx)
         }
-    }
+    } // channelActive
 
     override fun channelRead0(ctx: ChannelHandlerContext, msg: ByteBuf) {
         channelActive(ctx)
 
         // we always read from the wire when it's the next action to take
         // capture any payloads
-        if (handshakestate.action == HandshakeState.READ_MESSAGE) {
+        if (handshakeState.action == HandshakeState.READ_MESSAGE) {
             readNoiseMessage(msg.toByteArray())
         }
 
-        val remotePublicKeyState: DHState = handshakestate.remotePublicKey
-
-        // verify the signature of the remote's noise static public key once the remote public key has been provided by the XX protocol
-        if (remotePublicKeyState.hasPublicKey()) {
-            verifyPayload(ctx, instancePayload!!, remotePublicKeyState)
+        // verify the signature of the remote's noise static public key once
+        // the remote public key has been provided by the XX protocol
+        with(handshakeState.remotePublicKey) {
+            if (hasPublicKey()) {
+                verifyPayload(ctx, instancePayload!!, this)
+            }
         }
 
         // after reading messages and setting up state, write next message onto the wire
-        if (handshakestate.action == HandshakeState.WRITE_MESSAGE) {
+        if (handshakeState.action == HandshakeState.WRITE_MESSAGE) {
             if (role == Role.RESP) {
                 sendNoiseStaticKeyAsPayload(ctx)
             } else {
@@ -122,7 +119,7 @@ private class NoiseIoHandshake(
             }
         }
 
-        if (handshakestate.action == HandshakeState.SPLIT) {
+        if (handshakeState.action == HandshakeState.SPLIT) {
             splitHandshake(ctx)
         }
     } // channelRead0
@@ -141,7 +138,7 @@ private class NoiseIoHandshake(
         log.debug("Noise handshake READ_MESSAGE")
 
         val payload = ByteArray(msg.size)
-        val payloadLength = handshakestate.readMessage(msg, 0, msg.size, payload, 0)
+        val payloadLength = handshakeState.readMessage(msg, 0, msg.size, payload, 0)
 
         log.trace("msg.size:" + msg.size)
         log.trace("Read message size:$payloadLength")
@@ -169,10 +166,8 @@ private class NoiseIoHandshake(
         val identityPublicKey: ByteArray = marshalPublicKey(localKey.publicKey())
 
         // get noise static public key signature
-        val localNoisePubKey = ByteArray(localNoiseState.publicKeyLength)
-        localNoiseState.getPublicKey(localNoisePubKey, 0)
         val localNoiseStaticKeySignature =
-            localKey.sign("noise-libp2p-static-key:".toByteArray() + localNoisePubKey)
+            localKey.sign(noiseSignaturePhrase(localNoiseState))
 
         // generate an appropriate protobuf element
         val noiseHandshakePayload =
@@ -182,32 +177,24 @@ private class NoiseIoHandshake(
                 .setLibp2PData(ByteString.EMPTY)
                 .setLibp2PDataSignature(ByteString.EMPTY)
                 .build()
+                .toByteArray()
 
-        // create the message with the signed payload - verification happens once the noise static key is shared
-        val msgBuffer =
-            ByteArray(noiseHandshakePayload.toByteArray().size + (2 * (handshakestate.localKeyPair.publicKeyLength + 16))) // mac length is 16
-        val msgLength = handshakestate.writeMessage(
-            msgBuffer,
-            0,
-            noiseHandshakePayload.toByteArray(),
-            0,
-            noiseHandshakePayload.toByteArray().size
-        )
+        // create the message with the signed payload -
+        // verification happens once the noise static key is shared
         log.debug("Sending signed Noise static public key as payload")
-        log.debug("Noise handshake WRITE_MESSAGE")
-        log.trace("Sent message size:$msgLength")
-        // put the message frame which also contains the payload onto the wire
-        ctx.writeAndFlush(msgBuffer.copyOfRange(0, msgLength).toByteBuf())
+        sendNoiseMessage(ctx, noiseHandshakePayload)
     } // sendNoiseStaticKeyAsPayload
 
-    private fun sendNoiseMessage(ctx: ChannelHandlerContext) {
-        val sndmessage = ByteArray(2 * handshakestate.localKeyPair.publicKeyLength)
-        val sndmessageLength = handshakestate.writeMessage(sndmessage, 0, null, 0, 0)
+    private fun sendNoiseMessage(ctx: ChannelHandlerContext, msg: ByteArray? = null) {
+        val msgLength = msg?.size ?: 0
+
+        val outputBuffer = ByteArray(msgLength + (2 * (handshakeState.localKeyPair.publicKeyLength + 16))) // 16 is MAC length
+        val outputLength = handshakeState.writeMessage(outputBuffer, 0, msg, 0, msgLength)
 
         log.debug("Noise handshake WRITE_MESSAGE")
-        log.trace("Sent message length:$sndmessageLength")
+        log.trace("Sent message length:$outputLength")
 
-        ctx.writeAndFlush(sndmessage.copyOfRange(0, sndmessageLength).toByteBuf())
+        ctx.writeAndFlush(outputBuffer.copyOfRange(0, outputLength).toByteBuf())
     } // sendNoiseMessage
 
     private fun verifyPayload(
@@ -217,13 +204,10 @@ private class NoiseIoHandshake(
     ) {
         log.debug("Verifying noise static key payload")
 
-        val remotePublicKey = ByteArray(remotePublicKeyState.publicKeyLength)
-        remotePublicKeyState.getPublicKey(remotePublicKey, 0)
-
         val (pubKeyFromMessage, signatureFromMessage) = unpackKeyAndSignature(payload)
 
         val verified = pubKeyFromMessage.verify(
-            "noise-libp2p-static-key:".toByteArray() + remotePublicKey,
+            noiseSignaturePhrase(remotePublicKeyState),
             signatureFromMessage
         )
 
@@ -244,7 +228,7 @@ private class NoiseIoHandshake(
     } // unpackKeyAndSignature
 
     private fun splitHandshake(ctx: ChannelHandlerContext) {
-        val cipherStatePair = handshakestate.split()
+        val cipherStatePair = handshakeState.split()
 
         val aliceSplit = cipherStatePair.sender
         val bobSplit = cipherStatePair.receiver
@@ -278,4 +262,14 @@ private class NoiseIoHandshake(
         handshakeComplete.completeExceptionally(cause)
         ctx.pipeline().remove(this)
     }
-}
+} // class NoiseIoHandshake
+
+private fun noiseSignaturePhrase(dhState: DHState) =
+    "noise-libp2p-static-key:".toByteArray() + dhState.publicKey
+
+private val DHState.publicKey: ByteArray
+    get() {
+        val pubKey = ByteArray(publicKeyLength)
+        getPublicKey(pubKey, 0)
+        return pubKey
+    }

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -56,223 +56,225 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
 
         ch.pushHandler(
             handshakeHandlerName,
-            NoiseIoHandshake(handshakeComplete, if (ch.isInitiator) Role.INIT else Role.RESP)
+            NoiseIoHandshake(localKey, handshakeComplete, if (ch.isInitiator) Role.INIT else Role.RESP)
         )
 
         return handshakeComplete
     }
 
-    private inner class NoiseIoHandshake(
-        private val handshakeComplete: CompletableFuture<SecureChannel.Session>,
-        private val role: Role
-    ) : SimpleChannelInboundHandler<ByteBuf>() {
-        private val handshakestate = HandshakeState(protocolName, role.intVal)
+}
 
-        private var localNoiseState: DHState
-        private var sentNoiseKeyPayload = false
+private class NoiseIoHandshake(
+    private val localKey: PrivKey,
+    private val handshakeComplete: CompletableFuture<SecureChannel.Session>,
+    private val role: Role
+) : SimpleChannelInboundHandler<ByteBuf>() {
+    private val handshakestate = HandshakeState(NoiseXXSecureChannel.protocolName, role.intVal)
 
-        private lateinit var instancePayload: ByteArray
-        private var instancePayloadLength = 0
+    private var localNoiseState: DHState
+    private var sentNoiseKeyPayload = false
 
-        init {
-            log.debug("Starting handshake")
+    private lateinit var instancePayload: ByteArray
+    private var instancePayloadLength = 0
 
-            // configure the localDHState with the private
-            // which will automatically generate the corresponding public key
-            localNoiseState = Noise.createDH("25519")
-            localNoiseState.setPrivateKey(localStaticPrivateKey25519, 0)
-            handshakestate.localKeyPair.copyFrom(localNoiseState)
-            handshakestate.start()
-        }
+    init {
+        log.debug("Starting handshake")
 
-        override fun channelRead0(ctx: ChannelHandlerContext, msg1: ByteBuf) {
-            val msg = msg1.toByteArray()
-
-            channelActive(ctx)
-
-            if (role == Role.RESP && flagRemoteVerified && !flagRemoteVerifiedPassed) {
-                handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
-                return
-            }
-
-            // we always read from the wire when it's the next action to take
-            // capture any payloads
-            val payload = ByteArray(msg.size)
-            var payloadLength = 0
-            if (handshakestate.action == HandshakeState.READ_MESSAGE) {
-                log.debug("Noise handshake READ_MESSAGE")
-                try {
-                    payloadLength = handshakestate.readMessage(msg, 0, msg.size, payload, 0)
-                    log.trace("msg.size:" + msg.size)
-                    log.trace("Read message size:$payloadLength")
-                } catch (e: Exception) {
-                    handshakeFailed(ctx, e)
-                    return
-                }
-            }
-
-            val remotePublicKeyState: DHState = handshakestate.remotePublicKey
-            val remotePublicKey = ByteArray(remotePublicKeyState.publicKeyLength)
-            remotePublicKeyState.getPublicKey(remotePublicKey, 0)
-
-            if (payloadLength > 0 && instancePayloadLength == 0) {
-                // currently, only allow storing a single payload for verification (this should maybe be changed to a queue)
-                instancePayload = ByteArray(payloadLength)
-                payload.copyInto(instancePayload, 0, 0, payloadLength)
-                instancePayloadLength = payloadLength
-            }
-
-            // verify the signature of the remote's noise static public key once the remote public key has been provided by the XX protocol
-            if (!Arrays.equals(remotePublicKey, ByteArray(remotePublicKeyState.publicKeyLength))) {
-                verifyPayload(ctx, instancePayload, instancePayloadLength, remotePublicKey)
-            }
-
-            // after reading messages and setting up state, write next message onto the wire
-            if (role == Role.RESP && handshakestate.action == HandshakeState.WRITE_MESSAGE) {
-                sendNoiseStaticKeyAsPayload(ctx)
-            } else if (handshakestate.action == HandshakeState.WRITE_MESSAGE) {
-                val sndmessage = ByteArray(2 * handshakestate.localKeyPair.publicKeyLength)
-                val sndmessageLength: Int
-                log.debug("Noise handshake WRITE_MESSAGE")
-                sndmessageLength = handshakestate.writeMessage(sndmessage, 0, null, 0, 0)
-                log.trace("Sent message length:$sndmessageLength")
-                ctx.writeAndFlush(sndmessage.copyOfRange(0, sndmessageLength).toByteBuf())
-            }
-
-            if (handshakestate.action == HandshakeState.SPLIT && flagRemoteVerifiedPassed) {
-                cipherStatePair = handshakestate.split()
-                aliceSplit = cipherStatePair.sender
-                bobSplit = cipherStatePair.receiver
-                log.debug("Split complete")
-
-                // put alice and bob security sessions into the context and trigger the next action
-                val secureSession = NoiseSecureChannelSession(
-                    PeerId.fromPubKey(localKey.publicKey()),
-                    PeerId.random(),
-                    localKey.publicKey(),
-                    aliceSplit,
-                    bobSplit
-                )
-
-                handshakeSucceeded(ctx, secureSession)
-            }
-        }
-
-        override fun channelRegistered(ctx: ChannelHandlerContext) {
-            if (activated) return
-            activated = true
-
-            // even though both the alice and bob parties can have the payload ready
-            // the Noise protocol only permits alice to send a packet first
-            if (role == Role.INIT) {
-                sendNoiseStaticKeyAsPayload(ctx)
-            }
-        }
-
-        /**
-         * Sends the next Noise message with a payload of the identities and signatures
-         * Currently does not include additional data in the payload.
-         */
-        private fun sendNoiseStaticKeyAsPayload(ctx: ChannelHandlerContext) {
-            // only send the Noise static key once
-            if (sentNoiseKeyPayload) return
-            sentNoiseKeyPayload = true
-
-            // the payload consists of the identity public key, and the signature of the noise static public key
-            // the actual noise static public key is sent later as part of the XX handshake
-
-            // get identity public key
-            val identityPublicKey: ByteArray = marshalPublicKey(localKey.publicKey())
-
-            // get noise static public key signature
-            val localNoisePubKey = ByteArray(localNoiseState.publicKeyLength)
-            localNoiseState.getPublicKey(localNoisePubKey, 0)
-            val localNoiseStaticKeySignature =
-                localKey.sign("noise-libp2p-static-key:".toByteArray() + localNoisePubKey)
-
-            // generate an appropriate protobuf element
-            val noiseHandshakePayload =
-                Spipe.NoiseHandshakePayload.newBuilder()
-                    .setLibp2PKey(ByteString.copyFrom(identityPublicKey))
-                    .setNoiseStaticKeySignature(ByteString.copyFrom(localNoiseStaticKeySignature))
-                    .setLibp2PData(ByteString.EMPTY)
-                    .setLibp2PDataSignature(ByteString.EMPTY)
-                    .build()
-
-            // create the message with the signed payload - verification happens once the noise static key is shared
-            val msgBuffer =
-                ByteArray(noiseHandshakePayload.toByteArray().size + (2 * (handshakestate.localKeyPair.publicKeyLength + 16))) // mac length is 16
-            val msgLength = handshakestate.writeMessage(
-                msgBuffer,
-                0,
-                noiseHandshakePayload.toByteArray(),
-                0,
-                noiseHandshakePayload.toByteArray().size
-            )
-            log.debug("Sending signed Noise static public key as payload")
-            log.debug("Noise handshake WRITE_MESSAGE")
-            log.trace("Sent message size:$msgLength")
-            // put the message frame which also contains the payload onto the wire
-            ctx.writeAndFlush(msgBuffer.copyOfRange(0, msgLength).toByteBuf())
-        }
-
-        private fun verifyPayload(
-            ctx: ChannelHandlerContext,
-            payload: ByteArray,
-            payloadLength: Int,
-            remotePublicKey: ByteArray
-        ) {
-            log.debug("Verifying noise static key payload")
-            flagRemoteVerified = true
-
-            // the self-signed remote pubkey and signature would be retrieved from the first Noise payload
-            val inp = Spipe.NoiseHandshakePayload.parseFrom(payload.copyOfRange(0, payloadLength))
-            // validate the signature
-            val data: ByteArray = inp.libp2PKey.toByteArray()
-            val remotePubKeyFromMessage = unmarshalPublicKey(data)
-            val remoteSignatureFromMessage = inp.noiseStaticKeySignature.toByteArray()
-
-            flagRemoteVerifiedPassed = remotePubKeyFromMessage.verify(
-                "noise-libp2p-static-key:".toByteArray() + remotePublicKey,
-                remoteSignatureFromMessage
-            )
-
-            if (flagRemoteVerifiedPassed) {
-                log.debug("Remote verification passed")
-            } else {
-                handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
-                return
-//                ctx.fireChannelActive()
-                // throwing exception for early exit of protocol and for application to handle
-            }
-        }
-
-        override fun channelActive(ctx: ChannelHandlerContext) {
-            channelRegistered(ctx)
-        }
-
-        private fun handshakeSucceeded(ctx: ChannelHandlerContext, session: NoiseSecureChannelSession) {
-            handshakeComplete.complete(session)
-            ctx.pipeline().remove(this)
-            ctx.pipeline().addLast(NoiseXXCodec(session.aliceCipher, session.bobCipher))
-            ctx.fireChannelActive()
-        } // handshakeSucceeded
-
-        private fun handshakeFailed(ctx: ChannelHandlerContext, cause: String) {
-            handshakeFailed(ctx, Exception(cause))
-        }
-        private fun handshakeFailed(ctx: ChannelHandlerContext, cause: Throwable) {
-            log.error(cause.message)
-
-            handshakeComplete.completeExceptionally(cause)
-            ctx.pipeline().remove(this)
-        }
-
-        private var activated = false
-        private var flagRemoteVerified = false
-        private var flagRemoteVerifiedPassed = false
-        private lateinit var aliceSplit: CipherState
-        private lateinit var bobSplit: CipherState
-        private lateinit var cipherStatePair: CipherStatePair
+        // configure the localDHState with the private
+        // which will automatically generate the corresponding public key
+        localNoiseState = Noise.createDH("25519")
+        localNoiseState.setPrivateKey(NoiseXXSecureChannel.localStaticPrivateKey25519, 0)
+        handshakestate.localKeyPair.copyFrom(localNoiseState)
+        handshakestate.start()
     }
+
+    override fun channelRead0(ctx: ChannelHandlerContext, msg1: ByteBuf) {
+        val msg = msg1.toByteArray()
+
+        channelActive(ctx)
+
+        if (role == Role.RESP && flagRemoteVerified && !flagRemoteVerifiedPassed) {
+            handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
+            return
+        }
+
+        // we always read from the wire when it's the next action to take
+        // capture any payloads
+        val payload = ByteArray(msg.size)
+        var payloadLength = 0
+        if (handshakestate.action == HandshakeState.READ_MESSAGE) {
+            log.debug("Noise handshake READ_MESSAGE")
+            try {
+                payloadLength = handshakestate.readMessage(msg, 0, msg.size, payload, 0)
+                log.trace("msg.size:" + msg.size)
+                log.trace("Read message size:$payloadLength")
+            } catch (e: Exception) {
+                handshakeFailed(ctx, e)
+                return
+            }
+        }
+
+        val remotePublicKeyState: DHState = handshakestate.remotePublicKey
+        val remotePublicKey = ByteArray(remotePublicKeyState.publicKeyLength)
+        remotePublicKeyState.getPublicKey(remotePublicKey, 0)
+
+        if (payloadLength > 0 && instancePayloadLength == 0) {
+            // currently, only allow storing a single payload for verification (this should maybe be changed to a queue)
+            instancePayload = ByteArray(payloadLength)
+            payload.copyInto(instancePayload, 0, 0, payloadLength)
+            instancePayloadLength = payloadLength
+        }
+
+        // verify the signature of the remote's noise static public key once the remote public key has been provided by the XX protocol
+        if (!Arrays.equals(remotePublicKey, ByteArray(remotePublicKeyState.publicKeyLength))) {
+            verifyPayload(ctx, instancePayload, instancePayloadLength, remotePublicKey)
+        }
+
+        // after reading messages and setting up state, write next message onto the wire
+        if (role == Role.RESP && handshakestate.action == HandshakeState.WRITE_MESSAGE) {
+            sendNoiseStaticKeyAsPayload(ctx)
+        } else if (handshakestate.action == HandshakeState.WRITE_MESSAGE) {
+            val sndmessage = ByteArray(2 * handshakestate.localKeyPair.publicKeyLength)
+            val sndmessageLength: Int
+            log.debug("Noise handshake WRITE_MESSAGE")
+            sndmessageLength = handshakestate.writeMessage(sndmessage, 0, null, 0, 0)
+            log.trace("Sent message length:$sndmessageLength")
+            ctx.writeAndFlush(sndmessage.copyOfRange(0, sndmessageLength).toByteBuf())
+        }
+
+        if (handshakestate.action == HandshakeState.SPLIT && flagRemoteVerifiedPassed) {
+            cipherStatePair = handshakestate.split()
+            aliceSplit = cipherStatePair.sender
+            bobSplit = cipherStatePair.receiver
+            log.debug("Split complete")
+
+            // put alice and bob security sessions into the context and trigger the next action
+            val secureSession = NoiseSecureChannelSession(
+                PeerId.fromPubKey(localKey.publicKey()),
+                PeerId.random(),
+                localKey.publicKey(),
+                aliceSplit,
+                bobSplit
+            )
+
+            handshakeSucceeded(ctx, secureSession)
+        }
+    }
+
+    override fun channelRegistered(ctx: ChannelHandlerContext) {
+        if (activated) return
+        activated = true
+
+        // even though both the alice and bob parties can have the payload ready
+        // the Noise protocol only permits alice to send a packet first
+        if (role == Role.INIT) {
+            sendNoiseStaticKeyAsPayload(ctx)
+        }
+    }
+
+    /**
+     * Sends the next Noise message with a payload of the identities and signatures
+     * Currently does not include additional data in the payload.
+     */
+    private fun sendNoiseStaticKeyAsPayload(ctx: ChannelHandlerContext) {
+        // only send the Noise static key once
+        if (sentNoiseKeyPayload) return
+        sentNoiseKeyPayload = true
+
+        // the payload consists of the identity public key, and the signature of the noise static public key
+        // the actual noise static public key is sent later as part of the XX handshake
+
+        // get identity public key
+        val identityPublicKey: ByteArray = marshalPublicKey(localKey.publicKey())
+
+        // get noise static public key signature
+        val localNoisePubKey = ByteArray(localNoiseState.publicKeyLength)
+        localNoiseState.getPublicKey(localNoisePubKey, 0)
+        val localNoiseStaticKeySignature =
+            localKey.sign("noise-libp2p-static-key:".toByteArray() + localNoisePubKey)
+
+        // generate an appropriate protobuf element
+        val noiseHandshakePayload =
+            Spipe.NoiseHandshakePayload.newBuilder()
+                .setLibp2PKey(ByteString.copyFrom(identityPublicKey))
+                .setNoiseStaticKeySignature(ByteString.copyFrom(localNoiseStaticKeySignature))
+                .setLibp2PData(ByteString.EMPTY)
+                .setLibp2PDataSignature(ByteString.EMPTY)
+                .build()
+
+        // create the message with the signed payload - verification happens once the noise static key is shared
+        val msgBuffer =
+            ByteArray(noiseHandshakePayload.toByteArray().size + (2 * (handshakestate.localKeyPair.publicKeyLength + 16))) // mac length is 16
+        val msgLength = handshakestate.writeMessage(
+            msgBuffer,
+            0,
+            noiseHandshakePayload.toByteArray(),
+            0,
+            noiseHandshakePayload.toByteArray().size
+        )
+        log.debug("Sending signed Noise static public key as payload")
+        log.debug("Noise handshake WRITE_MESSAGE")
+        log.trace("Sent message size:$msgLength")
+        // put the message frame which also contains the payload onto the wire
+        ctx.writeAndFlush(msgBuffer.copyOfRange(0, msgLength).toByteBuf())
+    }
+
+    private fun verifyPayload(
+        ctx: ChannelHandlerContext,
+        payload: ByteArray,
+        payloadLength: Int,
+        remotePublicKey: ByteArray
+    ) {
+        log.debug("Verifying noise static key payload")
+        flagRemoteVerified = true
+
+        // the self-signed remote pubkey and signature would be retrieved from the first Noise payload
+        val inp = Spipe.NoiseHandshakePayload.parseFrom(payload.copyOfRange(0, payloadLength))
+        // validate the signature
+        val data: ByteArray = inp.libp2PKey.toByteArray()
+        val remotePubKeyFromMessage = unmarshalPublicKey(data)
+        val remoteSignatureFromMessage = inp.noiseStaticKeySignature.toByteArray()
+
+        flagRemoteVerifiedPassed = remotePubKeyFromMessage.verify(
+            "noise-libp2p-static-key:".toByteArray() + remotePublicKey,
+            remoteSignatureFromMessage
+        )
+
+        if (flagRemoteVerifiedPassed) {
+            log.debug("Remote verification passed")
+        } else {
+            handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
+            return
+//                ctx.fireChannelActive()
+            // throwing exception for early exit of protocol and for application to handle
+        }
+    }
+
+    override fun channelActive(ctx: ChannelHandlerContext) {
+        channelRegistered(ctx)
+    }
+
+    private fun handshakeSucceeded(ctx: ChannelHandlerContext, session: NoiseSecureChannelSession) {
+        handshakeComplete.complete(session)
+        ctx.pipeline().remove(this)
+        ctx.pipeline().addLast(NoiseXXCodec(session.aliceCipher, session.bobCipher))
+        ctx.fireChannelActive()
+    } // handshakeSucceeded
+
+    private fun handshakeFailed(ctx: ChannelHandlerContext, cause: String) {
+        handshakeFailed(ctx, Exception(cause))
+    }
+    private fun handshakeFailed(ctx: ChannelHandlerContext, cause: Throwable) {
+        log.error(cause.message)
+
+        handshakeComplete.completeExceptionally(cause)
+        ctx.pipeline().remove(this)
+    }
+
+    private var activated = false
+    private var flagRemoteVerified = false
+    private var flagRemoteVerifiedPassed = false
+    private lateinit var aliceSplit: CipherState
+    private lateinit var bobSplit: CipherState
+    private lateinit var cipherStatePair: CipherStatePair
 }

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -26,6 +26,8 @@ import java.util.concurrent.CompletableFuture
 
 private enum class Role(val intVal: Int) { INIT(HandshakeState.INITIATOR), RESP(HandshakeState.RESPONDER) }
 
+private val log = LogManager.getLogger(NoiseXXSecureChannel::class.java)
+
 class NoiseXXSecureChannel(private val localKey: PrivKey) :
     SecureChannel {
 
@@ -37,10 +39,6 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         var localStaticPrivateKey25519: ByteArray = ByteArray(32).also { Noise.random(it) }
     }
 
-    private val loggerNameParent = NoiseXXSecureChannel::class.java.name + '.' + this.hashCode()
-    private val logger = LogManager.getLogger(loggerNameParent)
-    private lateinit var chid: String
-
     private val handshakeHandlerName = "NoiseHandshake"
 
     override val announce = Companion.announce
@@ -50,14 +48,14 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         return initChannel(ch, "")
     }
 
-    override fun initChannel(ch: P2PChannel, selectedProtocol: String): CompletableFuture<SecureChannel.Session> {
-        chid = this.hashCode().toString()
-        logger.debug(chid)
-
+    override fun initChannel(
+        ch: P2PChannel,
+        selectedProtocol: String
+    ): CompletableFuture<SecureChannel.Session> {
         val handshakeComplete = CompletableFuture<SecureChannel.Session>()
 
         ch.pushHandler(
-            handshakeHandlerName + chid,
+            handshakeHandlerName,
             NoiseIoHandshake(handshakeComplete, if (ch.isInitiator) Role.INIT else Role.RESP)
         )
 
@@ -69,7 +67,6 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         private val role: Role
     ) : SimpleChannelInboundHandler<ByteBuf>() {
         private val handshakestate = HandshakeState(protocolName, role.intVal)
-        private val logger2 = LogManager.getLogger("$loggerNameParent.$chid.$role")
 
         private var localNoiseState: DHState
         private var sentNoiseKeyPayload = false
@@ -78,7 +75,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
         private var instancePayloadLength = 0
 
         init {
-            logger2.debug("Starting handshake")
+            log.debug("Starting handshake")
 
             // configure the localDHState with the private
             // which will automatically generate the corresponding public key
@@ -103,11 +100,11 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             val payload = ByteArray(msg.size)
             var payloadLength = 0
             if (handshakestate.action == HandshakeState.READ_MESSAGE) {
-                logger2.debug("Noise handshake READ_MESSAGE")
+                log.debug("Noise handshake READ_MESSAGE")
                 try {
                     payloadLength = handshakestate.readMessage(msg, 0, msg.size, payload, 0)
-                    logger2.trace("msg.size:" + msg.size)
-                    logger2.trace("Read message size:$payloadLength")
+                    log.trace("msg.size:" + msg.size)
+                    log.trace("Read message size:$payloadLength")
                 } catch (e: Exception) {
                     handshakeFailed(ctx, e)
                     return
@@ -136,9 +133,9 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             } else if (handshakestate.action == HandshakeState.WRITE_MESSAGE) {
                 val sndmessage = ByteArray(2 * handshakestate.localKeyPair.publicKeyLength)
                 val sndmessageLength: Int
-                logger2.debug("Noise handshake WRITE_MESSAGE")
+                log.debug("Noise handshake WRITE_MESSAGE")
                 sndmessageLength = handshakestate.writeMessage(sndmessage, 0, null, 0, 0)
-                logger2.trace("Sent message length:$sndmessageLength")
+                log.trace("Sent message length:$sndmessageLength")
                 ctx.writeAndFlush(sndmessage.copyOfRange(0, sndmessageLength).toByteBuf())
             }
 
@@ -146,7 +143,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
                 cipherStatePair = handshakestate.split()
                 aliceSplit = cipherStatePair.sender
                 bobSplit = cipherStatePair.receiver
-                logger2.debug("Split complete")
+                log.debug("Split complete")
 
                 // put alice and bob security sessions into the context and trigger the next action
                 val secureSession = NoiseSecureChannelSession(
@@ -212,9 +209,9 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
                 0,
                 noiseHandshakePayload.toByteArray().size
             )
-            logger2.debug("Sending signed Noise static public key as payload")
-            logger2.debug("Noise handshake WRITE_MESSAGE")
-            logger2.trace("Sent message size:$msgLength")
+            log.debug("Sending signed Noise static public key as payload")
+            log.debug("Noise handshake WRITE_MESSAGE")
+            log.trace("Sent message size:$msgLength")
             // put the message frame which also contains the payload onto the wire
             ctx.writeAndFlush(msgBuffer.copyOfRange(0, msgLength).toByteBuf())
         }
@@ -225,7 +222,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             payloadLength: Int,
             remotePublicKey: ByteArray
         ) {
-            logger2.debug("Verifying noise static key payload")
+            log.debug("Verifying noise static key payload")
             flagRemoteVerified = true
 
             // the self-signed remote pubkey and signature would be retrieved from the first Noise payload
@@ -241,7 +238,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             )
 
             if (flagRemoteVerifiedPassed) {
-                logger2.debug("Remote verification passed")
+                log.debug("Remote verification passed")
             } else {
                 handshakeFailed(ctx, "Responder verification of Remote peer id has failed")
                 return
@@ -265,7 +262,7 @@ class NoiseXXSecureChannel(private val localKey: PrivKey) :
             handshakeFailed(ctx, Exception(cause))
         }
         private fun handshakeFailed(ctx: ChannelHandlerContext, cause: Throwable) {
-            logger2.error(cause.message)
+            log.error(cause.message)
 
             handshakeComplete.completeExceptionally(cause)
             ctx.pipeline().remove(this)

--- a/src/main/kotlin/io/libp2p/security/plaintext/PlaintextInsecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/plaintext/PlaintextInsecureChannel.kt
@@ -12,8 +12,8 @@ import io.libp2p.core.multistream.Mode
 import io.libp2p.core.multistream.ProtocolMatcher
 import io.libp2p.core.security.SecureChannel
 import io.libp2p.etc.types.toProtobuf
-import io.libp2p.security.secio.InvalidInitialPacket
-import io.libp2p.security.secio.InvalidRemotePubKey
+import io.libp2p.security.InvalidInitialPacket
+import io.libp2p.security.InvalidRemotePubKey
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
@@ -2,6 +2,7 @@ package io.libp2p.security.secio
 
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
+import io.libp2p.security.SecureChannelError
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
@@ -56,7 +57,7 @@ class SecIoCodec(val local: SecioParams, val remote: SecioParams) : MessageToMes
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         log.error(cause.message)
-        if (cause is SecioError) {
+        if (cause is SecureChannelError) {
             ctx.channel().close()
         }
     } // exceptionCaught

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
@@ -31,39 +31,58 @@ class SecIoCodec(val local: SecioParams, val remote: SecioParams) : MessageToMes
     }
 
     override fun encode(ctx: ChannelHandlerContext, msg: ByteBuf, out: MutableList<Any>) {
-        val msgByteArr = msg.toByteArray()
-        val outByteArr = ByteArray(msgByteArr.size)
-        localCipher.processBytes(msgByteArr, 0, msgByteArr.size, outByteArr, 0)
+        val cipherText = processBytes(localCipher, msg.toByteArray())
+        val macArr = updateMac(local, cipherText)
 
-        local.mac.reset()
-        local.mac.update(outByteArr, 0, outByteArr.size)
-        val macArr = ByteArray(local.mac.macSize)
-        local.mac.doFinal(macArr, 0)
         out.add(
             Unpooled.wrappedBuffer(
-                Unpooled.wrappedBuffer(outByteArr),
+                Unpooled.wrappedBuffer(cipherText),
                 Unpooled.wrappedBuffer(macArr)
             )
         )
-    }
+    } // encode
 
     override fun decode(ctx: ChannelHandlerContext, msg: ByteBuf, out: MutableList<Any>) {
-        val macBytes = msg.toByteArray(from = msg.readableBytes() - remote.mac.macSize)
-        val cipherBytes = msg.toByteArray(to = msg.readableBytes() - remote.mac.macSize)
-        remote.mac.reset()
-        remote.mac.update(cipherBytes, 0, cipherBytes.size)
-        val macArr = ByteArray(remote.mac.macSize)
-        remote.mac.doFinal(macArr, 0)
-        if (!macBytes.contentEquals(macArr)) throw MacMismatch()
-        val plainBytes = ByteArray(cipherBytes.size)
-        remoteCipher.processBytes(cipherBytes, 0, cipherBytes.size, plainBytes, 0)
-        out.add(plainBytes.toByteBuf())
-    }
+        val (cipherBytes, macBytes) = textAndMac(msg)
+
+        val macArr = updateMac(remote, cipherBytes)
+
+        if (!macBytes.contentEquals(macArr))
+            throw MacMismatch()
+
+        val clearText = processBytes(remoteCipher, cipherBytes)
+        out.add(clearText.toByteBuf())
+    } // decode
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         log.error(cause.message)
         if (cause is SecioError) {
             ctx.channel().close()
         }
-    }
+    } // exceptionCaught
+
+    private fun textAndMac(msg: ByteBuf): Pair<ByteArray, ByteArray> {
+        val macBytes = msg.toByteArray(from = msg.readableBytes() - remote.mac.macSize)
+        val cipherBytes = msg.toByteArray(to = msg.readableBytes() - remote.mac.macSize)
+
+        return Pair(cipherBytes, macBytes)
+    } // textAndMac
+
+    private fun processBytes(cipher: StreamCipher, bytesIn: ByteArray): ByteArray {
+        val bytesOut = ByteArray(bytesIn.size)
+        cipher.processBytes(bytesIn, 0, bytesIn.size, bytesOut, 0)
+        return bytesOut
+    } // processBytes
+
+    private fun updateMac(secioParams: SecioParams, bytes: ByteArray): ByteArray {
+        with(secioParams.mac) {
+            reset()
+            update(bytes, 0, bytes.size)
+
+            val macArr = ByteArray(macSize)
+            doFinal(macArr, 0)
+
+            return macArr
+        } // with
+    } // updateMac
 }

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
@@ -43,7 +43,7 @@ data class SecioParams(
 /**
  * Created by Anton Nashatyrev on 14.06.2019.
  */
-class SecioHandshake(
+class SecIoNegotiator(
     private val outboundChannel: (ByteBuf) -> Unit,
     val localKey: PrivKey,
     val remotePeerId: PeerId?

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
@@ -17,6 +17,8 @@ import io.libp2p.etc.types.compareTo
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
 import io.libp2p.etc.types.toProtobuf
+import io.libp2p.security.InvalidInitialPacket
+import io.libp2p.security.InvalidRemotePubKey
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
 import org.bouncycastle.crypto.digests.SHA256Digest
@@ -73,7 +75,7 @@ class SecIoNegotiator(
 
     private val localPubKeyBytes = localKey.publicKey().bytes()
     private val remoteNonce: ByteArray
-        get() = remotePropose!!.rand.toByteArray()
+        get() = remotePropose.rand.toByteArray()
 
     fun isComplete() = state == State.FinalValidated
 
@@ -87,7 +89,7 @@ class SecIoNegotiator(
             .build()
 
         state = State.ProposeSent
-        write(proposeMsg!!)
+        write(proposeMsg)
     }
 
     fun onSecureChannelSetup() {

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
@@ -28,14 +28,8 @@ import spipe.pb.Spipe
 import java.security.SecureRandom
 
 data class SecioParams(
-    val nonce: ByteArray,
     val permanentPubKey: PubKey,
-    val ephemeralPubKey: ByteArray,
     val keys: StretchedKey,
-
-    val curveT: String,
-    val cipherT: String,
-    val hashT: String,
 
     val mac: HMac
 )
@@ -211,23 +205,13 @@ class SecIoNegotiator(
         state = State.KeysCreated
         return Pair(
             SecioParams(
-                nonce,
                 localKey.publicKey(),
-                ephPubKey!!.bytes(),
                 localKeys,
-                curve!!,
-                cipher!!,
-                hash!!,
                 hmacFactory.invoke(localKeys.macKey)
             ),
             SecioParams(
-                remotePropose!!.rand.toByteArray(),
                 remotePubKey!!,
-                remoteEphPubPoint.getEncoded(true),
                 remoteKeys,
-                curve!!,
-                cipher!!,
-                hash!!,
                 hmacFactory.invoke(remoteKeys.macKey)
             )
         )

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
@@ -4,16 +4,12 @@ import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.P2PChannel
 import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.PrivKey
-import io.libp2p.core.crypto.PubKey
 import io.libp2p.core.multistream.Mode
 import io.libp2p.core.multistream.ProtocolMatcher
 import io.libp2p.core.security.SecureChannel
 import io.libp2p.etc.REMOTE_PEER_ID
-import io.libp2p.etc.events.SecureChannelFailed
-import io.libp2p.etc.events.SecureChannelInitialized
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
-import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.SimpleChannelInboundHandler
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder
 import io.netty.handler.codec.LengthFieldPrepender
@@ -97,5 +93,3 @@ private class SecIoHandshake(
         super.channelUnregistered(ctx)
     }
 }
-
-

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
@@ -20,17 +20,12 @@ import io.netty.handler.codec.LengthFieldPrepender
 import org.apache.logging.log4j.LogManager
 import java.util.concurrent.CompletableFuture
 
-class SecIoSecureChannel(val localKey: PrivKey) :
-    SecureChannel {
+private val log = LogManager.getLogger(SecIoSecureChannel::class.java)
+private val HandshakeHandlerName = "SecIoHandshake"
 
-    private val log = LogManager.getLogger(SecIoSecureChannel::class.java)
-
-    private val HandshakeHandlerName = "SecIoHandshake"
-    private val HadshakeTimeout = 30 * 1000L
-
+class SecIoSecureChannel(private val localKey: PrivKey) : SecureChannel {
     override val announce = "/secio/1.0.0"
-    override val matcher =
-        ProtocolMatcher(Mode.STRICT, name = "/secio/1.0.0")
+    override val matcher = ProtocolMatcher(Mode.STRICT, name = "/secio/1.0.0")
 
     override fun initChannel(ch: P2PChannel, selectedProtocol: String): CompletableFuture<SecureChannel.Session> {
         val handshakeComplete = CompletableFuture<SecureChannel.Session>()
@@ -38,66 +33,69 @@ class SecIoSecureChannel(val localKey: PrivKey) :
         listOf(
             "PacketLenEncoder" to LengthFieldPrepender(4),
             "PacketLenDecoder" to LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4),
-            HandshakeHandlerName to SecIoHandshake(handshakeComplete)
+            HandshakeHandlerName to SecIoHandshake(localKey, handshakeComplete)
         ).forEach { ch.pushHandler(it.first, it.second) }
 
         return handshakeComplete
     }
+} // class SecIoSecureChannel
 
-    inner class SecIoHandshake(private val handshakeComplete: CompletableFuture<SecureChannel.Session>)
-            : SimpleChannelInboundHandler<ByteBuf>() {
-        private lateinit var negotiator: SecIoNegotiator
-        private var activated = false
-        private lateinit var secIoCodec: SecIoCodec
+private class SecIoHandshake(
+    private val localKey: PrivKey,
+    private val handshakeComplete: CompletableFuture<SecureChannel.Session>
+) : SimpleChannelInboundHandler<ByteBuf>() {
+    private lateinit var negotiator: SecIoNegotiator
+    private var activated = false
+    private lateinit var secIoCodec: SecIoCodec
 
-        override fun channelActive(ctx: ChannelHandlerContext) {
-            if (!activated) {
-                activated = true
-                val remotePeerId = ctx.channel().attr(REMOTE_PEER_ID).get()
-                negotiator =
-                    SecIoNegotiator({ buf -> writeAndFlush(ctx, buf) }, localKey, remotePeerId)
-                negotiator.start()
-            }
-        }
-
-        override fun channelRead0(ctx: ChannelHandlerContext, msg: ByteBuf) {
-            // it seems there is no guarantee from Netty that channelActive() must be called before channelRead()
-            channelActive(ctx)
-
-            val keys = negotiator.onNewMessage(msg)
-
-            if (keys != null) {
-                secIoCodec = SecIoCodec(keys.first, keys.second)
-                ctx.channel().pipeline().addBefore(HandshakeHandlerName, "SecIoCodec", secIoCodec)
-                negotiator.onSecureChannelSetup()
-            }
-
-            if (negotiator.isComplete()) {
-                val session = SecureChannel.Session(
-                    PeerId.fromPubKey(secIoCodec.local.permanentPubKey),
-                    PeerId.fromPubKey(secIoCodec.remote.permanentPubKey),
-                    secIoCodec.remote.permanentPubKey
-                )
-                handshakeComplete.complete(session)
-                ctx.channel().pipeline().remove(HandshakeHandlerName)
-                ctx.fireChannelActive()
-            }
-        }
-
-        private fun writeAndFlush(ctx: ChannelHandlerContext, bb: ByteBuf) {
-            ctx.writeAndFlush(bb)
-        }
-
-        override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-            handshakeComplete.completeExceptionally(cause)
-            log.error(cause.message)
-            ctx.channel().close()
-        }
-
-        override fun channelUnregistered(ctx: ChannelHandlerContext) {
-            handshakeComplete.completeExceptionally(ConnectionClosedException("Connection was closed ${ctx.channel()}"))
-            super.channelUnregistered(ctx)
+    override fun channelActive(ctx: ChannelHandlerContext) {
+        if (!activated) {
+            activated = true
+            val remotePeerId = ctx.channel().attr(REMOTE_PEER_ID).get()
+            negotiator =
+                SecIoNegotiator({ buf -> writeAndFlush(ctx, buf) }, localKey, remotePeerId)
+            negotiator.start()
         }
     }
+
+    override fun channelRead0(ctx: ChannelHandlerContext, msg: ByteBuf) {
+        // it seems there is no guarantee from Netty that channelActive() must be called before channelRead()
+        channelActive(ctx)
+
+        val keys = negotiator.onNewMessage(msg)
+
+        if (keys != null) {
+            secIoCodec = SecIoCodec(keys.first, keys.second)
+            ctx.channel().pipeline().addBefore(HandshakeHandlerName, "SecIoCodec", secIoCodec)
+            negotiator.onSecureChannelSetup()
+        }
+
+        if (negotiator.isComplete()) {
+            val session = SecureChannel.Session(
+                PeerId.fromPubKey(secIoCodec.local.permanentPubKey),
+                PeerId.fromPubKey(secIoCodec.remote.permanentPubKey),
+                secIoCodec.remote.permanentPubKey
+            )
+            handshakeComplete.complete(session)
+            ctx.channel().pipeline().remove(HandshakeHandlerName)
+            ctx.fireChannelActive()
+        }
+    }
+
+    private fun writeAndFlush(ctx: ChannelHandlerContext, bb: ByteBuf) {
+        ctx.writeAndFlush(bb)
+    }
+
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+        handshakeComplete.completeExceptionally(cause)
+        log.error(cause.message)
+        ctx.channel().close()
+    }
+
+    override fun channelUnregistered(ctx: ChannelHandlerContext) {
+        handshakeComplete.completeExceptionally(ConnectionClosedException("Connection was closed ${ctx.channel()}"))
+        super.channelUnregistered(ctx)
+    }
 }
+
 

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
@@ -59,7 +59,7 @@ class SecIoSecureChannel(val localKey: PrivKey) :
     }
 
     inner class SecIoHandshake : SimpleChannelInboundHandler<ByteBuf>() {
-        private lateinit var negotiator: SecioHandshake
+        private lateinit var negotiator: SecIoNegotiator
         private var activated = false
         private lateinit var secIoCodec: SecIoCodec
 
@@ -68,7 +68,7 @@ class SecIoSecureChannel(val localKey: PrivKey) :
                 activated = true
                 val remotePeerId = ctx.channel().attr(REMOTE_PEER_ID).get()
                 negotiator =
-                    SecioHandshake({ buf -> writeAndFlush(ctx, buf) }, localKey, remotePeerId)
+                    SecIoNegotiator({ buf -> writeAndFlush(ctx, buf) }, localKey, remotePeerId)
                 negotiator.start()
             }
         }

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
@@ -40,6 +40,7 @@ class SecIoSecureChannel(val localKey: PrivKey) :
             "PacketLenDecoder" to LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4),
             HandshakeHandlerName to SecIoHandshake(handshakeComplete)
         ).forEach { ch.pushHandler(it.first, it.second) }
+
         return handshakeComplete
     }
 
@@ -72,7 +73,7 @@ class SecIoSecureChannel(val localKey: PrivKey) :
             }
 
             if (negotiator.isComplete()) {
-                val session = SecioSession(
+                val session = SecureChannel.Session(
                     PeerId.fromPubKey(secIoCodec.local.permanentPubKey),
                     PeerId.fromPubKey(secIoCodec.remote.permanentPubKey),
                     secIoCodec.remote.permanentPubKey
@@ -100,8 +101,3 @@ class SecIoSecureChannel(val localKey: PrivKey) :
     }
 }
 
-/**
- * SecioSession exposes the identity and public security material of the other party as authenticated by SecIO.
- */
-class SecioSession(localId: PeerId, remoteId: PeerId, remotePubKey: PubKey) :
-    SecureChannel.Session(localId, remoteId, remotePubKey)

--- a/src/main/kotlin/io/libp2p/security/secio/SecioError.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecioError.kt
@@ -1,17 +1,10 @@
 package io.libp2p.security.secio
 
-/**
- * Created by Anton Nashatyrev on 14.06.2019.
- */
-open class SecioError : Exception()
+import io.libp2p.security.SecureHandshakeError
 
-open class SecioHandshakeError : SecioError()
+class NoCommonAlgos : SecureHandshakeError()
+class InvalidSignature : SecureHandshakeError()
+class InvalidNegotiationState : SecureHandshakeError()
+class SelfConnecting : SecureHandshakeError()
 
-class NoCommonAlgos : SecioHandshakeError()
-class InvalidRemotePubKey : SecioHandshakeError()
-class InvalidSignature : SecioHandshakeError()
-class InvalidNegotiationState : SecioHandshakeError()
-class InvalidInitialPacket : SecioHandshakeError()
-class SelfConnecting : SecioHandshakeError()
-
-class MacMismatch : SecioError()
+class MacMismatch : SecureHandshakeError()

--- a/src/test/external/go/ping-client/main.go
+++ b/src/test/external/go/ping-client/main.go
@@ -43,7 +43,7 @@ func main() {
 		for i := 1; i <= 5; i++ {
 			fmt.Printf("Ping %v", i)
 			pingResp := <-ch
-			fmt.Printf(" - %v\n", pingResp.RTT)
+			fmt.Printf(" in %v\n", pingResp.RTT)
 		}
 	}
 

--- a/src/test/external/js/pinger/lib/ping-client.js
+++ b/src/test/external/js/pinger/lib/ping-client.js
@@ -31,7 +31,7 @@ async function pingRemotePeer(address) {
   console.log(`pinging remote peer at ${address}`)
   for (let i = 0; i != 5; ++i) {
     const time = await ping(pingNode, remotePeerInfo)
-    console.log(`ping ${i+1} in ${time}ms`)
+    console.log(`Ping ${i+1} in ${time}ms`)
   }
 
   pingNode.stop()

--- a/src/test/kotlin/io/libp2p/security/secio/SecIoNegotiatorTest.kt
+++ b/src/test/kotlin/io/libp2p/security/secio/SecIoNegotiatorTest.kt
@@ -16,7 +16,7 @@ import java.math.BigInteger
  * Created by Anton Nashatyrev on 18.06.2019.
  */
 @Tag("secure-channel")
-class SecioHandshakeTest {
+class SecIoNegotiatorTest {
     @Test
     fun handshake() {
         val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
@@ -24,8 +24,8 @@ class SecioHandshakeTest {
         var bb1: ByteBuf? = null
         var bb2: ByteBuf? = null
 
-        val hs1 = SecioHandshake({ bb -> bb1 = bb }, privKey1, PeerId.fromPubKey(pubKey2))
-        val hs2 = SecioHandshake({ bb -> bb2 = bb }, privKey2, PeerId.fromPubKey(pubKey1))
+        val hs1 = SecIoNegotiator({ bb -> bb1 = bb }, privKey1, PeerId.fromPubKey(pubKey2))
+        val hs2 = SecIoNegotiator({ bb -> bb2 = bb }, privKey2, PeerId.fromPubKey(pubKey1))
 
         hs1.start()
         hs2.start()


### PR DESCRIPTION
Clarifying rework in SecioSecureChannel and NoiseXXChannel.

In particular, the handshake completion signalling of both is simplified, removing the need for a specific anonymous listener class - eg [4f09e9b](https://github.com/libp2p/jvm-libp2p/commit/4f09e9bd54a16a88d03ca90fb854da46d85fdc32)

Replaces draft PR #63. I've pulled the remote branch into this repository, and rebased against develop. 