### PR TITLE
Fix log ERROR when fail to decrypt inbound packet 

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/types/OtherExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/OtherExt.kt
@@ -1,5 +1,7 @@
 package io.libp2p.etc.types
 
+import kotlin.reflect.KClass
+
 fun Boolean.whenTrue(run: () -> Unit): Boolean {
     if (this) {
         run()
@@ -36,3 +38,6 @@ fun <T> defer(f: (Deferrable) -> T): T {
         deferrable.execute()
     }
 }
+
+fun <T : Throwable> Throwable.hasCauseOfType(clazz: KClass<T>): Boolean =
+    clazz.isInstance(this) || (cause != null && cause!!.hasCauseOfType(clazz))

--- a/src/main/kotlin/io/libp2p/etc/types/OtherExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/OtherExt.kt
@@ -1,5 +1,6 @@
 package io.libp2p.etc.types
 
+import com.google.common.base.Throwables
 import kotlin.reflect.KClass
 
 fun Boolean.whenTrue(run: () -> Unit): Boolean {
@@ -39,5 +40,7 @@ fun <T> defer(f: (Deferrable) -> T): T {
     }
 }
 
-fun <T : Throwable> Throwable.hasCauseOfType(clazz: KClass<T>): Boolean =
-    clazz.isInstance(this) || (cause != null && cause!!.hasCauseOfType(clazz))
+fun <T : Throwable> Throwable.hasCauseOfType(clazz: KClass<T>) =
+    Throwables.getCausalChain(this)
+        .filter(clazz::isInstance)
+        .any()

--- a/src/main/kotlin/io/libp2p/security/SecureChannelError.kt
+++ b/src/main/kotlin/io/libp2p/security/SecureChannelError.kt
@@ -3,6 +3,7 @@ package io.libp2p.security
 open class SecureChannelError : Exception {
     constructor() : super()
     constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(message: String) : super(message)
 }
 
 open class SecureHandshakeError : SecureChannelError()
@@ -10,4 +11,9 @@ open class SecureHandshakeError : SecureChannelError()
 class InvalidRemotePubKey : SecureHandshakeError()
 class InvalidInitialPacket : SecureHandshakeError()
 
-class CantDecryptInboundException(message: String, cause: Throwable) : SecureChannelError(message, cause)
+open class CantDecryptInboundException : SecureChannelError {
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(message: String) : super(message)
+}
+
+class InvalidMacException : CantDecryptInboundException("Invalid MAC")

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
@@ -71,12 +71,12 @@ class SecIoCodec(val local: SecioParams, val remote: SecioParams) : MessageToMes
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
         if (cause.hasCauseOfType(IOException::class)) {
             // Trace level because having clients unexpectedly disconnect is extremely common
-            log.trace("IOException in Noise channel", cause)
+            log.trace("IOException in SecIO channel", cause)
         } else if (cause.hasCauseOfType(SecureChannelError::class)) {
-            log.debug("Invalid Noise content", cause)
+            log.debug("Invalid SecIO content", cause)
             closeAbruptly(ctx)
         } else {
-            log.error("Unexpected error in Noise channel", cause)
+            log.error("Unexpected error in SecIO channel", cause)
         }
     } // exceptionCaught
 

--- a/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
+++ b/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
@@ -1,8 +1,10 @@
 package io.libp2p.security.secio
 
-import com.google.common.base.Throwables
+import io.libp2p.etc.types.hasCauseOfType
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
+import io.libp2p.security.CantDecryptInboundException
+import io.libp2p.security.InvalidMacException
 import io.libp2p.security.SecureChannelError
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -21,6 +23,7 @@ class SecIoCodec(val local: SecioParams, val remote: SecioParams) : MessageToMes
 
     private val localCipher = createCipher(local)
     private val remoteCipher = createCipher(remote)
