### PR TITLE
Check causal chain for exceptions when deciding what log level to use

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.Libp2pException
 import io.libp2p.etc.types.completedExceptionally
+import io.libp2p.etc.types.hasCauseOfType
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import org.apache.logging.log4j.LogManager
@@ -40,9 +41,9 @@ abstract class AbstractMuxHandler<TData>() :
     }
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        when (cause) {
-            is InternalErrorException -> log.warn("Muxer internal error", cause)
-            is Libp2pException -> log.debug("Muxer exception", cause)
+        when {
+            cause.hasCauseOfType(InternalErrorException::class) -> log.warn("Muxer internal error", cause)
+            cause.hasCauseOfType(Libp2pException::class) -> log.debug("Muxer exception", cause)
             else -> log.warn("Unexpected exception", cause)
         }
     }


### PR DESCRIPTION
Exceptions during decoding wind up being wrapped by netty in `DecoderException` so when deciding what level to use for exceptions, check the causal chain rather than just the outermost exception type.

See https://github.com/ConsenSys/teku/issues/3309 for an example of exceptions this would handle better.