### PR TITLE
Add a timeout to the connection upgrade process

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -271,7 +271,7 @@ abstract class AbstractRouter(
                     when {
                         err != null -> logger.warn("Exception while handling message from peer $peer: ${it.first}", err)
                         res == ValidationResult.Invalid -> logger.debug("Invalid pubsub message from peer $peer: ${it.first}")
-                        res == ValidationResult.Ignore -> logger.debug("Ingnoring pubsub message from peer $peer: ${it.first}")
+                        res == ValidationResult.Ignore -> logger.trace("Ignoring pubsub message from peer $peer: ${it.first}")
                         else -> {
                             newValidatedMessages(singletonList(it.first), peer)
                             flushAllPending()

--- a/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
@@ -9,9 +9,7 @@ import io.libp2p.etc.types.forward
 import io.libp2p.transport.ConnectionUpgrader
 import io.netty.channel.Channel
 import io.netty.channel.ChannelInitializer
-import org.apache.logging.log4j.LogManager
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
 
 class ConnectionBuilder(
     private val transport: Transport,

--- a/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
@@ -18,7 +18,6 @@ class ConnectionBuilder(
     private val initiator: Boolean,
     private val remotePeerId: PeerId? = null
 ) : ChannelInitializer<Channel>() {
-
     val connectionEstablished = CompletableFuture<Connection>()
 
     override fun initChannel(ch: Channel) {

--- a/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
@@ -21,8 +21,6 @@ class ConnectionBuilder(
     private val remotePeerId: PeerId? = null
 ) : ChannelInitializer<Channel>() {
 
-    private val log = LogManager.getLogger(ConnectionBuilder::class.java)
-
     val connectionEstablished = CompletableFuture<Connection>()
 
     override fun initChannel(ch: Channel) {

--- a/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/ConnectionBuilder.kt
@@ -38,12 +38,6 @@ class ConnectionBuilder(
                 connHandler.handleConnection(connection)
                 connection
             }
-            .orTimeout(5, TimeUnit.SECONDS)
-            .exceptionally {
-                log.debug("Failed to establish secure channel with {}", ch.remoteAddress(), it)
-                ch.close()
-                throw it
-            }
             .forward(connectionEstablished)
     } // initChannel
 } // ConnectionBuilder


### PR DESCRIPTION
Addresses an issue where connections may leak if the secure channel or muxer establishment process stalls (e.g. because the remote peer doesn't respond). This is done using a rather basic timeout which appears to solve the issue but may not be the most elegant solution.  If the upgrade fails, the channel is closed to prevent the connection leaking.

At minimum we need to make the timeout configurable but it may be that this timeout should be pushed down into the individual handlers (eg `NoiseXXSecureChannel` and the actual muxing implementations).