+    private var abruptlyClosing = false
 
     companion object {
         fun createCipher(params: SecioParams): StreamCipher {
@@ -46,32 +49,41 @@ class SecIoCodec(val local: SecioParams, val remote: SecioParams) : MessageToMes
     } // encode
 
     override fun decode(ctx: ChannelHandlerContext, msg: ByteBuf, out: MutableList<Any>) {
-        val (cipherBytes, macBytes) = textAndMac(msg)
+        if (abruptlyClosing) {
+            // if abrupt close was initiated by our node we shouldn't try decoding anything else
+            return
+        }
+        try {
+            val (cipherBytes, macBytes) = textAndMac(msg)
 
-        val macArr = updateMac(remote, cipherBytes)
+            val macArr = updateMac(remote, cipherBytes)
 
-        if (!macBytes.contentEquals(macArr))
-            throw MacMismatch()
+            if (!macBytes.contentEquals(macArr))
+                throw InvalidMacException()
 
-        val clearText = processBytes(remoteCipher, cipherBytes)
-        out.add(clearText.toByteBuf())
+            val clearText = processBytes(remoteCipher, cipherBytes)
+            out.add(clearText.toByteBuf())
+        } catch (e: Exception) {
+            throw CantDecryptInboundException("Error decrypting inbound message", e)
+        }
     } // decode
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        when (Throwables.getRootCause(cause)) {
-            is IOException -> {
-                // Trace level because having clients unexpectedly disconnect is extremely common
-                log.trace("IOException in SecIO channel", cause)
-            }
-            is SecureChannelError -> {
-                log.debug("Invalid SecIO content", cause)
-                ctx.channel().close()
-            }
-            else -> {
-                log.error("Unexpected error in SecIO channel", cause)
-            }
+        if (cause.hasCauseOfType(IOException::class)) {
+            // Trace level because having clients unexpectedly disconnect is extremely common
+            log.trace("IOException in Noise channel", cause)
+        } else if (cause.hasCauseOfType(SecureChannelError::class)) {
+            log.debug("Invalid Noise content", cause)
+            closeAbruptly(ctx)
+        } else {
+            log.error("Unexpected error in Noise channel", cause)
         }
     } // exceptionCaught
+
+    private fun closeAbruptly(ctx: ChannelHandlerContext) {
+        abruptlyClosing = true
+        ctx.close()
+    }
 
     private fun textAndMac(msg: ByteBuf): Pair<ByteArray, ByteArray> {
         val macBytes = msg.toByteArray(from = msg.readableBytes() - remote.mac.macSize)

--- a/src/test/kotlin/io/libp2p/security/CipherSecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/CipherSecureChannelTest.kt
@@ -1,0 +1,44 @@
+package io.libp2p.security
+
+import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.generateKeyPair
+import io.libp2p.tools.TestChannel
+import io.libp2p.tools.TestLogAppender
+import io.netty.buffer.Unpooled
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+abstract class CipherSecureChannelTest(secureChannelCtor: SecureChannelCtor, announce: String) :
+    SecureChannelTest(secureChannelCtor, announce) {
+
+    @Test
+    fun `test that on malformed message from remote the connection closes and no log noise`() {
+        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey2, _) = generateKeyPair(KEY_TYPE.ECDSA)
+
+        val protocolSelect1 = makeSelector(privKey1)
+        val protocolSelect2 = makeSelector(privKey2)
+
+        val eCh1 = makeChannel("#1", true, protocolSelect1)
+        val eCh2 = makeChannel("#2", false, protocolSelect2)
+
+        logger.debug("Connecting channels...")
+        TestChannel.interConnect(eCh1, eCh2)
+
+        logger.debug("Waiting for negotiation to complete...")
+        protocolSelect1.selectedFuture.get(10, TimeUnit.SECONDS)
+        protocolSelect2.selectedFuture.get(10, TimeUnit.SECONDS)
+        logger.debug("Secured!")
+
+        TestLogAppender().install().use { testLogAppender ->
+            Assertions.assertThatCode {
+                // writing invalid cipher data
+                eCh1.writeInbound(Unpooled.wrappedBuffer(ByteArray(128)))
+            }.doesNotThrowAnyException()
+
+            Assertions.assertThat(eCh1.isOpen).isFalse()
+            org.junit.jupiter.api.Assertions.assertFalse(testLogAppender.hasAnyWarns())
+        }
+    }
+}

--- a/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 
 typealias SecureChannelCtor = (PrivKey) -> SecureChannel
 
-private val logger = LogManager.getLogger(SecureChannelTest::class.java)
+val logger = LogManager.getLogger(SecureChannelTest::class.java)
 
 abstract class SecureChannelTest(
     val secureChannelCtor: SecureChannelCtor,
@@ -99,9 +99,9 @@ abstract class SecureChannelTest(
         }
     } // secureInterconnect
 
-    private fun makeSelector(key: PrivKey) = ProtocolSelect(listOf(secureChannelCtor(key)))
+    protected fun makeSelector(key: PrivKey) = ProtocolSelect(listOf(secureChannelCtor(key)))
 
-    private fun makeChannel(
+    protected fun makeChannel(
         name: String,
         initiator: Boolean,
         selector: ChannelInboundHandlerAdapter

--- a/src/test/kotlin/io/libp2p/security/noise/NoiseSecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/noise/NoiseSecureChannelTest.kt
@@ -1,12 +1,12 @@
 package io.libp2p.security.noise
 
-import io.libp2p.security.SecureChannelTest
+import io.libp2p.security.CipherSecureChannelTest
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 
 @DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
 @Tag("secure-channel")
-class NoiseSecureChannelTest : SecureChannelTest(
+class NoiseSecureChannelTest : CipherSecureChannelTest(
     ::NoiseXXSecureChannel,
     NoiseXXSecureChannel.announce
 )

--- a/src/test/kotlin/io/libp2p/security/secio/SecIoSecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/secio/SecIoSecureChannelTest.kt
@@ -1,10 +1,10 @@
 package io.libp2p.security.secio
 
-import io.libp2p.security.SecureChannelTest
+import io.libp2p.security.CipherSecureChannelTest
 import org.junit.jupiter.api.Tag
 
 @Tag("secure-channel")
-class SecIoSecureChannelTest : SecureChannelTest(
+class SecIoSecureChannelTest : CipherSecureChannelTest(
     ::SecIoSecureChannel,
     "/secio/1.0.0"
 )

--- a/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
@@ -12,10 +12,12 @@ class TestLogAppender : AbstractAppender("test", null, null), AutoCloseable {
 
     fun install(): TestLogAppender {
         (LogManager.getRootLogger() as Logger).addAppender(this)
+        start()
         return this
     }
 
     fun uninstall() {
+        stop()
         (LogManager.getRootLogger() as Logger).removeAppender(this)
     }
 


### PR DESCRIPTION
We have failed to handle the case when `javax.crypto.AEADBadTagException` is the root cause of `CantDecryptInboundException`

Also `abruptlyClosing` flag was added to avoid nested decode exceptions during channel close. When channel is closing the netty `ByteToMessageDecoder` tries to feed all unprocessed bytes to the pipeline which again causes `CantDecryptInboundException` from security 'codec'. This makes sense when channel is closed remotely but should be prevented when we are closing the local channel abruptly

Fix when merged to Teku https://github.com/ConsenSys/teku/issues/3214