### PR TITLE
Limit size of outbound write buffer

### DIFF
--- a/src/main/kotlin/io/libp2p/transport/implementation/ReadLimiter.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/ReadLimiter.kt
@@ -1,0 +1,13 @@
+package io.libp2p.transport.implementation
+
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+
+class ReadLimiter : ChannelInboundHandlerAdapter() {
+    override fun channelWritabilityChanged(ctx: ChannelHandlerContext?) {
+        if (ctx != null) {
+            ctx.channel().config().isAutoRead = ctx.channel().isWritable
+        }
+        super.channelWritabilityChanged(ctx)
+    }
+}


### PR DESCRIPTION
Avoids excessive memory usage when a peer requests data faster than it can read it.  There is probably a need to make the values used configurable and possibly vary them based on the stream state (ie multi stream negotiation should have little to no write buffer beyond what the OS provides, but things like Eth2 request for blocks might need more).  Not entirely sure how that should fit into the API for jvm-libp2p though.

Changes made:

 * Disable autoread when the channel become unwritable. This ensures we stop processing incoming requests when responses can't be read anyway.
 * Adds a WriteTimeoutHandler to fail writes if the buffer remains full for 30 seconds. Auto-close then causes these connections to be closed.
 * Limit size of write buffer to 1k instead of 64k. Ensures these limits apply quickly.

Prior to these changes a server handling a constant stream of `ls` multistream requests where the responses are not read, would use 5-6Gb of resident memory and all available CPU.  Afterwards resident memory only grows by a few Mb, the CPU usage is negligible and the attacking connection is disconnected.