### PR TITLE
Report error with context and full stack trace

### DIFF
--- a/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
@@ -84,7 +84,7 @@ private class SecIoHandshake(
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         handshakeComplete.completeExceptionally(cause)
-        log.error(cause.message)
+        log.error("SecIo handshake failed", cause)
         ctx.channel().close()
     }
 


### PR DESCRIPTION
When SecIo handshake fails, include the full stack trace instead of just the message.  Otherwise `NullPointerException` becomes a very unhelpful `null` error message with no context.

fixes #95 