### PR TITLE
Fix the panic when SemiDuplex has no outbound stream yet

### DIFF
--- a/src/main/kotlin/io/libp2p/core/Libp2pException.kt
+++ b/src/main/kotlin/io/libp2p/core/Libp2pException.kt
@@ -65,3 +65,9 @@ open class TransportNotSupportedException(message: String) : Libp2pException(mes
  * Indicates the message received from a remote party violates protocol
  */
 open class ProtocolViolationException(message: String) : Libp2pException(message)
+
+/**
+ * When trying to write a message to a peer within [io.libp2p.etc.util.P2PServiceSemiDuplex]
+ * but there is no yet outbound stream created.
+ */
+open class SemiDuplexNoOutboundStreamException(message: String) : Libp2pException(message)

--- a/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
@@ -62,6 +62,7 @@ fun <C> anyComplete(vararg all: CompletableFuture<C>): CompletableFuture<C> {
     return if (all.isEmpty()) completedExceptionally(NothingToCompleteException())
     else object : CompletableFuture<C>() {
         init {
+            val counter = AtomicInteger(all.size)
             all.forEach { it.whenComplete { v, t ->
                 if (t == null) {
                     complete(v)
@@ -70,7 +71,6 @@ fun <C> anyComplete(vararg all: CompletableFuture<C>): CompletableFuture<C> {
                 }
             } }
         }
-        val counter = AtomicInteger(all.size)
     }
 }
 

--- a/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
@@ -1,7 +1,8 @@
 package io.libp2p.etc.util
 
 import io.libp2p.core.BadPeerException
-import io.libp2p.core.InternalErrorException
+import io.libp2p.core.SemiDuplexNoOutboundStreamException
+import io.libp2p.etc.types.completedExceptionally
 import io.libp2p.etc.types.toVoidCompletableFuture
 import java.util.concurrent.CompletableFuture
 
@@ -17,7 +18,8 @@ abstract class P2PServiceSemiDuplex : P2PService() {
         var otherStreamHandler: StreamHandler? = null
 
         override fun writeAndFlush(msg: Any): CompletableFuture<Unit> =
-            getOutboundHandler()?.ctx?.writeAndFlush(msg)?.toVoidCompletableFuture() ?: throw InternalErrorException("No active outbound stream to write data $msg")
+            getOutboundHandler()?.ctx?.writeAndFlush(msg)?.toVoidCompletableFuture() ?: completedExceptionally(
+                SemiDuplexNoOutboundStreamException("No active outbound stream to write data $msg"))
 
         override fun isActive() = getOutboundHandler()?.ctx != null
 

--- a/src/main/kotlin/io/libp2p/pubsub/Errors.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/Errors.kt
@@ -17,4 +17,3 @@ class MessageAlreadySeenException(message: String) : PubsubException(message)
  */
 class InvalidMessageException(message: String) : PubsubException(message)
 
-class InternalError

--- a/src/main/kotlin/io/libp2p/pubsub/Errors.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/Errors.kt
@@ -16,4 +16,3 @@ class MessageAlreadySeenException(message: String) : PubsubException(message)
  * Throw when message validation failed
  */
 class InvalidMessageException(message: String) : PubsubException(message)
-

--- a/src/test/kotlin/io/libp2p/etc/types/AsyncExtTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/AsyncExtTest.kt
@@ -1,5 +1,6 @@
 package io.libp2p.etc.types
 
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 
@@ -17,5 +18,12 @@ class AsyncExtTest {
         futs[2].complete(3)
         assert(allFut.isDone)
         assert(allFut.get() == 6)
+    }
+
+    @Test
+    fun testAnyCompleteWithCompletedExceptionally() {
+        val anyComplete = anyComplete<Int>(completedExceptionally(RuntimeException("test")))
+
+        Assertions.assertTrue(anyComplete.isCompletedExceptionally)
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -119,7 +119,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         router2.router.subscribe("topic1")
         router1.connect(router2, LogLevel.INFO, LogLevel.INFO)
 
-        TestLogAppender().install().use {testLogAppender ->
+        TestLogAppender().install().use { testLogAppender ->
             val msg1 = Rpc.RPC.newBuilder()
                 .setControl(
                     Rpc.ControlMessage.newBuilder().addIhave(
@@ -131,7 +131,6 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
             Assertions.assertFalse(testLogAppender.hasAnyWarns())
         }
-
     }
 
     @Test
@@ -150,7 +149,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         router1.connect(router2, LogLevel.INFO, LogLevel.INFO)
         router2.connectSemiDuplex(router3, LogLevel.INFO, LogLevel.INFO)
 
-        TestLogAppender().install().use {testLogAppender ->
+        TestLogAppender().install().use { testLogAppender ->
 
             val msg1 = Rpc.RPC.newBuilder()
                 .addSubscriptions(Rpc.RPC.SubOpts.newBuilder()
@@ -173,5 +172,4 @@ class GossipPubsubRouterTest : PubsubRouterTest({
             Assertions.assertFalse(testLogAppender.hasAnyWarns())
         }
     }
-
 }

--- a/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
@@ -1,0 +1,33 @@
+package io.libp2p.tools
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.Logger
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import java.util.ArrayList
+
+class TestLogAppender : AbstractAppender("test", null, null), AutoCloseable {
+    val logs: MutableList<LogEvent> = ArrayList()
+
+    fun install(): TestLogAppender {
+        (LogManager.getRootLogger() as Logger).addAppender(this)
+        return this
+    }
+
+    fun uninstall() {
+        (LogManager.getRootLogger() as Logger).removeAppender(this)
+    }
+
+    override fun close() {
+        uninstall()
+    }
+
+    fun hasAny(level: Level) = logs.any { it.level == level }
+    fun hasAnyWarns() = hasAny(Level.ERROR) || hasAny(Level.WARN)
+
+
+    override fun append(event: LogEvent) {
+        logs += event.toImmutable()
+    }
+}

--- a/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
@@ -26,7 +26,6 @@ class TestLogAppender : AbstractAppender("test", null, null), AutoCloseable {
     fun hasAny(level: Level) = logs.any { it.level == level }
     fun hasAnyWarns() = hasAny(Level.ERROR) || hasAny(Level.WARN)
 
-
     override fun append(event: LogEvent) {
         logs += event.toImmutable()
     }


### PR DESCRIPTION
- Fix CompletableFuture anyComplete() implementation
- Tolerate the case when trying writing to a peer without established outbound stream within P2PServiceSemiDuplex

Resolves https://github.com/PegaSysEng/teku/issues/2620