### PR TITLE
Fix muxer exception handling

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
@@ -38,7 +38,7 @@ abstract class AbstractMuxHandler<TData>(var inboundInitializer: MuxChannelIniti
         super.channelUnregistered(ctx)
     }
 
-    override fun exceptionCaught(ctx: ChannelHandlerContext?, cause: Throwable?) {
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         when (cause) {
             is InternalErrorException -> log.warn("Muxer internal error", cause)
             is Libp2pException -> log.debug("Muxer exception", cause)

--- a/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
@@ -1,14 +1,18 @@
 package io.libp2p.etc.util.netty.mux
 
 import io.libp2p.core.ConnectionClosedException
+import io.libp2p.core.InternalErrorException
 import io.libp2p.core.Libp2pException
 import io.libp2p.etc.types.completedExceptionally
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
+import org.apache.logging.log4j.LogManager
 import java.util.concurrent.CompletableFuture
 import java.util.function.Function
 
 typealias MuxChannelInitializer<TData> = (MuxChannel<TData>) -> Unit
+
+private val log = LogManager.getLogger(AbstractMuxHandler::class.java)
 
 abstract class AbstractMuxHandler<TData>(var inboundInitializer: MuxChannelInitializer<TData>? = null) :
     ChannelInboundHandlerAdapter() {
@@ -34,19 +38,27 @@ abstract class AbstractMuxHandler<TData>(var inboundInitializer: MuxChannelIniti
         super.channelUnregistered(ctx)
     }
 
+    override fun exceptionCaught(ctx: ChannelHandlerContext?, cause: Throwable?) {
+        when (cause) {
+            is InternalErrorException -> log.warn("Muxer internal error", cause)
+            is Libp2pException -> log.debug("Muxer exception", cause)
+            else -> log.warn("Unexpected exception", cause)
+        }
+    }
+
     fun getChannelHandlerContext(): ChannelHandlerContext {
-        return ctx ?: throw Libp2pException("Internal error: handler context should be initialized at this stage")
+        return ctx ?: throw InternalErrorException("Internal error: handler context should be initialized at this stage")
     }
 
     protected fun childRead(id: MuxId, msg: TData) {
-        val child = streamMap[id] ?: throw Libp2pException("Channel with id $id not opened")
+        val child = streamMap[id] ?: throw ConnectionClosedException("Channel with id $id not opened")
         child.pipeline().fireChannelRead(msg)
     }
 
     abstract fun onChildWrite(child: MuxChannel<TData>, data: TData): Boolean
 
     protected fun onRemoteOpen(id: MuxId) {
-        val initializer = inboundInitializer ?: throw Libp2pException("Illegal state: inbound stream handler is not set up yet")
+        val initializer = inboundInitializer ?: throw InternalErrorException("Illegal state: inbound stream handler is not set up yet")
         val child = createChild(
             id,
             initializer,

--- a/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
+++ b/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
@@ -16,7 +16,7 @@ import io.netty.channel.ChannelHandlerContext
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicLong
 
-class MuxHandler(
+open class MuxHandler(
     private val ready: CompletableFuture<StreamMuxer.Session>?
 ) : AbstractMuxHandler<ByteBuf>(), StreamMuxer.Session {
     private val idGenerator = AtomicLong(0xF)

--- a/src/test/kotlin/io/libp2p/mux/MultiplexHandlerTest.kt
+++ b/src/test/kotlin/io/libp2p/mux/MultiplexHandlerTest.kt
@@ -40,7 +40,7 @@ class MultiplexHandlerTest {
     @BeforeEach
     fun startMultiplexor() {
         childHandlers.clear()
-        multistreamHandler = MuxHandler(
+        multistreamHandler = object : MuxHandler(
             createStreamHandler(
                 nettyInitializer {
                     println("New child channel created")
@@ -48,7 +48,13 @@ class MultiplexHandlerTest {
                     it.pipeline().addLast(handler)
                     childHandlers += handler
                 })
-        )
+        ) {
+            // MuxHandler consumes the exception. Override this behaviour for testing
+            override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+                super.exceptionCaught(ctx, cause)
+                ctx.fireExceptionCaught(cause)
+            }
+        }
 
         ech = TestChannel("test", true, LoggingHandler(LogLevel.ERROR), multistreamHandler)
     }


### PR DESCRIPTION
Handle AbstractMuxHandler exceptions since it's the last handler in connection pipeline. 
Log internal errors and unknown exceptions with WARN level

Partially addresses #101 issue. 