### PR TITLE
Fix Identify protocol stream close

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Builds are published to JCenter. Maven Central mirrors JCenter, but updates can 
   <dependency>
     <groupId>io.libp2p</groupId>
     <artifactId>jvm-libp2p-minimal</artifactId>
-    <version>0.5.5-RELEASE</version>
+    <version>0.5.6-RELEASE</version>
     <type>pom</type>
   </dependency>
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 // ./gradlew bintrayUpload -PbintrayUser=<user> -PbintrayApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.5.5-RELEASE"
+version = "0.6.0-RELEASE"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {

--- a/src/main/kotlin/io/libp2p/core/Stream.kt
+++ b/src/main/kotlin/io/libp2p/core/Stream.kt
@@ -26,4 +26,26 @@ interface Stream : P2PChannel {
     }
 
     fun writeAndFlush(msg: Any)
+
+    /**
+     * Resets the [Stream]. That means the stream is to be abruptly terminated.
+     * This method is basically used when any error occurs while communicating
+     * @see close
+     * @see closeWrite
+     */
+    fun reset() = close()
+
+    /**
+     * Equivalent to [reset].
+     * To close the [Stream] just from the local side use [closeWrite]
+     */
+    override fun close(): CompletableFuture<Unit>
+
+    /**
+     * Closes the local side of the [Stream].
+     * [closeWrite] means that local party completed writing to the [Stream]
+     * @see io.libp2p.etc.util.netty.mux.RemoteWriteClosed to be notified on the remote
+     * stream write side closing
+     */
+    fun closeWrite(): CompletableFuture<Unit>
 }

--- a/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
@@ -74,6 +74,9 @@ class MuxChannel<TData>(
     }
 }
 
+/**
+ * This Netty user event is fired to the [Stream] channel when remote peer closes its write side of the Stream
+ */
 class RemoteWriteClosed
 
 data class MultiplexSocketAddress(val parentAddress: SocketAddress, val streamId: MuxId) : SocketAddress() {

--- a/src/main/kotlin/io/libp2p/protocol/Identify.kt
+++ b/src/main/kotlin/io/libp2p/protocol/Identify.kt
@@ -40,6 +40,7 @@ class IdentifyProtocol(var idMessage: IdentifyOuterClass.Identify? = null) :
 
         override fun onMessage(stream: Stream, msg: IdentifyOuterClass.Identify) {
             resp.complete(msg)
+            stream.closeWrite()
         }
 
         override fun onClosed(stream: Stream) {

--- a/src/main/kotlin/io/libp2p/protocol/Identify.kt
+++ b/src/main/kotlin/io/libp2p/protocol/Identify.kt
@@ -64,7 +64,7 @@ class IdentifyProtocol(var idMessage: IdentifyOuterClass.Identify? = null) :
                 .build()
 
             stream.writeAndFlush(msgWithAddr)
-            stream.close()
+            stream.closeWrite()
         }
 
         override fun id(): CompletableFuture<IdentifyOuterClass.Identify> {

--- a/src/main/kotlin/io/libp2p/transport/implementation/StreamOverNetty.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/StreamOverNetty.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.Connection
 import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.etc.PROTOCOL
+import io.libp2p.etc.types.toVoidCompletableFuture
 import io.netty.channel.Channel
 import java.util.concurrent.CompletableFuture
 
@@ -29,5 +30,9 @@ class StreamOverNetty(
 
     override fun writeAndFlush(msg: Any) {
         nettyChannel.writeAndFlush(msg)
+    }
+
+    override fun closeWrite(): CompletableFuture<Unit> {
+        return nettyChannel.disconnect().toVoidCompletableFuture()
     }
 }

--- a/src/test/kotlin/io/libp2p/tools/TestStream.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestStream.kt
@@ -8,6 +8,7 @@ import io.libp2p.etc.PROTOCOL
 import io.libp2p.etc.STREAM
 import io.libp2p.etc.getP2PChannel
 import io.libp2p.etc.types.forward
+import io.libp2p.etc.types.toVoidCompletableFuture
 import io.libp2p.etc.util.netty.nettyInitializer
 import io.libp2p.transport.implementation.P2PChannelOverNetty
 import io.netty.channel.Channel
@@ -50,4 +51,7 @@ private class TestStream(ch: Channel, initiator: Boolean) : P2PChannelOverNetty(
     override fun writeAndFlush(msg: Any) {
         nettyChannel.writeAndFlush(msg)
     }
+
+    override fun closeWrite(): CompletableFuture<Unit> =
+        nettyChannel.disconnect().toVoidCompletableFuture()
 }


### PR DESCRIPTION
`Identify` protocol should `CLOSE` the stream after writing the data instead of `RESET`

Fixes https://github.com/PegaSysEng/teku/issues/2728