### PR TITLE
Optimize gossip score calculation

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
@@ -73,7 +73,7 @@ data class CappedValueDelegate<C : Comparable<C>>(
 ) : ReadWriteProperty<Any?, C> {
 
     override fun getValue(thisRef: Any?, property: KProperty<*>): C {
-        val oldValue = value
+        val oldValue = this.value
         val v1 = if (value > upperBound()) upperBoundVal() else value
         value = if (value < lowerBound()) lowerBoundVal() else v1
         if (oldValue != value) {
@@ -83,7 +83,7 @@ data class CappedValueDelegate<C : Comparable<C>>(
     }
 
     override fun setValue(thisRef: Any?, property: KProperty<*>, value: C) {
-        val oldValue = value
+        val oldValue = this.value
         this.value = value
         if (oldValue != value) {
             updateListener(value)

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -2,7 +2,6 @@ package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
-import io.libp2p.core.multiformats.Protocol
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.anyComplete
 import io.libp2p.etc.types.copy
@@ -34,9 +33,6 @@ const val MaxBackoffEntries = 10 * 1024
 const val MaxIAskedEntries = 256
 const val MaxPeerIHaveEntries = 256
 const val MaxIWantRequestsEntries = 10 * 1024
-
-fun P2PService.PeerHandler.getIP(): String? =
-    streamHandler.stream.connection.remoteAddress().getStringComponent(Protocol.IP4)
 
 fun P2PService.PeerHandler.isOutbound() = streamHandler.stream.connection.isInitiator
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -103,6 +103,7 @@ open class GossipRouter @JvmOverloads constructor(
         score.notifyDisconnected(peer)
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
+        acceptRequestsWhitelist -= peer
         collectPeerMessage(peer) // discard them
         super.onPeerDisconnected(peer)
     }

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -199,6 +199,8 @@ open class GossipRouter @JvmOverloads constructor(
         if (peerScore >= acceptRequestsWhitelistThresholdScore) {
             acceptRequestsWhitelist[peer] =
                 AcceptRequestsWhitelistEntry(curTime + acceptRequestsWhitelistDuration.toMillis())
+        } else {
+            acceptRequestsWhitelist -= peer
         }
 
         return peerScore >= score.params.graylistThreshold

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -55,9 +55,15 @@ open class GossipRouter @JvmOverloads constructor(
     subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()
 ) : AbstractRouter(subscriptionTopicSubscriptionFilter, params.maxGossipMessageSize) {
 
+    // The idea behind choosing these specific default values for acceptRequestsWhitelist was
+    // - from one side are pretty small and safe: peer unlikely be able to drop its score to `graylist`
+    //   with 128 messages. But even if so then it's not critical to accept some extra messages before
+    //   blocking - not too much space for DoS here
+    // - from the other side param values are pretty high to yield good performance gain
     val acceptRequestsWhitelistThresholdScore = 0
     val acceptRequestsWhitelistMaxMessages = 128
     val acceptRequestsWhitelistDuration = 1.seconds
+
     val score by lazy { GossipScore(scoreParams, executor, curTimeMillis) }
     val fanout: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
     val mesh: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -84,7 +84,7 @@ class GossipScore(
         fun meshMessageDeliveriesDeficitSqr() = meshMessageDeliveriesDeficit().pow(2)
 
         fun calcTopicScore(): Double {
-            val curTime = curTimeMillis();
+            val curTime = curTimeMillis()
             if (cacheValid && prevParams === params && curTime - prevTime < recalcMaxDuration.toMillis()) {
                 return cachedScore
             }

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -6,7 +6,6 @@ import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.cappedDouble
 import io.libp2p.etc.types.createLRUMap
 import io.libp2p.etc.types.millis
-import io.libp2p.etc.types.seconds
 import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.Topic
@@ -28,9 +27,9 @@ class GossipScore(
 ) {
 
     inner class TopicScores(val topic: Topic) {
-        private val recalcMaxDuration = 1.seconds
         private val params: GossipTopicScoreParams
             get() = topicParams[topic]
+        private val recalcMaxDuration = params.timeInMeshQuantum
         private var cachedScore: Double = 0.0
         private var cacheValid: Boolean = false
         private var prevParams = params

--- a/src/test/kotlin/io/libp2p/etc/types/DelegatesTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/DelegatesTest.kt
@@ -14,8 +14,7 @@ class DelegatesTest {
 
     var cappedValueDelegate: Double by CappedValueDelegate(0.0, { min.get() }, { minVal.get() }, { max.get() }, { maxVal.get() })
     var cappedInt: Int by cappedVar(10, 5, 20)
-    var cappedDouble: Double by cappedDouble(0.0, 1.0) { max.get() }
-
+    var cappedDouble: Double by cappedDouble(0.0, 1.0, { -> max.get() })
     @Test
     fun cappedVarTest() {
         Assertions.assertEquals(10, cappedInt)

--- a/src/test/kotlin/io/libp2p/etc/types/DelegatesTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/DelegatesTest.kt
@@ -21,10 +21,11 @@ class DelegatesTest {
         { minVal.get() },
         { max.get() },
         { maxVal.get() },
-        { cappedValueDelegateUpdates += it })
+        { cappedValueDelegateUpdates += it }
+    )
 
     var cappedInt: Int by cappedVar(10, 5, 20)
-    var cappedDouble: Double by cappedDouble(0.0, 1.0, { -> max.get() }, { cappedDoubleUpdates += it } )
+    var cappedDouble: Double by cappedDouble(0.0, 1.0, { -> max.get() }, { cappedDoubleUpdates += it })
     var blackhole: Double = 0.0
 
     @Test

--- a/src/test/kotlin/io/libp2p/etc/types/DelegatesTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/DelegatesTest.kt
@@ -12,9 +12,21 @@ class DelegatesTest {
     val min = AtomicDouble(5.0)
     val minVal = AtomicDouble(0.0)
 
-    var cappedValueDelegate: Double by CappedValueDelegate(0.0, { min.get() }, { minVal.get() }, { max.get() }, { maxVal.get() })
+    val cappedValueDelegateUpdates = mutableListOf<Double>()
+    val cappedDoubleUpdates = mutableListOf<Double>()
+
+    var cappedValueDelegate: Double by CappedValueDelegate(
+        0.0,
+        { min.get() },
+        { minVal.get() },
+        { max.get() },
+        { maxVal.get() },
+        { cappedValueDelegateUpdates += it })
+
     var cappedInt: Int by cappedVar(10, 5, 20)
-    var cappedDouble: Double by cappedDouble(0.0, 1.0, { -> max.get() })
+    var cappedDouble: Double by cappedDouble(0.0, 1.0, { -> max.get() }, { cappedDoubleUpdates += it } )
+    var blackhole: Double = 0.0
+
     @Test
     fun cappedVarTest() {
         Assertions.assertEquals(10, cappedInt)
@@ -88,5 +100,45 @@ class DelegatesTest {
         cappedValueDelegate = 6.0
         min.set(7.0)
         assertThat(cappedValueDelegate).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `test cappedDouble update callback`() {
+        cappedDouble = 5.0
+        assertThat(cappedDoubleUpdates).containsExactly(5.0)
+
+        cappedDouble = 5.0
+        assertThat(cappedDoubleUpdates).containsExactly(5.0)
+
+        cappedDouble = 4.0
+        assertThat(cappedDoubleUpdates).containsExactly(5.0, 4.0)
+
+        max.set(3.0)
+        blackhole = cappedDouble
+        assertThat(cappedDoubleUpdates).containsExactly(5.0, 4.0, 3.0)
+
+        max.set(5.0)
+        blackhole = cappedDouble
+        assertThat(cappedDoubleUpdates).containsExactly(5.0, 4.0, 3.0)
+    }
+
+    @Test
+    fun `test cappedValueDelegate update callback`() {
+        cappedValueDelegate = 8.0
+        assertThat(cappedValueDelegateUpdates).containsExactly(8.0)
+
+        cappedValueDelegate = 8.0
+        assertThat(cappedValueDelegateUpdates).containsExactly(8.0)
+
+        cappedValueDelegate = 7.0
+        assertThat(cappedValueDelegateUpdates).containsExactly(8.0, 7.0)
+
+        max.set(6.0)
+        blackhole = cappedValueDelegate
+        assertThat(cappedValueDelegateUpdates).containsExactly(8.0, 7.0, 15.0)
+
+        max.set(7.0)
+        blackhole = cappedValueDelegate
+        assertThat(cappedValueDelegateUpdates).containsExactly(8.0, 7.0, 15.0)
     }
 }


### PR DESCRIPTION
## Description
On every inbound message `GossipRouter` checks the peer score against `graylistThreshold` to decide whether a message should be processed or ignored. 
The score calculation is not too cheap for extensive inbound message flow. 

The following optimizations were made: 
- Cache `PeerHandler.getIP()` 
- Cache topic score unless any of input values changed or time changed more than `timeInMeshQuantum`. Ideally that should be made on something like Rx `ObservableValue`s and `Bindings` to look nicer but that seems like an overkill for this change 
-  Maintain whitelist with expiration and message count for `acceptRequestsFrom` for peers with non-negative score to avoid score recalculation for every inbound message. The basic idea behind is that `graylistThreshold` should be far below `0` and if a peer has the score 0 or above we could unconditionally accept some reasonable amount of  its messages for say 1 second. 

## Performance 

Profiling graph of `AbstractRouter.onInbound()`

### Before
![изображение](https://user-images.githubusercontent.com/8173857/112479615-45232f80-8d86-11eb-8aec-c43ebdcb2250.png)

### After
![изображение](https://user-images.githubusercontent.com/8173857/112479782-6ab03900-8d86-11eb-9ade-bdefc92830fa.png)
