### PR TITLE
Reduce log levels for expected conditions

### DIFF
--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -261,7 +261,7 @@ private class NoiseIoHandshake(
         handshakeFailed(ctx, Exception(cause))
     }
     private fun handshakeFailed(ctx: ChannelHandlerContext, cause: Throwable) {
-        log.error(cause.message)
+        log.debug("Noise handshake failed", cause)
 
         handshakeComplete.completeExceptionally(cause)
         ctx.pipeline().remove(this)

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoSecureChannel.kt
@@ -84,7 +84,7 @@ private class SecIoHandshake(
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         handshakeComplete.completeExceptionally(cause)
-        log.error(cause.message)
+        log.debug("SecIo handshake failed", cause)
         ctx.channel().close()
     }
 


### PR DESCRIPTION
Remote peers disconnecting or sending invalid content is a common occurrence and shouldn't result on error log messages.

Additionally at the reduced log level, ensure that the full exception is made available to the logging system so that the log configuration can choose whether or not to include the full stack trace.