### PR TITLE
Add method to retrieve peer score by peerId

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -3,6 +3,7 @@ package io.libp2p.pubsub.gossip
 import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
 import io.libp2p.core.P2PChannel
+import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.core.multistream.ProtocolDescriptor
@@ -21,6 +22,10 @@ class Gossip @JvmOverloads constructor(
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
         router.score.updateTopicParams(scoreParams)
+    }
+
+    fun getGossipScore(peerId: PeerId): Double {
+        return router.score.getCachedScore(peerId)
     }
 
     override val protocolDescriptor =

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -3,7 +3,6 @@ package io.libp2p.pubsub.gossip
 import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
 import io.libp2p.core.P2PChannel
-import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.core.multistream.ProtocolDescriptor
@@ -22,10 +21,6 @@ class Gossip @JvmOverloads constructor(
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
         router.score.updateTopicParams(scoreParams)
-    }
-
-    fun getGossipScore(peerId: PeerId): GossipScore.PeerScores {
-        return router.score.getPeerScore(peerId)
     }
 
     override val protocolDescriptor =

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
 import io.libp2p.core.P2PChannel
 import io.libp2p.core.Stream
+import io.libp2p.core.PeerId
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.core.multistream.ProtocolDescriptor
 import io.libp2p.core.pubsub.PubsubApi
@@ -21,6 +22,10 @@ class Gossip @JvmOverloads constructor(
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
         router.score.updateTopicParams(scoreParams)
+    }
+
+    fun getGossipScore(peerId: PeerId): GossipScore.PeerScores {
+        return router.score.getPeerScore(peerId)
     }
 
     override val protocolDescriptor =

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -3,8 +3,8 @@ package io.libp2p.pubsub.gossip
 import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
 import io.libp2p.core.P2PChannel
-import io.libp2p.core.Stream
 import io.libp2p.core.PeerId
+import io.libp2p.core.Stream
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.core.multistream.ProtocolDescriptor
 import io.libp2p.core.pubsub.PubsubApi

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -118,7 +118,7 @@ class GossipScore(
         val ips = mutableSetOf<String>()
         var connectedTimeMillis: Long = 0
         var disconnectedTimeMillis: Long = 0
-        var cachedScore: AtomicReference<Double> = AtomicReference(0.0)
+        val cachedScore: AtomicReference<Double> = AtomicReference(0.0)
 
         val topicScores = mutableMapOf<Topic, TopicScores>()
         var behaviorPenalty: Double by cappedDouble(0.0, peerParams.decayToZero)

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -193,6 +193,10 @@ class GossipScore(
         }
     }
 
+    fun getPeerScore(peerId: PeerId): PeerScores {
+        return peerScores.computeIfAbsent(peerId) { PeerScores() }
+    }
+
     fun notifyDisconnected(peer: P2PService.PeerHandler) {
         getPeerScores(peer).topicScores.filter { it.value.inMesh() }.forEach { t, _ ->
             notifyPruned(peer, t)

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipScoreTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipScoreTest.kt
@@ -180,10 +180,12 @@ class GossipScoreTest {
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
         score.notifyUnseenValidMessage(peer, msg)
         assertThat(score.score(peer)).isEqualTo(2.0)
+        assertThat(score.getCachedScore(peer.peerId)).isEqualTo(2.0)
 
         // Refresh to decay score
         score.refreshScores()
         assertThat(score.score(peer)).isEqualTo(1.0)
+        assertThat(score.getCachedScore(peer.peerId)).isEqualTo(1.0)
     }
 
     @Test


### PR DESCRIPTION
Added a method to retrieve peer score by peerId. This is needed for [making gossip scoring information visible to users](https://github.com/ConsenSys/teku/issues/3557).