### PR TITLE
Check if the stream was closed on init

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
@@ -52,7 +52,7 @@ abstract class P2PServiceSemiDuplex : P2PService() {
     }
 
     override fun streamActive(stream: StreamHandler) {
-        if (stream == (stream.getPeerHandler() as SDPeerHandler).getOutboundHandler()) {
+        if (!stream.aborted && stream == (stream.getPeerHandler() as SDPeerHandler).getOutboundHandler()) {
             // invoke streamActive only when outbound handler is activated
             super.streamActive(stream)
         }


### PR DESCRIPTION
If the stream was aborted during init, a peerHandler may never be assigned.  Need to handle that case in `P2PServiceSemiDuplex.streamActive`.  The superclass performs the same check but it must happen before calling `stream.getPeerHandler` to avoid exceptions.

fixes https://github.com/PegaSysEng/teku/issues/2359