### PR TITLE
More flexible pubsub message fields handling

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -71,7 +71,7 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
             it.receiver.apply(rpc2Msg(msg))
         }
         return validationFuts.thenApplyAll {
-            if (it.isEmpty())ValidationResult.Ignore
+            if (it.isEmpty()) ValidationResult.Ignore
             else it.reduce(validationResultReduce)
         }
     }
@@ -80,7 +80,9 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
         return MessageImpl(
             msg.data.toByteArray().toByteBuf(),
             msg.from.toByteArray(),
-            msg.seqno.toByteArray().copyOfRange(0, 8).toLongBigEndian(),
+            if (msg.hasSeqno())
+                msg.seqno.toByteArray().copyOfRange(0, 8).toLongBigEndian()
+            else 0,
             msg.topicIDsList.map { Topic(it) }
         )
     }

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -80,7 +80,7 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
         return MessageImpl(
             msg.data.toByteArray().toByteBuf(),
             msg.from.toByteArray(),
-            if (msg.hasSeqno())
+            if (msg.hasSeqno() && msg.seqno.size() >= 8)
                 msg.seqno.toByteArray().copyOfRange(0, 8).toLongBigEndian()
             else 0,
             msg.topicIDsList.map { Topic(it) }

--- a/src/test/kotlin/io/libp2p/pubsub/PubsubApiTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/PubsubApiTest.kt
@@ -1,19 +1,18 @@
 package io.libp2p.pubsub
 
-import io.libp2p.core.crypto.PrivKey
 import io.libp2p.core.pubsub.MessageApi
-import io.libp2p.core.pubsub.PubsubPublisherApi
 import io.libp2p.core.pubsub.Subscriber
 import io.libp2p.core.pubsub.Topic
+import io.libp2p.core.pubsub.createPubsubApi
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
-import io.libp2p.etc.types.toBytesBigEndian
-import io.libp2p.etc.types.toProtobuf
+import io.libp2p.etc.types.toLongBigEndian
 import io.libp2p.pubsub.flood.FloodRouter
-import io.netty.buffer.ByteBuf
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
-import pubsub.pb.Rpc
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.LinkedBlockingQueue
@@ -23,28 +22,11 @@ class PubsubApiTest {
 
     @Test
     fun testNoFromMessageField() {
-        class CustomApi(router: PubsubRouter) : PubsubApiImpl(router) {
-            inner class CustomPublisher(privKey: PrivKey, seqId: Long) : PublisherImpl(privKey, seqId) {
-                override fun createMessageToSign(data: ByteBuf, vararg topics: Topic): Rpc.Message {
-                    // not including 'from' field
-                    return Rpc.Message.newBuilder()
-                        .addAllTopicIDs(topics.map { it.topic })
-                        .setData(data.toByteArray().toProtobuf())
-                        .setSeqno(seqCounter.incrementAndGet().toBytesBigEndian().toProtobuf())
-                        .build()
-                }
-            }
-
-            override fun createPublisher(privKey: PrivKey, seqId: Long): PubsubPublisherApi {
-                return CustomPublisher(privKey, seqId)
-            }
-        }
-
         val fuzz = DeterministicFuzz()
         val router1 = fuzz.createTestRouter(FloodRouter())
-        val api1 = CustomApi(router1.router)
+        val api1 = createPubsubApi(router1.router)
         val router2 = fuzz.createTestRouter(FloodRouter())
-        val api2 = CustomApi(router2.router)
+        val api2 = createPubsubApi(router2.router)
 
         router1.connectSemiDuplex(router2)
 
@@ -55,7 +37,8 @@ class PubsubApiTest {
         fuzz.timeController.addTime(Duration.ofSeconds(10))
 
         val publisher1 = api1.createPublisher(router1.keyPair.first, 777)
-        val publishFut = publisher1.publish("Message".toByteArray().toByteBuf(), Topic("myTopic"))
+        val publishFut = publisher1
+            .publishExt("Message".toByteArray().toByteBuf(), byteArrayOf(), null, Topic("myTopic"))
 
         fuzz.timeController.addTime(Duration.ofSeconds(1))
 
@@ -63,10 +46,66 @@ class PubsubApiTest {
         val recMsg = receivedMessages2.poll(1, TimeUnit.SECONDS)
         println(recMsg)
         Assertions.assertNotNull(recMsg)
-        Assertions.assertEquals(1, recMsg.topics.size)
-        Assertions.assertEquals(Topic("myTopic"), recMsg.topics[0])
-        Assertions.assertEquals(778, recMsg.seqId)
-        Assertions.assertEquals("Message", recMsg.data.toByteArray().toString(StandardCharsets.UTF_8))
-        Assertions.assertEquals(0, recMsg.from.size)
+        assertEquals(1, recMsg.topics.size)
+        assertEquals(Topic("myTopic"), recMsg.topics[0])
+        assertEquals(778, recMsg.seqId)
+        assertEquals("Message", recMsg.data.toByteArray().toString(StandardCharsets.UTF_8))
+        assertEquals(0, recMsg.from.size)
+    }
+
+    @Test
+    fun testNoSenderPrivateKey() {
+        val fuzz = DeterministicFuzz()
+        val router1 = fuzz.createTestRouter(FloodRouter())
+        val api1 = createPubsubApi(router1.router)
+        val router2 = fuzz.createTestRouter(FloodRouter())
+
+        router1.connectSemiDuplex(router2)
+
+        api1.subscribe(Subscriber { println(it) }, Topic("myTopic"))
+        router2.router.subscribe("myTopic")
+
+        fuzz.timeController.addTime(Duration.ofSeconds(10))
+
+        val publisher1 = api1.createPublisher(null, 777)
+        val publishFut = publisher1.publish("Message".toByteArray().toByteBuf(), Topic("myTopic"))
+
+        fuzz.timeController.addTime(Duration.ofSeconds(1))
+
+        Assertions.assertTrue(publishFut.isDone)
+        val rawMsg = router2.inboundMessages.poll(1, TimeUnit.SECONDS)
+        println(rawMsg)
+        assertFalse(rawMsg.hasSignature())
+        assertFalse(rawMsg.hasFrom())
+        assertEquals("Message", rawMsg.data.toByteArray().toString(StandardCharsets.UTF_8))
+    }
+
+    @Test
+    fun testPublishExt() {
+        val fuzz = DeterministicFuzz()
+        val router1 = fuzz.createTestRouter(FloodRouter())
+        val api1 = createPubsubApi(router1.router)
+        val router2 = fuzz.createTestRouter(FloodRouter())
+
+        router1.connectSemiDuplex(router2)
+
+        api1.subscribe(Subscriber { println(it) }, Topic("myTopic"))
+        router2.router.subscribe("myTopic")
+
+        fuzz.timeController.addTime(Duration.ofSeconds(10))
+
+        val publisher1 = api1.createPublisher(null, 777)
+        val publishFut =
+            publisher1.publishExt("Message".toByteArray().toByteBuf(), byteArrayOf(1, 2, 3), 333, Topic("myTopic"))
+
+        fuzz.timeController.addTime(Duration.ofSeconds(1))
+
+        Assertions.assertTrue(publishFut.isDone)
+        val rawMsg = router2.inboundMessages.poll(1, TimeUnit.SECONDS)
+        println(rawMsg)
+        assertFalse(rawMsg.hasSignature())
+        assertEquals(333, rawMsg.seqno.toByteArray().copyOfRange(0, 8).toLongBigEndian())
+        assertArrayEquals(byteArrayOf(1, 2, 3), rawMsg.from.toByteArray())
+        assertEquals("Message", rawMsg.data.toByteArray().toString(StandardCharsets.UTF_8))
     }
 }


### PR DESCRIPTION
Primarily address this issue https://github.com/ethereum/eth2.0-specs/issues/1981

- Make `seqId` field optional
- Allow omitting sender private key (and thus signature) 
- Allow custom `sender` and `seqId` fields per message 

Fix https://github.com/PegaSysEng/teku/issues/2476