### PR TITLE
Tweak gossip scoring config apis

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
@@ -31,7 +31,7 @@ fun cappedDouble(value: Double, decayToZero: Double = Double.MIN_VALUE): CappedV
  * and may drop value to [0.0] when the new value is less than [decayToZero]
  */
 fun cappedDouble(value: Double, decayToZero: Double = Double.MIN_VALUE, upperBound: () -> Double) =
-    CappedValueDelegate(value, { decayToZero }, { 0.0 }, upperBound, upperBound)
+    CappedValueDelegate(value, { decayToZero }, { 0.0 }, upperBound)
 
 // thanks to https://stackoverflow.com/a/47948047/9630725
 class LazyMutable<T>(val initializer: () -> T, val rejectSetAfterGet: Boolean = false) : ReadWriteProperty<Any?, T> {

--- a/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
@@ -31,7 +31,7 @@ fun cappedDouble(value: Double, decayToZero: Double = Double.MIN_VALUE): CappedV
  * and may drop value to [0.0] when the new value is less than [decayToZero]
  */
 fun cappedDouble(value: Double, decayToZero: Double = Double.MIN_VALUE, upperBound: () -> Double) =
-    CappedValueDelegate(value, { decayToZero }, { 0.0 }, upperBound)
+    CappedValueDelegate(value, { decayToZero }, { 0.0 }, upperBound, upperBound)
 
 // thanks to https://stackoverflow.com/a/47948047/9630725
 class LazyMutable<T>(val initializer: () -> T, val rejectSetAfterGet: Boolean = false) : ReadWriteProperty<Any?, T> {
@@ -68,10 +68,8 @@ data class CappedValueDelegate<C : Comparable<C>>(
 ) : ReadWriteProperty<Any?, C> {
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): C {
-        val upper = upperBound.invoke()
-        val lower = lowerBound.invoke()
-        val v1 = if (value > upper) upper else value
-        value = if (value < lower) lower else v1
+        val v1 = if (value > upperBound.invoke()) upperBoundVal.invoke() else value
+        value = if (value < lowerBound.invoke()) lowerBoundVal.invoke() else v1
         return value
     }
 

--- a/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
@@ -68,8 +68,8 @@ data class CappedValueDelegate<C : Comparable<C>>(
 ) : ReadWriteProperty<Any?, C> {
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): C {
-        val v1 = if (value > upperBound.invoke()) upperBoundVal.invoke() else value
-        value = if (value < lowerBound.invoke()) lowerBoundVal.invoke() else v1
+        val v1 = if (value > upperBound()) upperBoundVal() else value
+        value = if (value < lowerBound()) lowerBoundVal() else v1
         return value
     }
 

--- a/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
@@ -61,10 +61,10 @@ class LazyMutable<T>(val initializer: () -> T, val rejectSetAfterGet: Boolean = 
 
 data class CappedValueDelegate<C : Comparable<C>>(
     private var value: C,
-    private var lowerBound: () -> C,
-    private var lowerBoundVal: () -> C = lowerBound,
-    private var upperBound: () -> C,
-    private var upperBoundVal: () -> C = upperBound
+    private val lowerBound: () -> C,
+    private val lowerBoundVal: () -> C = lowerBound,
+    private val upperBound: () -> C,
+    private val upperBoundVal: () -> C = upperBound
 ) : ReadWriteProperty<Any?, C> {
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): C {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -13,11 +13,15 @@ import io.netty.channel.ChannelHandler
 import java.util.concurrent.CompletableFuture
 
 class Gossip @JvmOverloads constructor(
-    val router: GossipRouter = GossipRouter(),
-    val api: PubsubApi = PubsubApiImpl(router),
-    val debugGossipHandler: ChannelHandler? = null
+    private val router: GossipRouter = GossipRouter(),
+    private val api: PubsubApi = PubsubApiImpl(router),
+    private val debugGossipHandler: ChannelHandler? = null
 ) :
     ProtocolBinding<Unit>, ConnectionHandler, PubsubApi by api {
+
+    fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
+        router.score.updateTopicParams(scoreParams)
+    }
 
     override val protocolDescriptor =
         if (router.protocol == PubsubProtocol.Gossip_V_1_1)

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -417,10 +417,7 @@ class GossipTopicsScoreParams(
     private val defaultParams: GossipTopicScoreParams = GossipTopicScoreParams(),
     topicParamsMap: Map<Topic, GossipTopicScoreParams> = mapOf()
 ) {
-    val topicParams: MutableMap<Topic, GossipTopicScoreParams>
-    init {
-        this.topicParams = topicParamsMap.toMutableMap()
-    }
+    val topicParams: MutableMap<Topic, GossipTopicScoreParams> = topicParamsMap.toMutableMap()
 
     operator fun get(topic: Topic) = topicParams.getOrDefault(topic, defaultParams)
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -415,9 +415,22 @@ data class GossipPeerScoreParams(
  */
 class GossipTopicsScoreParams(
     private val defaultParams: GossipTopicScoreParams = GossipTopicScoreParams(),
-    private val topicParams: Map<Topic, GossipTopicScoreParams> = mapOf()
+    topicParamsMap: Map<Topic, GossipTopicScoreParams> = mapOf()
 ) {
+    val topicParams: MutableMap<Topic, GossipTopicScoreParams>
+    init {
+        this.topicParams = topicParamsMap.toMutableMap()
+    }
+
     operator fun get(topic: Topic) = topicParams.getOrDefault(topic, defaultParams)
+
+    fun setTopicParams(topic: Topic, params: GossipTopicScoreParams) {
+        topicParams[topic] = params
+    }
+
+    fun clearTopicParams(topic: Topic) {
+        topicParams.remove(topic)
+    }
 }
 
 /**

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -2,7 +2,9 @@ package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.PeerId
 import io.libp2p.core.pubsub.ValidationResult
-import io.libp2p.etc.types.*
+import io.libp2p.etc.types.cappedDouble
+import io.libp2p.etc.types.createLRUMap
+import io.libp2p.etc.types.millis
 import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.Topic

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipPeerScoreParamsBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipPeerScoreParamsBuilder.kt
@@ -23,6 +23,8 @@ class GossipPeerScoreParamsBuilder() {
 
     private var behaviourPenaltyDecay: Double? = null
 
+    private var behaviourPenaltyThreshold: Double? = null
+
     private var decayInterval: Duration? = null
 
     private var decayToZero: Double? = null
@@ -39,6 +41,7 @@ class GossipPeerScoreParamsBuilder() {
         this.ipColocationFactorThreshold = source.ipColocationFactorThreshold
         this.behaviourPenaltyWeight = source.behaviourPenaltyWeight
         this.behaviourPenaltyDecay = source.behaviourPenaltyDecay
+        this.behaviourPenaltyThreshold = source.behaviourPenaltyThreshold
         this.decayInterval = source.decayInterval
         this.decayToZero = source.decayToZero
         this.retainScore = source.retainScore
@@ -78,6 +81,10 @@ class GossipPeerScoreParamsBuilder() {
         behaviourPenaltyDecay = value
     }
 
+    fun behaviourPenaltyThreshold(value: Double): GossipPeerScoreParamsBuilder = apply {
+        behaviourPenaltyThreshold = value
+    }
+
     fun decayInterval(value: Duration): GossipPeerScoreParamsBuilder = apply { decayInterval = value }
 
     fun decayToZero(value: Double): GossipPeerScoreParamsBuilder = apply { decayToZero = value }
@@ -96,6 +103,7 @@ class GossipPeerScoreParamsBuilder() {
             ipColocationFactorThreshold = ipColocationFactorThreshold!!,
             behaviourPenaltyWeight = behaviourPenaltyWeight!!,
             behaviourPenaltyDecay = behaviourPenaltyDecay!!,
+            behaviourPenaltyThreshold = behaviourPenaltyThreshold!!,
             decayInterval = decayInterval!!,
             decayToZero = decayToZero!!,
             retainScore = retainScore!!
@@ -115,6 +123,7 @@ class GossipPeerScoreParamsBuilder() {
         )
         check(behaviourPenaltyWeight != null, { "behaviourPenaltyWeight must not be null" })
         check(behaviourPenaltyDecay != null, { "behaviourPenaltyDecay must not be null" })
+        check(behaviourPenaltyThreshold != null, { "behaviourPenaltyThreshold must not be null" })
         check(decayInterval != null, { "decayInterval must not be null" })
         check(decayToZero != null, { "decayToZero must not be null" })
         check(retainScore != null, { "retainScore must not be null" })

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/Eth2GossipParams.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/Eth2GossipParams.kt
@@ -65,7 +65,7 @@ val Eth2DefaultAttestTopicParams = GossipTopicScoreParams(
 private val subnetTopicParams =
     (0..63).map { "$AttestTopicPrefix$it$AttestTopicSuffix" to Eth2DefaultAttestTopicParams }.toMap()
 val Eth2DefaultTopicsParams = GossipTopicsScoreParams(
-    topicParams =
+    topicParamsMap =
         mapOf(
             BlocksTopic to Eth2DefaultBlockTopicParams,
             AggrAttestTopic to Eth2DefaultAggrAttestTopicParams

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipScoreTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipScoreTest.kt
@@ -1,25 +1,28 @@
 package io.libp2p.pubsub.gossip
 
+import com.google.protobuf.ByteString
 import io.libp2p.core.PeerId
-import io.libp2p.etc.types.minutes
-import io.libp2p.etc.types.seconds
+import io.libp2p.etc.types.*
 import io.libp2p.etc.util.P2PService
+import io.libp2p.pubsub.DefaultPubsubMessage
+import io.libp2p.pubsub.Topic
 import io.libp2p.tools.schedulers.ControlledExecutorServiceImpl
 import io.libp2p.tools.schedulers.TimeControllerImpl
 import io.mockk.every
 import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+import java.nio.charset.StandardCharsets
+import java.util.*
 
 class GossipScoreTest {
 
     @Test
     fun `test misbehavior score threshold`() {
-        val peerId = PeerId.random()
-        val peerHandler = mockk<P2PService.PeerHandler>()
-        every { peerHandler.peerId } returns peerId
-        every { peerHandler.getIP() } returns "127.0.0.1"
+        val peer = mockPeer()
 
         val peerScoreParams = GossipPeerScoreParams(
             decayInterval = 1.seconds,
@@ -33,26 +36,654 @@ class GossipScoreTest {
 
         val score = GossipScore(scoreParams, executor, { timeController.time })
 
-        assertEquals(0.0, score.score(peerHandler))
+        assertEquals(0.0, score.score(peer))
 
         // not hit threshold yet
-        score.notifyRouterMisbehavior(peerHandler, 5)
-        assertEquals(0.0, score.score(peerHandler))
+        score.notifyRouterMisbehavior(peer, 5)
+        assertEquals(0.0, score.score(peer))
 
         // behaviourPenaltyThreshold reached
-        score.notifyRouterMisbehavior(peerHandler, 1)
-        assertTrue(score.score(peerHandler) < 0)
+        score.notifyRouterMisbehavior(peer, 1)
+        assertTrue(score.score(peer) < 0)
 
         // quadratic penalty
-        score.notifyRouterMisbehavior(peerHandler, 10)
-        assertTrue(score.score(peerHandler) < -50)
+        score.notifyRouterMisbehavior(peer, 10)
+        assertTrue(score.score(peer) < -50)
 
         // negative behaviour should not be forgotten so fast
         timeController.addTime(10.seconds)
-        assertTrue(score.score(peerHandler) < 0)
+        assertTrue(score.score(peer) < 0)
 
         // time heals
         timeController.addTime(10.minutes)
-        assertEquals(0.0, score.score(peerHandler))
+        assertEquals(0.0, score.score(peer))
+    }
+
+    @Test
+    fun `test topic score`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic = "testTopic"
+        val otherTopic = "randomTopic"
+        val topicScoreParams = GossipTopicScoreParams(
+            topicWeight = 1.0,
+            timeInMeshWeight = 1.0,
+            timeInMeshQuantum = 1.seconds,
+            timeInMeshCap = 1.0,
+            firstMessageDeliveriesWeight = 2.0,
+            firstMessageDeliveriesDecay = 0.9,
+            firstMessageDeliveriesCap = 4.0,
+            meshMessageDeliveriesWeight = -1.0,
+            meshMessageDeliveriesDecay = 0.9,
+            meshMessageDeliveriesThreshold = 3.0,
+            meshMessageDeliveriesCap = 5.0,
+            meshMessageDeliveriesActivation = 10.seconds,
+            meshMessageDeliveryWindow = 2.seconds,
+            invalidMessageDeliveriesWeight = -0.5,
+            invalidMessageDeliveriesDecay = .9
+        )
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // After 1 quantum of time in the mesh, we should increment the score by timeInMeshWeight
+        timeController.addTime(1.seconds)
+        assertThat(score.score(peer)).isEqualTo(1.0)
+
+        // After delivering a message, we should increase our score by firstMessageDeliveriesWeight
+        val msg = DefaultPubsubMessage(createRpcMessage(topic))
+        score.notifyUnseenValidMessage(peer, msg)
+        assertThat(score.score(peer)).isEqualTo(3.0)
+
+        // Message for an unknown topic should be scored using default (disabled) scoring, so score should not change
+        val unknownTopicMsg = DefaultPubsubMessage(createRpcMessage(otherTopic))
+        score.notifyUnseenValidMessage(peer, unknownTopicMsg)
+        assertThat(score.score(peer)).isEqualTo(3.0)
+
+        // Invalid msg should decrement score
+        val invalidMsg = DefaultPubsubMessage(createRpcMessage(topic, 2))
+        score.notifyUnseenInvalidMessage(peer, invalidMsg)
+        assertThat(score.score(peer)).isEqualTo(2.5)
+
+        // Invalid msg for unknown topic should not decrement score
+        val unknownInvalidMsg = DefaultPubsubMessage(createRpcMessage(otherTopic, 2))
+        score.notifyUnseenInvalidMessage(peer, unknownInvalidMsg)
+        assertThat(score.score(peer)).isEqualTo(2.5)
+
+        // Advance time to activate low delivery penalty
+        // We've delivered 1 message which is 2 below the meshDeliveriesThreshold (3)
+        // Squaring this, we get a penalty of -4
+        timeController.addTime(10.seconds)
+        assertThat(score.score(peer)).isEqualTo(2.5 - 4.0)
+    }
+
+    @Test
+    fun `test first message delivery decay`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic: Topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .firstMessageDeliveriesCap(4.0)
+            .firstMessageDeliveriesWeight(2.0)
+            .firstMessageDeliveriesDecay(0.5)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        // Check initial value
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // After delivering a message, we should increase our score by firstMessageDeliveriesWeight
+        val msg = DefaultPubsubMessage(createRpcMessage(topic))
+        score.notifyUnseenValidMessage(peer, msg)
+        assertThat(score.score(peer)).isEqualTo(2.0)
+
+        // Refresh to decay score
+        score.refreshScores()
+        assertThat(score.score(peer)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `test mesh message delivery decay`() {
+        val peer = mockPeer()
+        val otherPeer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic: Topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .firstMessageDeliveriesCap(0.0)
+            .firstMessageDeliveriesWeight(0.0)
+            .firstMessageDeliveriesDecay(0.0)
+            .meshMessageDeliveriesActivation(1.seconds)
+            .meshMessageDeliveryWindow(2.seconds)
+            .meshMessageDeliveriesDecay(0.5)
+            .meshMessageDeliveriesCap(4.0)
+            .meshMessageDeliveriesThreshold(3.0)
+            .meshMessageDeliveriesWeight(-1.0)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        // Check initial value
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Deliver first message from other peer
+        val msg = DefaultPubsubMessage(createRpcMessage(topic))
+        score.notifyUnseenValidMessage(otherPeer, msg)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Deliver same message from target peer
+        score.notifySeenMessage(peer, msg, Optional.empty())
+        // Score should not change yet because we haven't passed the activation window
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Move through activation window and check score
+        // Score should be negative since we haven't met delivery threshold
+        timeController.addTime(2.seconds)
+        assertThat(score.score(peer)).isEqualTo(-4.0)
+
+        // Refresh to decay score, increasing the message delivery penalty since the delivered message counter decays
+        // Penalty = (3 - (1 * .5))^2
+        score.refreshScores()
+        assertThat(score.score(peer)).isEqualTo(-6.25)
+    }
+
+    @Test
+    fun `test invalid message decay`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic: Topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .invalidMessageDeliveriesDecay(0.5)
+            .invalidMessageDeliveriesWeight(-2.0)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        // Check initial value
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // After delivering an invalid message, we should get a penalty
+        val msg = DefaultPubsubMessage(createRpcMessage(topic))
+        score.notifyUnseenInvalidMessage(peer, msg)
+        assertThat(score.score(peer)).isEqualTo(-2.0)
+
+        // Refresh to decay score
+        // counter 1 decays to 0.5, score = weight * counter^2 = -0.5
+        score.refreshScores()
+        assertThat(score.score(peer)).isEqualTo(-0.5)
+    }
+
+    @Test
+    fun `update topic weight param`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .timeInMeshWeight(2.0)
+            .timeInMeshQuantum(1.seconds)
+            .timeInMeshCap(6.0)
+            .build()
+        val updatedTopicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(2.0)
+            .timeInMeshWeight(2.0)
+            .timeInMeshQuantum(1.seconds)
+            .timeInMeshCap(6.0)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Increase time in mesh beyond max
+        timeController.addTime(10.seconds)
+        assertThat(score.score(peer)).isEqualTo(12.0)
+
+        // Update params
+        score.updateTopicParams(mapOf(Pair(topic, updatedTopicScoreParams)))
+
+        // Score calculation should be updated
+        assertThat(score.score(peer)).isEqualTo(24.0)
+    }
+
+    @Test
+    fun `update time in mesh params`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .timeInMeshWeight(2.0)
+            .timeInMeshQuantum(1.seconds)
+            .timeInMeshCap(6.0)
+            .build()
+        val updatedTopicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .timeInMeshWeight(1.0)
+            .timeInMeshQuantum(500.millis)
+            .timeInMeshCap(4.0)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Increase time in mesh beyond max
+        timeController.addTime(10.seconds)
+        assertThat(score.score(peer)).isEqualTo(12.0)
+
+        // Update params
+        score.updateTopicParams(mapOf(Pair(topic, updatedTopicScoreParams)))
+
+        // Score calculation should be updated
+        assertThat(score.score(peer)).isEqualTo(4.0)
+    }
+
+    @Test
+    fun `update first message delivery topic params`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic: Topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .firstMessageDeliveriesCap(4.0)
+            .firstMessageDeliveriesWeight(2.0)
+            .firstMessageDeliveriesDecay(1.0)
+            .build()
+        val updatedTopicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .firstMessageDeliveriesCap(2.0)
+            .firstMessageDeliveriesWeight(1.0)
+            .firstMessageDeliveriesDecay(0.5)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        // Check initial value
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Deliver several message
+        for (i in 0..5) {
+            val msg = DefaultPubsubMessage(createRpcMessage(topic, i))
+            score.notifyUnseenValidMessage(peer, msg)
+        }
+        assertThat(score.score(peer)).isEqualTo(8.0)
+
+        // Update params and check score again
+        score.updateTopicParams(mapOf(Pair(topic, updatedTopicScoreParams)))
+        assertThat(score.score(peer)).isEqualTo(2.0)
+
+        // Check decay
+        score.refreshScores()
+        assertThat(score.score(peer)).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `update mesh message delivery topic params`() {
+        // TODO
+        val peer = mockPeer()
+        val otherPeer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic: Topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .firstMessageDeliveriesCap(0.0)
+            .firstMessageDeliveriesWeight(0.0)
+            .firstMessageDeliveriesDecay(0.0)
+            .meshMessageDeliveriesActivation(1.seconds)
+            .meshMessageDeliveryWindow(2.seconds)
+            .meshMessageDeliveriesDecay(1.0)
+            .meshMessageDeliveriesCap(4.0)
+            .meshMessageDeliveriesThreshold(4.0)
+            .meshMessageDeliveriesWeight(-1.0)
+            .build()
+        val updatedTopicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .firstMessageDeliveriesCap(0.0)
+            .firstMessageDeliveriesWeight(0.0)
+            .firstMessageDeliveriesDecay(0.0)
+            .meshMessageDeliveriesActivation(2.seconds)
+            .meshMessageDeliveryWindow(2.seconds)
+            .meshMessageDeliveriesDecay(0.5)
+            .meshMessageDeliveriesCap(2.0)
+            .meshMessageDeliveriesThreshold(2.0)
+            .meshMessageDeliveriesWeight(-2.0)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        // Check initial value
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Deliver a bunch of invalid messages
+        for (i in 0..5) {
+            // Deliver first message from other peer
+            val msg = DefaultPubsubMessage(createRpcMessage(topic, i))
+            score.notifyUnseenValidMessage(otherPeer, msg)
+            assertThat(score.score(peer)).isEqualTo(0.0)
+
+            // Deliver same message from target peer
+            score.notifySeenMessage(peer, msg, Optional.empty())
+            // Score should not change yet because we haven't passed the activation window
+            assertThat(score.score(peer)).isEqualTo(0.0)
+        }
+
+        // Move through activation window and check score
+        // Score should be 0 since we should be at the delivery threshold (4)
+        timeController.addTime(2.seconds)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Update params
+        score.updateTopicParams(mapOf(Pair(topic, updatedTopicScoreParams)))
+
+        // Refresh to decay score, deliveries should be capped at 2, and decay at rate of 0.5, leaving counter = 1.0
+        score.refreshScores()
+        // Score should be 0.0 since activation window has expanded
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // Move through new activation window and check score again
+        timeController.addTime(1.seconds)
+        assertThat(score.score(peer)).isEqualTo(-2.0)
+    }
+
+    @Test
+    fun `update invalid message topic params`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topic: Topic = "testTopic"
+        val topicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .invalidMessageDeliveriesDecay(1.0)
+            .invalidMessageDeliveriesWeight(-2.0)
+            .build()
+        val updatedTopicScoreParams = GossipTopicScoreParams.builder()
+            .topicWeight(1.0)
+            .invalidMessageDeliveriesDecay(0.5)
+            .invalidMessageDeliveriesWeight(-1.0)
+            .build()
+
+        val defaultScoreParams = GossipTopicScoreParams.builder().build()
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topic, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        // Check initial value
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Add peer to mesh
+        score.notifyMeshed(peer, topic)
+        assertThat(score.score(peer)).isEqualTo(0.0)
+
+        // After delivering an invalid message, we should get a penalty
+        val msg = DefaultPubsubMessage(createRpcMessage(topic))
+        score.notifyUnseenInvalidMessage(peer, msg)
+        assertThat(score.score(peer)).isEqualTo(-2.0)
+
+        // Update params and check score is updated
+        score.updateTopicParams(mapOf(Pair(topic, updatedTopicScoreParams)))
+        assertThat(score.score(peer)).isEqualTo(-1.0)
+
+        // Refresh to decay score
+        // counter 1 decays to 0.5, score = weight * counter^2 = -0.25
+        score.refreshScores()
+        assertThat(score.score(peer)).isEqualTo(-0.25)
+    }
+
+    @Test
+    fun `update topic params for untracked topic`() {
+        val peer = mockPeer()
+
+        // Setup score params with topic config
+        val peerScoreParams = GossipPeerScoreParams.builder().build()
+        val topicA = "topicA"
+        val topicB = "topicB"
+        val topicScoreParams = GossipTopicScoreParams(
+            topicWeight = 1.0,
+            timeInMeshWeight = 1.0,
+            timeInMeshQuantum = 1.seconds,
+            timeInMeshCap = 1.0,
+            firstMessageDeliveriesWeight = 2.0,
+            firstMessageDeliveriesDecay = 0.9,
+            firstMessageDeliveriesCap = 4.0,
+            meshMessageDeliveriesWeight = -1.0,
+            meshMessageDeliveriesDecay = 0.9,
+            meshMessageDeliveriesThreshold = 3.0,
+            meshMessageDeliveriesCap = 5.0,
+            meshMessageDeliveriesActivation = 1.seconds,
+            meshMessageDeliveryWindow = 2.seconds,
+            invalidMessageDeliveriesWeight = -0.5,
+            invalidMessageDeliveriesDecay = .9
+        )
+        // Set defaults so that counters are tracked but score is 0
+        val defaultScoreParams = GossipTopicScoreParams(
+            topicWeight = 0.0,
+            timeInMeshWeight = 1.0,
+            timeInMeshQuantum = 1.seconds,
+            timeInMeshCap = 1000.0,
+            firstMessageDeliveriesWeight = 0.0,
+            firstMessageDeliveriesDecay = 1.0,
+            firstMessageDeliveriesCap = 1000.0,
+            meshMessageDeliveriesWeight = 0.0,
+            meshMessageDeliveriesDecay = 1.0,
+            meshMessageDeliveriesThreshold = 0.0,
+            meshMessageDeliveriesCap = 1000.0,
+            meshMessageDeliveriesActivation = 0.seconds,
+            meshMessageDeliveryWindow = 200.seconds,
+            invalidMessageDeliveriesWeight = 0.0,
+            invalidMessageDeliveriesDecay = 1.0
+        )
+        val topicsScoreParams = GossipTopicsScoreParams(defaultScoreParams, mutableMapOf(Pair(topicA, topicScoreParams)))
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = peerScoreParams,
+            topicsScoreParams = topicsScoreParams
+        )
+
+        // Setup time provider - apply non-zero time so that we don't get 0-valued timestamps that may be interpreted
+        // as empty
+        val timeController = TimeControllerImpl()
+        timeController.addTime(1.hours)
+        val executor = ControlledExecutorServiceImpl(timeController)
+
+        val score = GossipScore(scoreParams, executor, { timeController.time })
+        assertEquals(0.0, score.score(peer))
+
+        // Generate same activity for topic a and b
+        for (curTopic in arrayOf(topicA, topicB)) {
+            // Add peer to mesh
+            score.notifyMeshed(peer, curTopic)
+
+            // Deliver a valid first message
+            val msg = DefaultPubsubMessage(createRpcMessage(curTopic))
+            score.notifyUnseenValidMessage(peer, msg)
+
+            // Deliver an invalid message
+            val invalidMsg = DefaultPubsubMessage(createRpcMessage(curTopic, 2))
+            score.notifyUnseenInvalidMessage(peer, invalidMsg)
+        }
+
+        // Increase time in mesh past activation period
+        timeController.addTime(2.seconds)
+
+        // Score should just hold value for topicA since the default topic has params that zero-out its score
+        assertThat(score.score(peer)).isEqualTo(-1.5)
+
+        // Update params and now second topic should contribute to the score (doubling it)
+        score.updateTopicParams(mapOf(Pair(topicB, topicScoreParams)))
+        assertThat(score.score(peer)).isEqualTo(-3.0)
+    }
+
+    private fun createRpcMessage(topic: String, seqNo: Int = 1): Rpc.Message {
+        return Rpc.Message.newBuilder()
+            .addTopicIDs(topic)
+            .setSeqno(seqNo.toBytesBigEndian().toProtobuf())
+            .setData(ByteString.copyFrom("Test", StandardCharsets.US_ASCII))
+            .build()
+    }
+
+    private fun mockPeer(): P2PService.PeerHandler {
+        val peerId = PeerId.random()
+        val peer = mockk<P2PService.PeerHandler>()
+        every { peer.peerId } returns peerId
+        every { peer.getIP() } returns "127.0.0.1"
+        return peer
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipScoreTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipScoreTest.kt
@@ -2,7 +2,12 @@ package io.libp2p.pubsub.gossip
 
 import com.google.protobuf.ByteString
 import io.libp2p.core.PeerId
-import io.libp2p.etc.types.*
+import io.libp2p.etc.types.hours
+import io.libp2p.etc.types.millis
+import io.libp2p.etc.types.minutes
+import io.libp2p.etc.types.seconds
+import io.libp2p.etc.types.toBytesBigEndian
+import io.libp2p.etc.types.toProtobuf
 import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.DefaultPubsubMessage
 import io.libp2p.pubsub.Topic
@@ -16,7 +21,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import pubsub.pb.Rpc
 import java.nio.charset.StandardCharsets
-import java.util.*
+import java.util.Optional
 
 class GossipScoreTest {
 


### PR DESCRIPTION
### Description
Update gossip scoring configuration API's:
* Expose setter for `GossipPeerScoreparamsBuilder.behaviourPenaltyThreshold`
* Add `Gossip.updateTopicScoreParams` to allow for topic scoring params to be updated after startup