### PR TITLE
Throw exception when multistream messages do not end with line ending

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/netty/StringSuffixCodec.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/StringSuffixCodec.kt
@@ -1,18 +1,20 @@
 package io.libp2p.etc.util.netty
 
 import io.netty.channel.ChannelHandlerContext
+import io.netty.handler.codec.DecoderException
 import io.netty.handler.codec.MessageToMessageCodec
 
 /**
  * Adds/removes trailing character from messages
  */
-class StringSuffixCodec(val trainlingChar: Char) : MessageToMessageCodec<String, String>() {
+class StringSuffixCodec(val trailingChar: Char) : MessageToMessageCodec<String, String>() {
 
     override fun encode(ctx: ChannelHandlerContext?, msg: String, out: MutableList<Any>) {
-        out += (msg + trainlingChar)
+        out += (msg + trailingChar)
     }
 
     override fun decode(ctx: ChannelHandlerContext?, msg: String, out: MutableList<Any>) {
-        out += msg.trimEnd(trainlingChar)
+        if (!msg.endsWith(trailingChar)) throw DecoderException("Missing message end character")
+        out += msg.substring(0, msg.length - 1);
     }
 }

--- a/src/main/kotlin/io/libp2p/etc/util/netty/StringSuffixCodec.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/StringSuffixCodec.kt
@@ -15,6 +15,6 @@ class StringSuffixCodec(val trailingChar: Char) : MessageToMessageCodec<String, 
 
     override fun decode(ctx: ChannelHandlerContext?, msg: String, out: MutableList<Any>) {
         if (!msg.endsWith(trailingChar)) throw DecoderException("Missing message end character")
-        out += msg.substring(0, msg.length - 1);
+        out += msg.substring(0, msg.length - 1)
     }
 }

--- a/src/test/kotlin/io/libp2p/etc/util/netty/StringSuffixCodecTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/util/netty/StringSuffixCodecTest.kt
@@ -1,0 +1,37 @@
+package io.libp2p.etc.util.netty
+
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.DecoderException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class StringSuffixCodecTest {
+    val channel = EmbeddedChannel(StringSuffixCodec('\n'))
+
+    @Test
+    fun encodeAppendTrailingChar() {
+        channel.writeOutbound("theMessage")
+        val result = channel.readOutbound<String>()
+        assertEquals(result, "theMessage\n");
+    }
+
+    @Test
+    fun decodeStripsTrailingChar() {
+        channel.writeInbound("theMessage\n")
+        val result = channel.readInbound<String>()
+        assertEquals(result, "theMessage");
+    }
+
+    @Test
+    fun decodeOnlyStripsSingleTrailingChar() {
+        channel.writeInbound("theMessage\n\n")
+        val result = channel.readInbound<String>()
+        assertEquals(result, "theMessage\n");
+    }
+
+    @Test
+    fun decodeThrowsWhenTrailingCharMissing() {
+        assertThrows<DecoderException> { channel.writeInbound("theMessage") }
+    }
+}

--- a/src/test/kotlin/io/libp2p/etc/util/netty/StringSuffixCodecTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/util/netty/StringSuffixCodecTest.kt
@@ -13,21 +13,21 @@ class StringSuffixCodecTest {
     fun encodeAppendTrailingChar() {
         channel.writeOutbound("theMessage")
         val result = channel.readOutbound<String>()
-        assertEquals(result, "theMessage\n");
+        assertEquals(result, "theMessage\n")
     }
 
     @Test
     fun decodeStripsTrailingChar() {
         channel.writeInbound("theMessage\n")
         val result = channel.readInbound<String>()
-        assertEquals(result, "theMessage");
+        assertEquals(result, "theMessage")
     }
 
     @Test
     fun decodeOnlyStripsSingleTrailingChar() {
         channel.writeInbound("theMessage\n\n")
         val result = channel.readInbound<String>()
-        assertEquals(result, "theMessage\n");
+        assertEquals(result, "theMessage\n")
     }
 
     @Test


### PR DESCRIPTION
Multistream messages must end with `\n` so treat messages that don't as invalid.
Also only strip a single `\n` character from the end of the message.