### PR TITLE
Fix unfair IWANT penalty

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -356,7 +356,7 @@ open class GossipRouter @JvmOverloads constructor(
         val staleIWantTime = this.curTimeMillis() - params.iWantFollowupTime.toMillis()
         iWantRequests.entries.removeIf { (key, time) ->
             (time < staleIWantTime)
-                .whenTrue { notifyRouterMisbehavior(key.first, 1) }
+                .whenTrue { notifyIWantTimeout(key.first, key.second) }
         }
 
         try {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -155,7 +155,7 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     protected open fun notifyIWantTimeout(peer: PeerHandler, msgId: MessageId) {
-        notifyRouterMisbehavior(peer, 1, MisbehaviorReason.MissingIWant)
+        notifyRouterMisbehavior(peer, 1)
     }
 
     protected open fun notifyMeshed(peer: PeerHandler, topic: Topic) {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -114,6 +114,7 @@ open class GossipRouter @JvmOverloads constructor(
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
         score.notifyUnseenMessage(peer, msg)
+        notifyAnyMessage(peer, msg)
     }
 
     override fun notifySeenMessage(
@@ -122,6 +123,7 @@ open class GossipRouter @JvmOverloads constructor(
         validationResult: Optional<ValidationResult>
     ) {
         score.notifySeenMessage(peer, msg, validationResult)
+        notifyAnyMessage(peer, msg)
         if (validationResult.isPresent && validationResult.get() != ValidationResult.Invalid) {
             notifyAnyValidMessage(peer, msg)
         }
@@ -140,11 +142,23 @@ open class GossipRouter @JvmOverloads constructor(
         notifyRouterMisbehavior(peer, 1)
     }
 
-    private fun notifyAnyValidMessage(peer: PeerHandler, msg: PubsubMessage) {
-        iWantRequests -= peer to msg.messageId
+    protected open fun notifyAnyMessage(peer: PeerHandler, msg: PubsubMessage) {
+        if (iWantRequests.remove(peer to msg.messageId) != null) {
+            notifyIWantComplete(peer, msg)
+        }
     }
 
-    fun notifyMeshed(peer: PeerHandler, topic: Topic) {
+    protected open fun notifyAnyValidMessage(peer: PeerHandler, msg: PubsubMessage) {
+    }
+
+    protected open fun notifyIWantComplete(peer: PeerHandler, msg: PubsubMessage) {
+    }
+
+    protected open fun notifyIWantTimeout(peer: PeerHandler, msgId: MessageId) {
+        notifyRouterMisbehavior(peer, 1, MisbehaviorReason.MissingIWant)
+    }
+
+    protected open fun notifyMeshed(peer: PeerHandler, topic: Topic) {
         score.notifyMeshed(peer, topic)
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipPeerScoreParamsBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipPeerScoreParamsBuilder.kt
@@ -31,6 +31,7 @@ class GossipPeerScoreParamsBuilder() {
 
     constructor(source: GossipPeerScoreParams) : this() {
         this.topicScoreCap = source.topicScoreCap
+        this.isDirect = source.isDirect
         this.appSpecificScore = source.appSpecificScore
         this.appSpecificWeight = source.appSpecificWeight
         this.ipWhitelisted = source.ipWhitelisted

--- a/src/test/kotlin/io/libp2p/pubsub/TestRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/TestRouter.kt
@@ -38,9 +38,10 @@ class SemiduplexConnection(val conn1: TestConnection, val conn2: TestConnection)
 class TestRouter(val name: String = "" + cnt.getAndIncrement(), val protocol: String = "/test/undefined") {
 
     val inboundMessages = LinkedBlockingQueue<PubsubMessage>()
+    var handlerValidationResult = RESULT_VALID
     var routerHandler: (PubsubMessage) -> CompletableFuture<ValidationResult> = {
         inboundMessages += it
-        RESULT_VALID
+        handlerValidationResult
     }
 
     var testExecutor: ScheduledExecutorService by lazyVar { Executors.newSingleThreadScheduledExecutor() }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/Eth2GossipParams.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/Eth2GossipParams.kt
@@ -66,10 +66,10 @@ private val subnetTopicParams =
     (0..63).map { "$AttestTopicPrefix$it$AttestTopicSuffix" to Eth2DefaultAttestTopicParams }.toMap()
 val Eth2DefaultTopicsParams = GossipTopicsScoreParams(
     topicParams =
-    mapOf(
-        BlocksTopic to Eth2DefaultBlockTopicParams,
-        AggrAttestTopic to Eth2DefaultAggrAttestTopicParams
-    ) + subnetTopicParams
+        mapOf(
+            BlocksTopic to Eth2DefaultBlockTopicParams,
+            AggrAttestTopic to Eth2DefaultAggrAttestTopicParams
+        ) + subnetTopicParams
 )
 
 val Eth2DefaultPeerScoreParams = GossipPeerScoreParams(

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/Eth2GossipParams.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/Eth2GossipParams.kt
@@ -1,0 +1,96 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.etc.types.minutes
+import io.libp2p.etc.types.seconds
+import io.libp2p.etc.types.times
+
+// Spec constants
+val SlotDuration = 12.seconds
+val SlotsPerEpoch = 32
+val EpochDuration = SlotDuration * SlotsPerEpoch
+val BlocksTopic = "/eth2/00000000/beacon_block/ssz_snappy"
+val AggrAttestTopic = "/eth2/00000000/beacon_aggregate_and_proof/ssz_snappy"
+val AttestTopicPrefix = "/eth2/00000000/beacon_attestation_"
+val AttestTopicSuffix = "/ssz_snappy"
+
+val Eth2DefaultGossipParams = GossipParams(
+    D = 8,
+    DLow = 6,
+    DHigh = 12,
+    DLazy = 8,
+
+    pruneBackoff = 1.minutes,
+    floodPublish = true,
+    gossipFactor = 0.25,
+    DScore = 4,
+    DOut = 2,
+    // TODO peersInPx
+    graftFloodThreshold = 10.seconds,
+    opportunisticGraftTicks = 85,
+    opportunisticGraftPeers = 2,
+    gossipRetransmission = 3,
+    maxIHaveLength = 5000,
+    maxIHaveMessages = 5,
+    iWantFollowupTime = 3.seconds
+)
+
+val Eth2DefaultBlockTopicParams = GossipTopicScoreParams(
+    topicWeight = 0.5,
+    timeInMeshWeight = 0.0324,
+    timeInMeshQuantum = SlotDuration,
+    timeInMeshCap = 300.0,
+    firstMessageDeliveriesWeight = 1.0,
+    firstMessageDeliveriesDecay = 0.9928,
+    firstMessageDeliveriesCap = 23.0,
+    meshMessageDeliveriesWeight = -0.724,
+    meshMessageDeliveriesDecay = 0.9928,
+    meshMessageDeliveriesThreshold = 14.0,
+    meshMessageDeliveriesCap = 139.0,
+    meshMessageDeliveriesActivation = EpochDuration * 4,
+    meshMessageDeliveryWindow = 2.seconds,
+    meshFailurePenaltyWeight = -0.724,
+    meshFailurePenaltyDecay = 0.9928,
+    invalidMessageDeliveriesWeight = -142.0,
+    invalidMessageDeliveriesDecay = 0.9971
+)
+
+val Eth2DefaultAggrAttestTopicParams = GossipTopicScoreParams(
+    // TODO
+)
+
+val Eth2DefaultAttestTopicParams = GossipTopicScoreParams(
+    // TODO
+)
+
+private val subnetTopicParams =
+    (0..63).map { "$AttestTopicPrefix$it$AttestTopicSuffix" to Eth2DefaultAttestTopicParams }.toMap()
+val Eth2DefaultTopicsParams = GossipTopicsScoreParams(
+    topicParams =
+    mapOf(
+        BlocksTopic to Eth2DefaultBlockTopicParams,
+        AggrAttestTopic to Eth2DefaultAggrAttestTopicParams
+    ) + subnetTopicParams
+)
+
+val Eth2DefaultPeerScoreParams = GossipPeerScoreParams(
+    decayInterval = SlotDuration,
+    decayToZero = 0.1,
+    retainScore = EpochDuration * 100,
+    appSpecificWeight = 1.0,
+    ipColocationFactorWeight = -35.5,
+    ipColocationFactorThreshold = 10,
+    behaviourPenaltyThreshold = 6.0,
+    behaviourPenaltyWeight = -15.92,
+    behaviourPenaltyDecay = 0.9857,
+    topicScoreCap = 35.5
+)
+
+val Eth2DefaultScoreParams = GossipScoreParams(
+    peerScoreParams = Eth2DefaultPeerScoreParams,
+    topicsScoreParams = Eth2DefaultTopicsParams,
+    gossipThreshold = -4000.0,
+    publishThreshold = -8000.0,
+    graylistThreshold = -16000.0,
+    acceptPXThreshold = 100.0,
+    opportunisticGraftThreshold = 5.0
+)

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -1,13 +1,17 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.core.pubsub.RESULT_IGNORE
 import io.libp2p.etc.types.seconds
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.pubsub.DeterministicFuzz
 import io.libp2p.pubsub.MockRouter
 import io.libp2p.pubsub.PubsubRouterTest
 import io.libp2p.pubsub.TestRouter
+import io.libp2p.pubsub.gossip.builders.GossipPeerScoreParamsBuilder
+import io.libp2p.pubsub.gossip.builders.GossipScoreParamsBuilder
 import io.libp2p.tools.TestLogAppender
 import io.netty.handler.logging.LogLevel
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import pubsub.pb.Rpc
@@ -207,6 +211,52 @@ class GossipPubsubRouterTest : PubsubRouterTest({
             mockRouter.sendToSingle(msg1)
 
             Assertions.assertFalse(testLogAppender.hasAnyWarns())
+        }
+    }
+
+    @Test
+    fun testIgnoreDoesntReduceScores() {
+        // check that with Eth2 Gossip scoring params
+        // a peers which IGNOREs all inbound messages doesn't got underscored
+
+        val fuzz = DeterministicFuzz()
+        val gossipScoreParams = GossipScoreParamsBuilder(Eth2DefaultScoreParams)
+            .peerScoreParams(
+                // disable colocation factor for simulation
+                GossipPeerScoreParamsBuilder(Eth2DefaultPeerScoreParams).ipColocationFactorWeight(0.0).build()
+            ).build()
+
+        val allCount = 20
+        val allRouters = (1..allCount).map {
+            val r = GossipRouter(Eth2DefaultGossipParams, gossipScoreParams)
+            fuzz.createTestRouter(r)
+        }
+
+        val senderRouter = allRouters[0]
+        val scoringRouter = allRouters[1]
+        val ignoringRouter = allRouters[2]
+        ignoringRouter.handlerValidationResult = RESULT_IGNORE
+        val crowdRouters = allRouters.subList(3, allCount - 1)
+
+        (crowdRouters + ignoringRouter).forEach {
+            senderRouter.connectSemiDuplex(it)
+            it.connectSemiDuplex(scoringRouter)
+        }
+        allRouters.forEach { it.router.subscribe(BlocksTopic) }
+
+        fuzz.timeController.addTime(10.seconds)
+        for (i in 0..100) {
+            val msg = newMessage(BlocksTopic, i.toLong(), "Hello-$i".toByteArray())
+            senderRouter.router.publish(msg)
+
+            fuzz.timeController.addTime(20.seconds)
+            assert(scoringRouter.inboundMessages.size > 0)
+            scoringRouter.inboundMessages.clear()
+        }
+
+        val gossipRouter = scoringRouter.router as GossipRouter
+        gossipRouter.peers.forEach {
+            assertThat(gossipRouter.score.score(it)).isGreaterThanOrEqualTo(0.0)
         }
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -217,7 +217,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
     @Test
     fun testIgnoreDoesntReduceScores() {
         // check that with Eth2 Gossip scoring params
-        // a peers which IGNOREs all inbound messages doesn't got underscored
+        // a peers which IGNOREs all inbound messages doesn't get underscored
 
         val fuzz = DeterministicFuzz()
         val gossipScoreParams = GossipScoreParamsBuilder(Eth2DefaultScoreParams)


### PR DESCRIPTION
Fix the following scenario: 
- Node receives unseen `IHAVE` for message `M` from peer `P1`
- Node sends `IWANT M` to `P1`
- Node receives message `M` from peer `P2` notify the client and waits for its validation 
- While still in process of validation the `M` is received  from `P1` (as a response to `IWANT`)
- `notifyAnyValidMessage` is not called for the latter inbound and pending entry is not removed from `iWantRequests`
- Peer `P1` is penalized for `IWANT` response timeout 

The `iWantRequests` entry need to be cleared on any message. If a message occurs invalid the peer would be penalized in another way 

Also add the test verifying that a long period of Gossip `IGNORE` (i.e. not publishing any messages) doesn't underscore the node with Eth2 params 