### PR TITLE
Get negotiated Gossip protocol version from either inbound or outbound stream

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -38,10 +38,15 @@ fun P2PService.PeerHandler.getIP(): String? =
     streamHandler.stream.connection.remoteAddress().getStringComponent(Protocol.IP4)
 
 fun P2PService.PeerHandler.isOutbound() = streamHandler.stream.connection.isInitiator
-fun P2PService.PeerHandler.getOutboundProtocol() = getOutboundHandler()?.stream?.getProtocol()?.getNow(null)
-    ?: throw InternalErrorException("Outbound gossip stream not initialized or protocol is missing")
 
-fun P2PService.PeerHandler.getOutboundGossipProtocol() = PubsubProtocol.fromProtocol(getOutboundProtocol())
+fun P2PService.PeerHandler.getPeerProtocol(): PubsubProtocol {
+    fun P2PService.StreamHandler.getProtocol(): String? = stream.getProtocol().getNow(null)
+    val proto =
+        getOutboundHandler()?.getProtocol()
+            ?: getInboundHandler()?.getProtocol()
+            ?: throw InternalErrorException("Couldn't get peer gossip protocol")
+    return PubsubProtocol.fromProtocol(proto)
+}
 
 /**
  * Router implementing this protocol: https://github.com/libp2p/specs/tree/master/pubsub/gossipsub
@@ -111,7 +116,11 @@ open class GossipRouter @JvmOverloads constructor(
         score.notifyUnseenMessage(peer, msg)
     }
 
-    override fun notifySeenMessage(peer: PeerHandler, msg: PubsubMessage, validationResult: Optional<ValidationResult>) {
+    override fun notifySeenMessage(
+        peer: PeerHandler,
+        msg: PubsubMessage,
+        validationResult: Optional<ValidationResult>
+    ) {
         score.notifySeenMessage(peer, msg, validationResult)
         if (validationResult.isPresent && validationResult.get() != ValidationResult.Invalid) {
             notifyAnyValidMessage(peer, msg)
@@ -449,7 +458,7 @@ open class GossipRouter @JvmOverloads constructor(
 
     private fun enqueuePrune(peer: PeerHandler, topic: Topic) {
         val pruneBuilder = Rpc.ControlPrune.newBuilder().setTopicID(topic)
-        if (peer.getOutboundGossipProtocol() == PubsubProtocol.Gossip_V_1_1 && this.protocol == PubsubProtocol.Gossip_V_1_1) {
+        if (peer.getPeerProtocol() == PubsubProtocol.Gossip_V_1_1 && this.protocol == PubsubProtocol.Gossip_V_1_1) {
             // add v1.1 specific fields
             pruneBuilder.backoff = params.pruneBackoff.seconds
             (getTopicPeers(topic) - peer)

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -208,16 +208,5 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
             Assertions.assertFalse(testLogAppender.hasAnyWarns())
         }
-
-        router2.connect(router1, LogLevel.INFO, LogLevel.INFO)
-
-        val msg1 = Rpc.RPC.newBuilder()
-            .setControl(
-                Rpc.ControlMessage.newBuilder().addIhave(
-                    Rpc.ControlIHave.newBuilder().addMessageIDs("messageId".toByteArray().toProtobuf())
-                )
-            ).build()
-
-        mockRouter.sendToSingle(msg1)
     }
 }


### PR DESCRIPTION
Addition to PR #136 : 
    when the outbound Gossip stream is not created yet and remote Gossip peer (just connected) sends GRAFT to which we want respond with PRUNE causes exception (see https://github.com/ConsenSys/teku/issues/2836). 
This is because the `GossipRouter.enqueuePrune` needs the negotiated Gossip version to respond properly (Gossip v1.1 should be backward compatible with v1.0) and the version is retrieved from outbound stream. As the outbound stream can be not created yet the version can be retrieved from the inbound stream with the same result. One of inbound or outbound stream should 100% exist 

Fixes Teku issue https://github.com/ConsenSys/teku/issues/2836 when new version integrated