### PR TITLE
Retrieve the value from seenMessages once to avoid NullPointerException

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -38,7 +38,8 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
     override var curTimeMillis: () -> Long by lazyVarInit { { System.currentTimeMillis() } }
     override var random by lazyVarInit { Random() }
     override var name: String = "router"
-    var messageIdGenerator: (Rpc.Message) -> MessageId = { it.from.toByteArray().toHex() + it.seqno.toByteArray().toHex() }
+    var messageIdGenerator: (Rpc.Message) -> MessageId =
+        { it.from.toByteArray().toHex() + it.seqno.toByteArray().toHex() }
 
     private val peerTopics = MultiSet<PeerHandler, String>()
     private var msgHandler: (Rpc.Message) -> CompletableFuture<ValidationResult> = { RESULT_VALID }

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -183,10 +183,10 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
         val msgUnseen = msgSubscribed
             .filter { subscribedMessage ->
                 val messageId = getMessageId(subscribedMessage)
-                val seenMessage = seenMessages[messageId]
-                if (seenMessage != null) {
+                val validationResult = seenMessages[messageId]
+                if (validationResult != null) {
                     // Message has been seen
-                    notifySeenMessage(peer, subscribedMessage, seenMessage)
+                    notifySeenMessage(peer, subscribedMessage, validationResult)
                     false
                 } else {
                     // Message is unseen


### PR DESCRIPTION
In `AbstractRouter` seenMessages is an LRU map so it automatically removes items when new ones are added to stay below some maximum size. So we could wind up with a message in msgSubscribed which is present in seenMessages when we first create msgUnseen but is then evicted when we we add the unseen messages on the second line. Then when we get to the last line seenMessages[getMessageId(it)] returns null because the message has now been dropped from seenMessages.

To avoid this, retrieve the value from `seenMessages` once and hold on to it while processing.  This avoids the risk that the value is dropped while recording the newly seen messages.

A less invasive change would be to move the line:
```
msgUnseen.forEach { seenMessages[getMessageId(it)] = Optional.empty() }
```
down below the line that calls `notifySeenMessage` which is the second place we look up the value from `seenMessages`.  But that feels like a very subtle dependency on ordering.

fixes https://github.com/PegaSysEng/teku/issues/2452