### PR TITLE
Release 0.5.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 // ./gradlew bintrayUpload -PbintrayUser=<user> -PbintrayApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.5.2-RELEASE"
+version = "0.5.3-RELEASE"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {

--- a/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
+++ b/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
@@ -1,5 +1,6 @@
 package io.libp2p.core.pubsub
 
+import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.PrivKey
 import io.libp2p.pubsub.PubsubApiImpl
 import io.libp2p.pubsub.PubsubRouter
@@ -77,6 +78,13 @@ interface PubsubSubscriberApi {
             RESULT_VALID
         }, *topics)
     }
+
+    /**
+     * Get the topics each peer is subscribed to
+     *
+     * @return a map of the peer's {@link PeerId} to the set of topics it is subscribed to
+     */
+    fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>>
 }
 
 /**

--- a/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
@@ -36,11 +36,11 @@ abstract class P2PServiceSemiDuplex : P2PService() {
             peerHandler as SDPeerHandler
             when {
                 peerHandler.otherStreamHandler != null -> {
-                    stream.close()
+                    streamHandler.closeAbruptly()
                     throw BadPeerException("Duplicate steam for peer ${peerHandler.peerId}. Closing it silently")
                 }
                 peerHandler.streamHandler.stream.isInitiator == stream.isInitiator -> {
-                    stream.close()
+                    streamHandler.closeAbruptly()
                     throw BadPeerException("Duplicate stream with initiator = ${stream.isInitiator} for peer ${peerHandler.peerId}")
                 }
                 else -> {

--- a/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
@@ -45,14 +45,14 @@ abstract class P2PServiceSemiDuplex : P2PService() {
                 }
                 else -> {
                     peerHandler.otherStreamHandler = streamHandler
-                    streamHandler.peerHandler = peerHandler
+                    streamHandler.initPeerHandler(peerHandler)
                 }
             }
         }
     }
 
     override fun streamActive(stream: StreamHandler) {
-        if (stream == (stream.peerHandler as SDPeerHandler).getOutboundHandler()) {
+        if (stream == (stream.getPeerHandler() as SDPeerHandler).getOutboundHandler()) {
             // invoke streamActive only when outbound handler is activated
             super.streamActive(stream)
         }

--- a/src/main/kotlin/io/libp2p/etc/util/netty/AbstractChildChannel.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/AbstractChildChannel.kt
@@ -23,7 +23,7 @@ abstract class AbstractChildChannel(parent: Channel, id: ChannelId?) : AbstractC
         OPEN, ACTIVE, INACTIVE, CLOSED
     }
 
-    private val closeFuture = parent.closeFuture()
+    private val parentCloseFuture = parent.closeFuture()
     private var state = State.OPEN
     private var closeImplicitly = false
     private val parentCloseListener = GenericFutureListener { _: Future<Void> -> closeImpl() }
@@ -51,7 +51,7 @@ abstract class AbstractChildChannel(parent: Channel, id: ChannelId?) : AbstractC
 
     override fun doRegister() {
         state = State.ACTIVE
-        closeFuture.addListener(parentCloseListener)
+        parentCloseFuture.addListener(parentCloseListener)
     }
 
     override fun doDeregister() {
@@ -68,7 +68,7 @@ abstract class AbstractChildChannel(parent: Channel, id: ChannelId?) : AbstractC
         if (!closeImplicitly) onClientClosed()
         deactivate()
         pipeline().deregister()
-        closeFuture.removeListener(parentCloseListener)
+        parentCloseFuture.removeListener(parentCloseListener)
         state = State.CLOSED
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -104,6 +104,14 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
         return subscription
     }
 
+    override fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>> {
+        return router.getPeerTopics().thenApply { peerTopics ->
+            peerTopics.mapValues { topicNames ->
+                topicNames.value.mapTo(HashSet()) { topicName -> Topic(topicName) }
+            }
+        }
+    }
+
     private fun unsubscribeImpl(sub: SubscriptionImpl) {
         val routerToUnsubscribe = mutableListOf<String>()
 

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub
 
+import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.ValidationResult
 import io.netty.channel.ChannelHandler
@@ -47,6 +48,13 @@ interface PubsubMessageRouter {
      * to receive messages on the following topics any more
      */
     fun unsubscribe(vararg topics: String)
