### PR TITLE
Do not set omitted fields to default values when regossiping

### DIFF
--- a/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
+++ b/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
@@ -155,7 +155,7 @@ interface PubsubApi : PubsubSubscriberApi {
      *     are omitted
      * @param seqIdGenerator supplies `seqId` for published messages
      */
-    fun createPublisher(privKey: PrivKey?, seqIdGenerator: () -> Long): PubsubPublisherApi
+    fun createPublisher(privKey: PrivKey?, seqIdGenerator: () -> Long?): PubsubPublisherApi
 }
 
 /**
@@ -169,11 +169,11 @@ interface MessageApi {
     /**
      * Sender identity. Usually it a [PeerId] derived from the sender's public key
      */
-    val from: ByteArray
+    val from: ByteArray?
     /**
      * Sequence id for the sender. A pair [from]` + `[seqId] should be globally unique
      */
-    val seqId: Long
+    val seqId: Long?
     /**
      * A set of message topics
      */


### PR DESCRIPTION
`from`, `seqNo` and `signature` are all optional fields.  On parsing they are allowed to be optional, but for `from` and `seqNo` previously the parsed message would set them to default values and when the messages were regossiped, the default values became explicitly set.  This caused the regossiped messages to be rejected by Lighthouse's stricter gossip 1.1 validation.

This does result in a public API change as from and seqId are now optional.  Additionally to enable testing, the seqIdGenerator can now return a null sequence number allowing the generation of messages with no sequence number.