### PR TITLE
Fix pubsub: ignore incoming messages we are not subscribed to

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 // ./gradlew bintrayUpload -PbintrayUser=<user> -PbintrayApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.6.0-RELEASE"
+version = "0.5.1-RELEASE"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 // ./gradlew bintrayUpload -PbintrayUser=<user> -PbintrayApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.5.1-RELEASE"
+version = "0.6.0-RELEASE"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {

--- a/src/main/kotlin/io/libp2p/multistream/ProtocolSelect.kt
+++ b/src/main/kotlin/io/libp2p/multistream/ProtocolSelect.kt
@@ -36,9 +36,6 @@ class ProtocolSelect<TController>(val protocols: List<ProtocolBinding<TControlle
     }
 
     override fun channelActive(ctx: ChannelHandlerContext) {
-        if (!userEvent) {
-            println("Ops")
-        }
         if (!activeFired) {
             ctx.fireChannelActive()
         }

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -70,7 +70,10 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
         }.map {
             it.receiver.apply(rpc2Msg(msg))
         }
-        return validationFuts.thenApplyAll { it.reduce(validationResultReduce) }
+        return validationFuts.thenApplyAll {
+            if (it.isEmpty())ValidationResult.Ignore
+            else it.reduce(validationResultReduce)
+        }
     }
 
     private fun rpc2Msg(msg: Rpc.Message): MessageApi {

--- a/src/test/kotlin/io/libp2p/tools/ProtobufUtils.kt
+++ b/src/test/kotlin/io/libp2p/tools/ProtobufUtils.kt
@@ -1,0 +1,42 @@
+package io.libp2p.tools
+
+/**
+ * When protobuf message is converted to String it prints binary data ([ByteSequence]) by escaping bytes as
+ * characters.
+ * The string looks like `\026\030L\034E?\226\374`
+ * This functions converts this representation back to bytes.
+ * This can be handy when sorting out logs
+ */
+fun parseProtobufBytesToString(str: String): ByteArray {
+    val bytes = mutableListOf<Byte>()
+    var pos = 0
+    while (pos < str.length) {
+        bytes += when (str[pos]) {
+            '\\' -> {
+                pos++
+                when (str[pos]) {
+                    in '0'..'9' -> {
+                        val r = ((("" + str[pos]).toInt() shl 6) or
+                                (("" + str[pos + 1]).toInt() shl 3) or
+                                (("" + str[pos + 2]).toInt())).toByte()
+                        pos += 2
+                        r
+                    }
+                    'a' -> 0x07
+                    'b' -> '\b'.toByte()
+                    'f' -> 0xC
+                    'n' -> '\n'.toByte()
+                    'r' -> '\r'.toByte()
+                    't' -> '\t'.toByte()
+                    'v' -> 0x0b
+                    '\\' -> '\\'.toByte()
+                    '\'' -> '\''.toByte()
+                    '"' -> '"'.toByte()
+                    else -> throw IllegalArgumentException("Invalid escape char")
+                }.also { pos++ }
+            }
+            else -> str[pos++].toByte()
+        }
+    }
+    return bytes.toByteArray()
+}


### PR DESCRIPTION
- Ignore inbound messages without topics we are subscribed to. 
- Call notifyNonSubscribedMessage for potential penalty for the peer which is sending such messages
- Don't fail with exception if a message without subscribed topics still reaches Api class
- Add utility method for debugging protobuf related issues

Fixes https://github.com/PegaSysEng/teku/issues/2143