+
+    /**
+     * Get the topics each peer is subscribed to
+     *
+     * @return a map of the peer's {@link PeerId} to the set of topics it is subscribed to
+     */
+    fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<String>>>
 }
 
 /**

--- a/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
+++ b/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
@@ -43,6 +43,5 @@ class NoiseXXCodec(val aliceCipher: CipherState, val bobCipher: CipherState) : M
                 logger.error("Unexpected error in Noise channel", cause)
             }
         }
-        logger.error(cause)
     }
 }

--- a/src/main/kotlin/io/libp2p/transport/implementation/P2PChannelOverNetty.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/P2PChannelOverNetty.kt
@@ -17,6 +17,8 @@ abstract class P2PChannelOverNetty(
     val nettyChannel: Channel,
     override val isInitiator: Boolean
 ) : P2PChannel {
+    private val closeCompletableFuture by lazy { nettyChannel.closeFuture().toVoidCompletableFuture() }
+
     override fun pushHandler(handler: ChannelHandler) {
         nettyChannel.pipeline().addLast(handler)
     }
@@ -30,7 +32,7 @@ abstract class P2PChannelOverNetty(
 
     override fun close() = nettyChannel.close().toVoidCompletableFuture()
 
-    override fun closeFuture() = nettyChannel.closeFuture().toVoidCompletableFuture()
+    override fun closeFuture() = closeCompletableFuture
     override fun toString(): String {
         return "P2PChannelOverNetty(nettyChannel=$nettyChannel, isInitiator=$isInitiator)"
     }

--- a/src/main/kotlin/io/libp2p/transport/implementation/P2PChannelOverNetty.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/P2PChannelOverNetty.kt
@@ -31,4 +31,7 @@ abstract class P2PChannelOverNetty(
     override fun close() = nettyChannel.close().toVoidCompletableFuture()
 
     override fun closeFuture() = nettyChannel.closeFuture().toVoidCompletableFuture()
+    override fun toString(): String {
+        return "P2PChannelOverNetty(nettyChannel=$nettyChannel, isInitiator=$isInitiator)"
+    }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-class MockRouter(
+open class MockRouter(
     override val protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1
 ) : AbstractRouter() {
 

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -19,6 +19,11 @@ import io.libp2p.pubsub.DeterministicFuzz
 import io.libp2p.pubsub.MessageId
 import io.libp2p.pubsub.MockRouter
 import io.libp2p.pubsub.SemiduplexConnection
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelOutboundHandlerAdapter
+import io.netty.channel.ChannelPromise
 import io.netty.handler.logging.LogLevel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -111,6 +116,46 @@ class GossipV1_1Tests {
         val messageBodies = apiMessages.map { it.data.toString(StandardCharsets.UTF_8) }
         assertTrue("Hello-1" in messageBodies)
         assertTrue("Hello-3" in messageBodies)
+    }
+
+    @Test
+    fun testPenaltyForMalformedMessage() {
+        class MalformedMockRouter : MockRouter() {
+            var malform = false
+            override fun initChannel(streamHandler: StreamHandler) {
+                streamHandler.stream.pushHandler(object : ChannelOutboundHandlerAdapter() {
+                    override fun write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise) {
+                        msg as ByteBuf
+                        if (malform) {
+                            val malformedPayload = Unpooled.wrappedBuffer(ByteArray(msg.readableBytes() - 5))
+                            ctx.write(Unpooled.wrappedBuffer(msg.slice(0, 5), malformedPayload), promise)
+                        } else {
+                            ctx.write(msg, promise)
+                        }
+                    }
+                })
+                super.initChannel(streamHandler)
+            }
+        }
+        val mockRouter = MalformedMockRouter()
+        val test = TwoRoutersTest(mockRouter = { mockRouter })
+
+        val api = createPubsubApi(test.gossipRouter)
+        val apiMessages = mutableListOf<MessageApi>()
+        api.subscribe(Subscriber { apiMessages += it }, io.libp2p.core.pubsub.Topic("topic1"))
+
+        val msg1 = Rpc.RPC.newBuilder()
+            .addPublish(newMessage("topic1", 0L, "Hello-1".toByteArray()))
+            .build()
+        mockRouter.malform = true
+
+        val peerScores = test.gossipRouter.score.peerScores.values.first()
+        // no behavior penalty before flooding
+        assertEquals(0.0, peerScores.behaviorPenalty)
+
+        test.mockRouter.sendToSingle(msg1)
+
+        assertTrue(peerScores.behaviorPenalty > 0)
     }
 
     @Test


### PR DESCRIPTION
New pubsub API feature:
- https://github.com/libp2p/jvm-libp2p/pull/118: Add method to API to retrieve complete list of subscribed topics by peer

The following issues were fixed: 
- #116: Fix pubsub malformed msg handling
- #117: Catch and report internal pubsub exceptions.
- #120: Fix gossip unsubscribe
- 7030249a: Remove listener from parent channel (Connection) on closing child channel (Stream) to avoid leaking Stream instances. Fixes https://github.com/PegaSysEng/teku/issues/2286
- 98a72bdf: Remove obsolete logging. Fix https://github.com/PegaSysEng/teku/issues/2268
- #124 'Duplicate stream for peer' exceptions
- https://github.com/libp2p/jvm-libp2p/pull/121/commits/d1b96c132665e33e879d7fc263787ef0d06310f7 CompletableFuture instance leaking