### PR TITLE
Fix misc QuantStamp issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Builds are published to JCenter. Maven Central mirrors JCenter, but updates can 
   <dependency>
     <groupId>io.libp2p</groupId>
     <artifactId>jvm-libp2p-minimal</artifactId>
-    <version>0.5.5-RELEASE</version>
+    <version>0.5.6-RELEASE</version>
     <type>pom</type>
   </dependency>
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.google.protobuf.gradle.proto
 import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.protoc
 import com.jfrog.bintray.gradle.BintrayExtension
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
@@ -93,7 +94,11 @@ tasks.test {
     }
 
     testLogging {
-        events("PASSED", "FAILED", "SKIPPED")
+        events("FAILED")
+        exceptionFormat = TestExceptionFormat.FULL
+        showCauses = true
+        showExceptions = true
+        showStackTraces = true
     }
 
     // disabling the parallel test runs for the time being due to port collisions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 // ./gradlew bintrayUpload -PbintrayUser=<user> -PbintrayApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.5.5-RELEASE"
+version = "0.6.0-RELEASE"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {

--- a/src/main/java/io/libp2p/discovery/mdns/ServiceInfo.java
+++ b/src/main/java/io/libp2p/discovery/mdns/ServiceInfo.java
@@ -223,13 +223,7 @@ public abstract class ServiceInfo implements Cloneable {
      * @see java.lang.Object#clone()
      */
     @Override
-    public ServiceInfo clone() {
-        try {
-            return (ServiceInfo) super.clone();
-        } catch (CloneNotSupportedException exception) {
-            // clone is supported
-            return null;
-        }
+    public ServiceInfo clone() throws CloneNotSupportedException {
+        return (ServiceInfo) super.clone();
     }
-
 }

--- a/src/main/java/io/libp2p/discovery/mdns/impl/DNSRecord.java
+++ b/src/main/java/io/libp2p/discovery/mdns/impl/DNSRecord.java
@@ -4,21 +4,20 @@
 
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.impl.DNSOutgoing.MessageOutputStream;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
+import io.libp2p.discovery.mdns.impl.util.ByteWrangler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
-import io.libp2p.discovery.mdns.impl.DNSOutgoing.MessageOutputStream;
-
-import io.libp2p.discovery.mdns.impl.util.ByteWrangler;
+import java.util.Objects;
 
 
 /**
@@ -44,6 +43,11 @@ public abstract class DNSRecord extends DNSEntry {
     @Override
     public boolean equals(Object other) {
         return (other instanceof DNSRecord) && super.equals(other) && sameValue((DNSRecord) other);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), _ttl, _created);
     }
 
     abstract boolean sameValue(DNSRecord other);

--- a/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
+++ b/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -400,6 +401,8 @@ public class JmDNSImpl extends JmDNS {
         for (Future<Void> shutdown : shutdowns) {
             try {
                 shutdown.get(10, TimeUnit.SECONDS);
+            } catch (CancellationException e) {
+                logger.trace("Task was already cancelled");
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
                 logger.debug("Exception when stopping JmDNS: ", e);
                 throw new RuntimeException(e);

--- a/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
+++ b/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
@@ -402,8 +402,11 @@ public class JmDNSImpl extends JmDNS {
             try {
                 shutdown.get(10, TimeUnit.SECONDS);
             } catch (CancellationException e) {
-                logger.trace("Task was already cancelled");
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                logger.trace("Task was already cancelled", e);
+            } catch (InterruptedException e) {
+                logger.trace("Stopping was interrupted", e);
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException | TimeoutException e) {
                 logger.debug("Exception when stopping JmDNS: ", e);
                 throw new RuntimeException(e);
             }

--- a/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
+++ b/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
@@ -4,6 +4,17 @@
 
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.AnswerListener;
+import io.libp2p.discovery.mdns.JmDNS;
+import io.libp2p.discovery.mdns.ServiceInfo;
+import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
+import io.libp2p.discovery.mdns.impl.tasks.Responder;
+import io.libp2p.discovery.mdns.impl.tasks.ServiceResolver;
+import io.libp2p.discovery.mdns.impl.util.NamedThreadFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.Inet6Address;
@@ -12,21 +23,18 @@ import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.SocketAddress;
 import java.net.SocketException;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.locks.ReentrantLock;
-
-import io.libp2p.discovery.mdns.AnswerListener;
-import io.libp2p.discovery.mdns.JmDNS;
-import io.libp2p.discovery.mdns.ServiceInfo;
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
-import io.libp2p.discovery.mdns.impl.tasks.Responder;
-import io.libp2p.discovery.mdns.impl.tasks.ServiceResolver;
-import io.libp2p.discovery.mdns.impl.util.NamedThreadFactory;
 
 /**
  * Derived from mDNS implementation in Java.
@@ -394,10 +402,6 @@ public class JmDNSImpl extends JmDNS {
 
             if (allDone)
                 break;
-
-            try {
-                TimeUnit.MILLISECONDS.sleep(100);
-            } catch(InterruptedException e) { }
         }
 
         logger.debug("JmDNS Stopping.");

--- a/src/main/java/io/libp2p/discovery/mdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/io/libp2p/discovery/mdns/impl/ServiceInfoImpl.java
@@ -4,18 +4,25 @@
 
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.ServiceInfo;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
+import io.libp2p.discovery.mdns.impl.util.ByteWrangler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.util.*;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
-import io.libp2p.discovery.mdns.impl.util.ByteWrangler;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
-import io.libp2p.discovery.mdns.ServiceInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * JmDNS service information.
@@ -381,6 +388,7 @@ public class ServiceInfoImpl extends ServiceInfo {
         ServiceInfoImpl serviceInfo = new ServiceInfoImpl(this.getQualifiedNameMap(), _port, _weight, _priority, _text);
         serviceInfo._ipv6Addresses.addAll(Arrays.asList(getInet6Addresses()));
         serviceInfo._ipv4Addresses.addAll(Arrays.asList(getInet4Addresses()));
+        serviceInfo._server = _server;
         return serviceInfo;
     }
 


### PR DESCRIPTION
This PR addresses minor QuantStamp libp2p-related issues: 
- https://github.com/quantstamp/teku/issues/27: Clone method does not copy entire state 
- https://github.com/quantstamp/teku/issues/30: Clone May Return `null`
- https://github.com/quantstamp/teku/issues/29: Ignored `InterruptedException`
- (parttially) https://github.com/quantstamp/teku/issues/15: Incorrect Custom Equality and Hash Functions 
