### PR TITLE
Bugfix/warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     id("com.google.protobuf") version "0.8.7"
     `build-scan`
 
+    `maven`
     `maven-publish`
     id("com.jfrog.bintray") version "1.8.1"
     id("org.jetbrains.dokka") version "0.9.18"

--- a/src/main/kotlin/io/libp2p/etc/types/ByteArrayExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/ByteArrayExt.kt
@@ -61,6 +61,7 @@ fun Int.toBytesBigEndian() =
 /**
  * Extends ByteBuf to add a read* method for unsigned varints, as defined in https://github.com/multiformats/unsigned-varint.
  */
+@kotlin.ExperimentalUnsignedTypes
 fun ByteArray.readUvarint(): Pair<Long, ByteArray>? {
     var x: Long = 0
     var s = 0

--- a/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
@@ -38,6 +38,7 @@ class MuxChannel<TData>(
                 // the msg is released by both onChildWrite and buf.remove() so we need to retain
                 // however it is still to be confirmed that no buf leaks happen here TODO
                 ReferenceCountUtil.retain(msg)
+                @Suppress("UNCHECKED_CAST")
                 parent.onChildWrite(this, msg as TData)
                 buf.remove()
             } catch (cause: Throwable) {

--- a/src/main/kotlin/io/libp2p/host/HostImpl.kt
+++ b/src/main/kotlin/io/libp2p/host/HostImpl.kt
@@ -95,6 +95,7 @@ class HostImpl(
 
     override fun <TController> newStream(protocol: String, conn: Connection): StreamPromise<TController> {
         val binding =
+            @Suppress("UNCHECKED_CAST")
             protocolHandlers.bindings.find { it.matcher.matches(protocol) } as? ProtocolBinding<TController>
             ?: throw NoSuchLocalProtocolException("Protocol handler not found: $protocol")
 

--- a/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -319,8 +319,8 @@ abstract class PubsubRouterTest(val router: RouterCtor) {
 
         val routers = List(3) { fuzz.createTestRouter(router()) }
 
-        val conn_1_2 = routers[0].connectSemiDuplex(routers[1], pubsubLogs = LogLevel.ERROR)
-        val conn_2_3 = routers[1].connectSemiDuplex(routers[2], pubsubLogs = LogLevel.ERROR)
+        routers[0].connectSemiDuplex(routers[1], pubsubLogs = LogLevel.ERROR)
+        routers[1].connectSemiDuplex(routers[2], pubsubLogs = LogLevel.ERROR)
 
         val apis = routers.map { it.api }
         class RecordingSubscriber : Subscriber {

--- a/src/test/kotlin/io/libp2p/security/secio/EchoSampleTest.kt
+++ b/src/test/kotlin/io/libp2p/security/secio/EchoSampleTest.kt
@@ -50,7 +50,7 @@ class EchoSampleTest {
     fun connect1() {
         val logger = LogManager.getLogger("test")
 
-        val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
         val upgrader = ConnectionUpgrader(
             listOf(SecIoSecureChannel(privKey1)),
             listOf(MplexStreamMuxer().also {

--- a/src/test/kotlin/io/libp2p/transport/NullConnectionUpgrader.kt
+++ b/src/test/kotlin/io/libp2p/transport/NullConnectionUpgrader.kt
@@ -30,7 +30,7 @@ class NullConnectionUpgrader : ConnectionUpgrader(emptyList(), emptyList()) {
     private class DoNothingMuxerSession : StreamMuxer.Session {
         override var inboundStreamHandler: StreamHandler<*>?
             get() = throw NotImplementedError("Test only. Shouldn't be called")
-            set(value) {}
+            set(_) {}
 
         override fun <T> createStream(streamHandler: StreamHandler<T>): StreamPromise<T> {
             throw NotImplementedError("Test only. Shouldn't be called")


### PR DESCRIPTION
Fixes compiler warnings for src/main and src/test, and also one of the Gradle warnings. 

(Nothing we can do about the 'Deprecated Gradle features' warning unfortunately. That's on the Kotlin plugin.)