### PR TITLE
Reduce log level from INFO to DEBUG on inbound invalid gossip message

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -230,7 +230,7 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
             it.second.whenCompleteAsync(BiConsumer { res, err ->
                 when {
                     err != null -> logger.warn("Exception while handling message from peer $peer: ${it.first}", err)
-                    res == ValidationResult.Invalid -> logger.info("Invalid pubsub message from peer $peer: ${it.first}")
+                    res == ValidationResult.Invalid -> logger.debug("Invalid pubsub message from peer $peer: ${it.first}")
                     res == ValidationResult.Ignore -> logger.debug("Ingnoring pubsub message from peer $peer: ${it.first}")
                     else -> {
                         newValidatedMessages(singletonList(it.first), peer)

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -193,7 +193,7 @@ abstract class AbstractRouter : P2PServiceSemiDuplex(), PubsubRouter, PubsubRout
                 validator.validate(it)
                 true
             } catch (e: Exception) {
-                logger.info("Invalid pubsub message from peer $peer: $it", e)
+                logger.debug("Invalid pubsub message from peer $peer: $it", e)
                 seenMessages[getMessageId(it)] = Optional.of(ValidationResult.Invalid)
                 notifyUnseenInvalidMessage(peer, it)
                 false


### PR DESCRIPTION
Reduce log level from INFO to DEBUG on inbound invalid gossip message

Should fix: https://github.com/PegaSysEng/teku/issues/2439