### PR TITLE
Fix 2 flaky tests, clean up build 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,7 @@ protobuf {
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
     kotlinOptions {
-        freeCompilerArgs = listOf("-XXLanguage:+InlineClasses", "-Xjvm-default=enable")
+        freeCompilerArgs = listOf("-Xjvm-default=enable")
     }
 }
 

--- a/src/main/java/io/libp2p/discovery/mdns/impl/tasks/ServiceResolver.java
+++ b/src/main/java/io/libp2p/discovery/mdns/impl/tasks/ServiceResolver.java
@@ -7,6 +7,7 @@ package io.libp2p.discovery.mdns.impl.tasks;
 import io.libp2p.discovery.mdns.impl.DNSOutgoing;
 import io.libp2p.discovery.mdns.impl.DNSQuestion;
 import io.libp2p.discovery.mdns.impl.JmDNSImpl;
+import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
 import org.apache.logging.log4j.LogManager;
@@ -16,8 +17,6 @@ import java.io.IOException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
 
 /**
  * The ServiceResolver queries three times consecutively for services of a given type, and then removes itself from the timer.
@@ -50,6 +49,7 @@ public class ServiceResolver extends DNSTask {
         );
     }
 
+    @SuppressWarnings("unchecked")
     public Future<Void> stop() {
         _scheduler.shutdown();
         return (Future<Void>)_isShutdown;

--- a/src/main/kotlin/io/libp2p/protocol/Ping.kt
+++ b/src/main/kotlin/io/libp2p/protocol/Ping.kt
@@ -30,7 +30,7 @@ open class PingBinding(ping: PingProtocol) :
 class PingTimeoutException : Libp2pException()
 
 open class PingProtocol : ProtocolHandler<PingController>() {
-    var scheduler by lazyVar { Executors.newSingleThreadScheduledExecutor() }
+    var timeoutScheduler by lazyVar { Executors.newSingleThreadScheduledExecutor() }
     var curTime: () -> Long = { System.currentTimeMillis() }
     var random = Random()
     var pingSize = 32
@@ -77,30 +77,33 @@ open class PingProtocol : ProtocolHandler<PingController>() {
         }
 
         override fun onClosed(stream: Stream) {
-            closed = true
-
-            scheduler.shutdownNow()
-
-            activeFuture.completeExceptionally(ConnectionClosedException())
             synchronized(requests) {
+                closed = true
                 requests.values.forEach { it.second.completeExceptionally(ConnectionClosedException()) }
                 requests.clear()
+                timeoutScheduler.shutdownNow()
             }
+            activeFuture.completeExceptionally(ConnectionClosedException())
         }
 
         override fun ping(): CompletableFuture<Long> {
-            if (closed) return completedExceptionally(ConnectionClosedException())
             val ret = CompletableFuture<Long>()
             val data = ByteArray(pingSize)
             random.nextBytes(data)
             val dataS = data.toHex()
-            requests[dataS] = curTime() to ret
-            scheduler.schedule(
-                {
-                    requests.remove(dataS)?.second?.completeExceptionally(PingTimeoutException())
-                },
-                pingTimeout.toMillis(), TimeUnit.MILLISECONDS
-            )
+
+            synchronized(requests) {
+                if (closed) return completedExceptionally(ConnectionClosedException())
+                requests[dataS] = curTime() to ret
+
+                timeoutScheduler.schedule(
+                    {
+                        requests.remove(dataS)?.second?.completeExceptionally(PingTimeoutException())
+                    },
+                    pingTimeout.toMillis(), TimeUnit.MILLISECONDS
+                )
+            }
+
             stream.writeAndFlush(data.toByteBuf())
             return ret
         }

--- a/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
@@ -94,7 +94,7 @@ abstract class SecureChannelTest(
 
         while (data2 != handler1.getAllReceived()) {
             if (handler1.receivedQueue.poll(5, TimeUnit.SECONDS) == null) {
-                fail<Any>("Didn't receive all the data1: '${handler1.getAllReceived()}', data2: '${handler1.getAllReceived()}'")
+                fail<Any>("Didn't receive all the data1: '${handler1.getAllReceived()}', data2: '${handler2.getAllReceived()}'")
             }
         }
         while (data1 != handler2.getAllReceived()) {

--- a/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.nio.charset.StandardCharsets
+import java.util.Collections
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
@@ -131,7 +132,7 @@ abstract class SecureChannelTest(
         val data: String = "Hello World from $name"
     ) : TestHandler(name) {
 
-        val received = mutableListOf<String>()
+        val received = Collections.synchronizedList(mutableListOf<String>())
         val receivedQueue = LinkedBlockingQueue<String>()
 
         override fun channelActive(ctx: ChannelHandlerContext) {

--- a/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
@@ -17,6 +17,7 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.util.ResourceLeakDetector
 import org.apache.logging.log4j.LogManager
+import org.assertj.core.api.Assertions.fail
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.nio.charset.StandardCharsets
@@ -92,10 +93,14 @@ abstract class SecureChannelTest(
         eCh2.pipeline().fireChannelActive()
 
         while (data2 != handler1.getAllReceived()) {
-            handler1.receivedQueue.poll(5, TimeUnit.SECONDS)
+            if (handler1.receivedQueue.poll(5, TimeUnit.SECONDS) == null) {
+                fail<Any>("Didn't receive all the data1: '${handler1.getAllReceived()}', data2: '${handler1.getAllReceived()}'")
+            }
         }
         while (data1 != handler2.getAllReceived()) {
-            handler2.receivedQueue.poll(5, TimeUnit.SECONDS)
+            if (handler2.receivedQueue.poll(5, TimeUnit.SECONDS) == null) {
+                fail<Any>("Didn't receive all the data2: '${handler2.getAllReceived()}'")
+            }
         }
     } // secureInterconnect
 

--- a/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
@@ -107,8 +107,6 @@ abstract class SecureChannelTest(
                 fail<Any>("Didn't receive all the data2: '${handler2.getAllReceived()}'")
             }
         }
-
-        throw RuntimeException("Test")
     } // secureInterconnect
 
     protected fun makeSelector(key: PrivKey) = ProtocolSelect(listOf(secureChannelCtor(key)))

--- a/src/test/kotlin/io/libp2p/tools/TestChannel.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestChannel.kt
@@ -11,6 +11,7 @@ import io.netty.channel.embedded.EmbeddedChannel
 import org.apache.logging.log4j.LogManager
 import java.net.InetSocketAddress
 import java.net.SocketAddress
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
@@ -47,6 +48,10 @@ class TestChannel(
     val sentMsgCount = AtomicLong()
     var executor: Executor by lazyVar {
         Executors.newSingleThreadExecutor(threadFactory)
+    }
+
+    fun <TRet> onChannelThread(task: (EmbeddedChannel) -> TRet): CompletableFuture<TRet> {
+        return CompletableFuture.supplyAsync({ task(this) }, executor)
     }
 
     @Synchronized


### PR DESCRIPTION
Fix 
- `SecureChannelTest` which periodically just hung the build: the reason was in using a regular `ArrayList` in multithreading scenario. Also discovered that channel methods were called from two threads: main and `TestChannel.executor`
- `HostTest.pingOverSecureConnection()` which periodically failed with non-expected exception: the reason was in unsynchronized `Ping` actions 
- Clean up build warnings 