### PR TITLE
Fix gossip unsubscribe

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -5,6 +5,7 @@ import io.libp2p.core.PeerId
 import io.libp2p.core.multiformats.Protocol
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.anyComplete
+import io.libp2p.etc.types.copy
 import io.libp2p.etc.types.createLRUMap
 import io.libp2p.etc.types.median
 import io.libp2p.etc.types.seconds
@@ -302,7 +303,8 @@ open class GossipRouter @JvmOverloads constructor(
 
     override fun unsubscribe(topic: Topic) {
         super.unsubscribe(topic)
-        mesh[topic]?.forEach { prune(it, topic) }
+        mesh[topic]?.copy()?.forEach { prune(it, topic) }
+        mesh -= topic
     }
 
     private fun catchingHeartbeat() {


### PR DESCRIPTION
Was getting the following exception on `GossipRouter.unsubscribe()`: 
```
java.util.ConcurrentModificationException: null
        at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719) ~[?:?]
        at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:741) ~[?:?]
        at io.libp2p.pubsub.gossip.GossipRouter.unsubscribe(GossipRouter.kt:607) ~[jvm-libp2p-minimal-0.6.0-RELEASE.jar:?]
        at io.libp2p.pubsub.AbstractRouter$unsubscribe$1.invoke(AbstractRouter.kt:292) ~[jvm-libp2p-minimal-0.6.0-RELEASE.jar:?]
        at io.libp2p.pubsub.AbstractRouter$unsubscribe$1.invoke(AbstractRouter.kt:34) ~[jvm-libp2p-minimal-0.6.0-RELEASE.jar:?]
        at io.libp2p.etc.util.P2PService$runOnEventThread$1.run(P2PService.kt:212) [jvm-libp2p-minimal-0.6.0-RELEASE.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java) [?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
```

Also the `GossipRouter.mesh` for unsubscribed topic remained non-null and might potentially be an inconsistency reason since it is assumed in the code that `mesh[topic] == null` if the router is not subscribed