### PR TITLE
Add method to API to retrieve complete list of subscribed topics by peer

### DIFF
--- a/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
+++ b/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
@@ -1,5 +1,6 @@
 package io.libp2p.core.pubsub
 
+import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.PrivKey
 import io.libp2p.pubsub.PubsubApiImpl
 import io.libp2p.pubsub.PubsubRouter
@@ -77,6 +78,13 @@ interface PubsubSubscriberApi {
             RESULT_VALID
         }, *topics)
     }
+
+    /**
+     * Get the topics each peer is subscribed to
+     *
+     * @return a map of the peer's {@link PeerId} to the set of topics it is subscribed to
+     */
+    fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>>
 }
 
 /**

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub
 
+import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.RESULT_VALID
 import io.libp2p.core.pubsub.ValidationResult
@@ -301,6 +302,16 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
             )
         }
         subscribedTopics -= topic
+    }
+
+    override fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<String>>> {
+        return submitOnEventThread {
+            val topicsByPeerId = hashMapOf<PeerId, Set<String>>()
+            peerTopics.forEach { entry ->
+                topicsByPeerId[entry.key.peerId] = HashSet(entry.value)
+            }
+            topicsByPeerId
+        }
     }
 
     protected open fun send(peer: PeerHandler, msg: Rpc.RPC): CompletableFuture<Unit> {

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -107,7 +107,7 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
     override fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>> {
         return router.getPeerTopics().thenApply { peerTopics ->
             peerTopics.mapValues { topicNames ->
-                topicNames.value.mapTo(HashSet()) { topicName -> Topic(topicName) } as Set<Topic>
+                topicNames.value.mapTo(HashSet()) { topicName -> Topic(topicName) }
             }
         }
     }

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -104,6 +104,14 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
         return subscription
     }
 
+    override fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>> {
+        return router.getPeerTopics().thenApply { peerTopics ->
+            peerTopics.mapValues { topicNames ->
+                topicNames.value.mapTo(HashSet()) { topicName -> Topic(topicName) } as Set<Topic>
+            }
+        }
+    }
+
     private fun unsubscribeImpl(sub: SubscriptionImpl) {
         val routerToUnsubscribe = mutableListOf<String>()
 

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub
 
+import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.ValidationResult
 import io.netty.channel.ChannelHandler
@@ -47,6 +48,13 @@ interface PubsubMessageRouter {
      * to receive messages on the following topics any more
      */
     fun unsubscribe(vararg topics: String)
+
+    /**
+     * Get the topics each peer is subscribed to
+     *
+     * @return a map of the peer's {@link PeerId} to the set of topics it is subscribed to
+     */
+    fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<String>>>
 }
 
 /**


### PR DESCRIPTION
This exposes the `peerTopics` variable via the public API which is useful for clients needing to evaluate how many peers are subscribed to particular topics.

Not entirely sure this is the right way to fit it into the APIs but think it is.  The big downside is that internally topics are tracked as `String` but the `PubsubSubscriberApi` wraps them in a `Topic` type.  That results in having to iterate through the data multiple times - once to copy the current state and once to wrap the `String` in `Topic`.  