### PR TITLE
Fix intermittent Travis test failures 

### DIFF
--- a/src/test/java/io/libp2p/tools/schedulers/TaskQueue.java
+++ b/src/test/java/io/libp2p/tools/schedulers/TaskQueue.java
@@ -1,0 +1,87 @@
+package io.libp2p.tools.schedulers;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Queue;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class TaskQueue {
+
+    private NavigableMap<Long, Queue<TimeController.Task>> tasks = Collections.synchronizedNavigableMap(new TreeMap<>());
+    private boolean executing = false;
+
+    public void add(TimeController.Task task) {
+        tasks.computeIfAbsent(task.getTime(), t -> new ConcurrentLinkedQueue<>()).add(task);
+    }
+
+    public void remove(TimeController.Task task) {
+        tasks.computeIfPresent(task.getTime(), (t, queue) -> {
+            queue.remove(task);
+            return queue;
+        });
+    }
+
+    public boolean isEmpty() {
+        return tasks.isEmpty();
+    }
+
+    public long getEarliestTime() {
+        Map.Entry<Long, Queue<TimeController.Task>> entry = tasks.firstEntry();
+        return entry == null ? 0 : entry.getKey();
+    }
+
+    private Queue<TimeController.Task> peekEarliest() {
+        return tasks.get(getEarliestTime());
+    }
+
+    public void dropEarliest() {
+        tasks.remove(getEarliestTime());
+    }
+
+    public void executeEarliest() {
+        if (executing) return;
+        executing = true;
+        try {
+            Queue<TimeController.Task> taskQueue = peekEarliest();
+            if (taskQueue == null) return;
+
+            Queue<CompletableFuture<Void>> resQueue = new LinkedBlockingQueue<>();
+
+            drainQueue(taskQueue, resQueue);
+
+            while (!resQueue.isEmpty()) {
+                try {
+                    resQueue.poll().get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            dropEarliest();
+        } finally {
+            executing = false;
+        }
+    }
+
+    public boolean isExecuting() {
+        return executing;
+    }
+
+    private synchronized void drainQueue(Queue<TimeController.Task> taskQueue, Queue<CompletableFuture<Void>> resQueue) {
+        while (!taskQueue.isEmpty()) {
+            TimeController.Task task = taskQueue.poll();
+            CompletableFuture<Void> taskFut = task.execute();
+            if (taskFut.isDone()) {
+                resQueue.add(taskFut);
+            } else {
+                CompletableFuture<Void> resFut = taskFut.whenComplete((v, t) -> {
+                    drainQueue(taskQueue, resQueue);
+                });
+                resQueue.add(resFut);
+            }
+        }
+    }
+}

--- a/src/test/java/io/libp2p/tools/schedulers/TimeController.java
+++ b/src/test/java/io/libp2p/tools/schedulers/TimeController.java
@@ -1,6 +1,7 @@
 package io.libp2p.tools.schedulers;
 
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Controls global time and execution order of child executors
@@ -18,7 +19,7 @@ public interface TimeController {
 
     long getTime();
 
-    void execute();
+    CompletableFuture<Void> execute();
   }
 
   /**

--- a/src/test/java/io/libp2p/tools/schedulers/TimeControllerImpl.java
+++ b/src/test/java/io/libp2p/tools/schedulers/TimeControllerImpl.java
@@ -1,32 +1,16 @@
 package io.libp2p.tools.schedulers;
 
-import com.google.common.collect.TreeMultimap;
-
-import java.util.Comparator;
-import java.util.NavigableSet;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class TimeControllerImpl implements TimeController {
   private static AtomicLong id = new AtomicLong();
   TimeController parent;
 
-  private static class OrderedTask {
-    final long order = id.incrementAndGet();
-    final Task task;
+  TaskQueue taskQueue = new TaskQueue();
 
-    public OrderedTask(Task task) {
-      this.task = task;
-    }
-
-    public long getOrder() {
-      return order;
-    }
-  }
-
-  TreeMultimap<Long, OrderedTask> tasks = TreeMultimap.create(
-          Comparator.naturalOrder(), Comparator.comparing(OrderedTask::getOrder));
   long curTime;
   long timeShift;
+  private boolean executingImmediate = false;
 
   @Override
   public long getTime() {
@@ -47,16 +31,9 @@ public class TimeControllerImpl implements TimeController {
       throw new IllegalArgumentException("newTime < curTime: " + newTime + ", " + curTime);
     }
     newTime += timeShift;
-    while (!tasks.isEmpty()) {
-      OrderedTask orderedTask = tasks.values().iterator().next();
-      Task task = orderedTask.task;
-      if (task.getTime() <= newTime) {
-        curTime = task.getTime();
-        tasks.remove(task.getTime(), orderedTask);
-        task.execute();
-      } else {
-        break;
-      }
+    while (!taskQueue.isEmpty() && taskQueue.getEarliestTime() <= newTime) {
+      curTime = taskQueue.getEarliestTime();
+      taskQueue.executeEarliest();
     }
     curTime = newTime;
   }
@@ -68,7 +45,22 @@ public class TimeControllerImpl implements TimeController {
       return;
     }
 
-    tasks.put(task.getTime(), new OrderedTask(task));
+    taskQueue.add(task);
+
+    if (getTime() == task.getTime() && !taskQueue.isExecuting()) {
+      executeImmediateTasksNonRecursively();
+    }
+  }
+
+  private void executeImmediateTasksNonRecursively() {
+    if (!executingImmediate) {
+      try {
+        executingImmediate = true;
+        setTime(getTime());
+      } finally {
+        executingImmediate = false;
+      }
+    }
   }
 
   @Override
@@ -78,13 +70,7 @@ public class TimeControllerImpl implements TimeController {
       return;
     }
 
-    NavigableSet<OrderedTask> tasks = this.tasks.get(task.getTime());
-    for (OrderedTask orderedTask : tasks) {
-      if (orderedTask.task == task) {
-        this.tasks.remove(task.getTime(), orderedTask);
-        return;
-      }
-    }
+    taskQueue.remove(task);
   }
 
   @Override


### PR DESCRIPTION
We are having `FloodPubsubRouterTest.TenNeighboursTopology` intermittent failures on Travis. The failing is not reproducible locally. 
The case seemed even more mysterious taking into account that the test should be absolutely deterministic: 
- the whole network is executed on a single thread
- all randoms are determined with initial random seed  

It seems that the failing is caused by `StackOverflowException` since the current `ControlledExecutorService.execute()` invokes the submitted task 'in place' thus causing a pubsub message dissemination through the whole test peers network to be done on a single stack. 

Incrementing the number of test peers https://github.com/libp2p/jvm-libp2p/blob/9f741670cb27e55514768be1cce5c6d394e93cf5/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt#L222 allows to reproduce the issue locally 

This PR picks up `ControlledExecutorService` related changes from the `simulator` branch which queues `execute()` tasks until the current task completes. 
