### PR TITLE
Throw specialized exception when no suitable peers to broadcast outbound exception

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/Errors.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/Errors.kt
@@ -16,3 +16,8 @@ class MessageAlreadySeenException(message: String) : PubsubException(message)
  * Throw when message validation failed
  */
 class InvalidMessageException(message: String) : PubsubException(message)
+
+/**
+ * Thrown when no suitable peers found to broadcast outbound exception
+ */
+class NoPeersForOutboundMessageException(message: String) : PubsubException(message)

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -14,6 +14,7 @@ import io.libp2p.etc.types.whenTrue
 import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.AbstractRouter
 import io.libp2p.pubsub.MessageId
+import io.libp2p.pubsub.NoPeersForOutboundMessageException
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.PubsubProtocol
 import io.libp2p.pubsub.SeenCache
@@ -360,7 +361,14 @@ open class GossipRouter @JvmOverloads constructor(
 
         mCache += msg
         flushAllPending()
-        return anyComplete(list)
+
+        if (list.isNotEmpty()) {
+            return anyComplete(list)
+        } else {
+            return CompletableFuture.failedFuture(
+                NoPeersForOutboundMessageException("No peers for message topics ${msg.topics} found")
+            )
+        }
     }
 
     override fun subscribe(topic: Topic) {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.anyComplete
+import io.libp2p.etc.types.completedExceptionally
 import io.libp2p.etc.types.copy
 import io.libp2p.etc.types.createLRUMap
 import io.libp2p.etc.types.median
@@ -365,7 +366,7 @@ open class GossipRouter @JvmOverloads constructor(
         if (list.isNotEmpty()) {
             return anyComplete(list)
         } else {
-            return CompletableFuture.failedFuture(
+            return completedExceptionally(
                 NoPeersForOutboundMessageException("No peers for message topics ${msg.topics} found")
             )
         }


### PR DESCRIPTION
Throw specialized exception when no suitable peers to broadcast outbound exception. 
Currently an abstract `io.libp2p.etc.types.NothingToCompleteException` is thrown. 
The final intention is to get rid of noisy DEBUG logs with stacktrace in Teku client