### PR TITLE
Fix IllegalStateException

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/netty/AbstractChildChannel.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/AbstractChildChannel.kt
@@ -21,14 +21,9 @@ abstract class AbstractChildChannel(parent: Channel, id: ChannelId?) : AbstractC
         OPEN, ACTIVE, INACTIVE, CLOSED
     }
 
+    private val closeFuture = parent.closeFuture()
     private var state = State.OPEN
     private var closeImplicitly = false
-
-    init {
-        parent.closeFuture().addListener {
-            closeImpl()
-        }
-    }
 
     fun closeImpl() {
         closeImplicitly = true
@@ -53,6 +48,9 @@ abstract class AbstractChildChannel(parent: Channel, id: ChannelId?) : AbstractC
 
     override fun doRegister() {
         state = State.ACTIVE
+        closeFuture.addListener {
+            closeImpl()
+        }
     }
 
     override fun doDeregister() {


### PR DESCRIPTION
Fix IllegalStateException:
```
An exception was thrown by io.libp2p.etc.util.netty.AbstractChildChannel$1.operationComplete()
java.lang.IllegalStateException: channel not registered to an event loop
	at io.netty.channel.AbstractChannel.eventLoop(AbstractChannel.java:163) ~[netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.AbstractChannelHandlerContext.executor(AbstractChannelHandlerContext.java:127) ~[netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.AbstractChannelHandlerContext.newPromise(AbstractChannelHandlerContext.java:856) ~[netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.AbstractChannelHandlerContext.close(AbstractChannelHandlerContext.java:467) ~[netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.DefaultChannelPipeline.close(DefaultChannelPipeline.java:968) ~[netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.AbstractChannel.close(AbstractChannel.java:243) ~[netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.libp2p.etc.util.netty.AbstractChildChannel.closeImpl(AbstractChildChannel.kt:36) ~[jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.libp2p.etc.util.netty.AbstractChildChannel$1.operationComplete(AbstractChildChannel.kt:29) ~[jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:502) [netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:476) [netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:415) [netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.util.concurrent.DefaultPromise.addListener(DefaultPromise.java:152) [netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.DefaultChannelPromise.addListener(DefaultChannelPromise.java:95) [netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.netty.channel.DefaultChannelPromise.addListener(DefaultChannelPromise.java:30) [netty-all-4.1.36.Final.jar:4.1.36.Final]
	at io.libp2p.etc.util.netty.AbstractChildChannel.<init>(AbstractChildChannel.kt:28) [jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.libp2p.etc.util.netty.mux.MuxChannel.<init>(MuxChannel.kt:17) [jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.libp2p.etc.util.netty.mux.AbstractMuxHandler.createChild(AbstractMuxHandler.kt:91) [jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.libp2p.etc.util.netty.mux.AbstractMuxHandler.access$createChild(AbstractMuxHandler.kt:13) [jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.libp2p.etc.util.netty.mux.AbstractMuxHandler$newStream$1.apply(AbstractMuxHandler.kt:106) [jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
	at io.libp2p.etc.util.netty.mux.AbstractMuxHandler$newStream$1.apply(AbstractMuxHandler.kt:13) [jvm-libp2p-minimal-0.3.2-RELEASE.jar:?]
```

Don't invoke `closeImpl` until we know that we have a registered eventLoop.