### PR TITLE
Upgrade gradle to 6.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
   - openjdk8
 
 script:
-  - ./gradlew build --scan -s
+  - ./gradlew build -s
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,7 @@ plugins {
     idea
     kotlin("jvm") version "1.3.31"
     id("org.jmailen.kotlinter") version "1.26.0"
-    id("com.google.protobuf") version "0.8.7"
-    `build-scan`
+    id("com.google.protobuf") version "0.8.13"
 
     `maven`
     `maven-publish`
@@ -173,11 +172,6 @@ task("interopTest", Test::class) {
 
 kotlinter {
     allowWildcardImports = false
-}
-
-buildScan {
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
 }
 
 val sourcesJar by tasks.registering(Jar::class) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Adds support for JDK 14
Upgrade google protobuf plugin for compatibility with new gradle
Remove buildscan plugin as it is now only available in gradle enterprise.