### PR TITLE
Fix pubsub malformed msg handling

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -85,6 +85,9 @@ abstract class P2PService {
         open fun isActive() = streamHandler.ctx != null
         open fun getInboundHandler(): StreamHandler? = streamHandler
         open fun getOutboundHandler(): StreamHandler? = streamHandler
+        override fun toString(): String {
+            return "PeerHandler(peerId=$peerId, stream=${streamHandler.stream})"
+        }
     }
 
     /**

--- a/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -145,7 +145,7 @@ abstract class P2PService {
     }
 
     protected open fun streamException(stream: StreamHandler, cause: Throwable) {
-        onPeerException(stream.peerHandler, cause)
+        onPeerWireException(stream.peerHandler, cause)
     }
 
     protected open fun streamInbound(stream: StreamHandler, msg: Any) {
@@ -182,10 +182,10 @@ abstract class P2PService {
     protected abstract fun onInbound(peer: PeerHandler, msg: Any)
 
     /**
-     * Notifies on error in peer communication
+     * Notifies on error in peer wire communication
      * Invoked on event thread
      */
-    protected open fun onPeerException(peer: PeerHandler, cause: Throwable) {
+    protected open fun onPeerWireException(peer: PeerHandler, cause: Throwable) {
         logger.warn("Error by peer $peer ", cause)
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -157,6 +157,7 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
         peer.writeAndFlush(helloPubsubMsg)
     }
 
+    protected open fun notifyMalformedMessage(peer: PeerHandler) {}
     protected open fun notifyUnseenMessage(peer: PeerHandler, msg: Rpc.Message) {}
     protected open fun notifyNonSubscribedMessage(peer: PeerHandler, msg: Rpc.Message) {}
     protected open fun notifySeenMessage(peer: PeerHandler, msg: Rpc.Message, validationResult: Optional<ValidationResult>) {}
@@ -246,6 +247,12 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
     override fun onPeerDisconnected(peer: PeerHandler) {
         super.onPeerDisconnected(peer)
         peerTopics.removeAll(peer)
+    }
+
+    override fun onPeerWireException(peer: PeerHandler, cause: Throwable) {
+        // exception occurred in protobuf decoders
+        logger.debug("Malformed message from $peer : $cause")
+        notifyMalformedMessage(peer)
     }
 
     private fun handleMessageSubscriptions(peer: PeerHandler, msg: Rpc.RPC.SubOpts) {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -122,7 +122,6 @@ open class GossipRouter @JvmOverloads constructor(
         notifyRouterMisbehavior(peer, 1)
     }
 
-
     private fun notifyAnyValidMessage(peer: PeerHandler, msg: Rpc.Message) {
         iWantRequests -= peer to getMessageId(msg)
     }

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -118,6 +118,11 @@ open class GossipRouter @JvmOverloads constructor(
         notifyAnyValidMessage(peer, msg)
     }
 
+    override fun notifyMalformedMessage(peer: PeerHandler) {
+        notifyRouterMisbehavior(peer, 1)
+    }
+
+
     private fun notifyAnyValidMessage(peer: PeerHandler, msg: Rpc.Message) {
         iWantRequests -= peer to getMessageId(msg)
     }

--- a/src/main/kotlin/io/libp2p/transport/implementation/P2PChannelOverNetty.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/P2PChannelOverNetty.kt
@@ -31,4 +31,7 @@ abstract class P2PChannelOverNetty(
     override fun close() = nettyChannel.close().toVoidCompletableFuture()
 
     override fun closeFuture() = nettyChannel.closeFuture().toVoidCompletableFuture()
+    override fun toString(): String {
+        return "P2PChannelOverNetty(nettyChannel=$nettyChannel, isInitiator=$isInitiator)"
+    }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-class MockRouter(
+open class MockRouter(
     override val protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1
 ) : AbstractRouter() {
 

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -119,7 +119,7 @@ class GossipV1_1Tests {
     }
 
     @Test
-    fun malformedMessageTest() {
+    fun testPenaltyForMalformedMessage() {
         class MalformedMockRouter : MockRouter() {
             var malform = false
             override fun initChannel(streamHandler: StreamHandler) {
@@ -148,7 +148,15 @@ class GossipV1_1Tests {
             .addPublish(newMessage("topic1", 0L, "Hello-1".toByteArray()))
             .build()
         mockRouter.malform = true
+
+
+        val peerScores = test.gossipRouter.score.peerScores.values.first()
+        // no behavior penalty before flooding
+        assertEquals(0.0, peerScores.behaviorPenalty)
+
         test.mockRouter.sendToSingle(msg1)
+
+        assertTrue(peerScores.behaviorPenalty > 0)
     }
 
     @Test

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -123,7 +123,7 @@ class GossipV1_1Tests {
         class MalformedMockRouter : MockRouter() {
             var malform = false
             override fun initChannel(streamHandler: StreamHandler) {
-                streamHandler.stream.pushHandler(object: ChannelOutboundHandlerAdapter() {
+                streamHandler.stream.pushHandler(object : ChannelOutboundHandlerAdapter() {
                     override fun write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise) {
                         msg as ByteBuf
                         if (malform) {
@@ -148,7 +148,6 @@ class GossipV1_1Tests {
             .addPublish(newMessage("topic1", 0L, "Hello-1".toByteArray()))
             .build()
         mockRouter.malform = true
-
 
         val peerScores = test.gossipRouter.score.peerScores.values.first()
         // no behavior penalty before flooding


### PR DESCRIPTION
Handle the issue: https://github.com/PegaSysEng/teku/issues/2288

It's not an exceptional situation in P2P when a malformed message received from a peer. So we shouldn't shout with `WARN` level in such situations, but just penalize the peer and `log.debug` the reason