### PR TITLE
Improve multistream implementation 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,9 +51,9 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${log4j2Version}")
     implementation("javax.xml.bind:jaxb-api:2.3.1")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.4.2")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.4.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
     testImplementation("io.mockk:mockk:1.10.0")
     testRuntimeOnly("org.mockito:mockito-core:3.3.3")
     testImplementation("org.mockito:mockito-junit-jupiter:3.3.3")

--- a/src/main/kotlin/io/libp2p/core/multistream/MultistreamProtocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multistream/MultistreamProtocol.kt
@@ -1,9 +1,9 @@
 package io.libp2p.core.multistream
 
 import io.libp2p.core.P2PChannelHandler
-import io.libp2p.multistream.MultistreamProtocolV1Impl
+import io.libp2p.multistream.MultistreamProtocolDebugV1
 
-val MultistreamProtocolV1: MultistreamProtocolDebug = MultistreamProtocolV1Impl
+val MultistreamProtocolV1: MultistreamProtocolDebug = MultistreamProtocolDebugV1()
 
 interface MultistreamProtocol {
 

--- a/src/main/kotlin/io/libp2p/etc/util/netty/TotalTimeoutHandler.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/TotalTimeoutHandler.kt
@@ -1,0 +1,32 @@
+package io.libp2p.etc.util.netty
+
+import io.netty.channel.ChannelException
+import io.netty.channel.ChannelHandlerAdapter
+import io.netty.channel.ChannelHandlerContext
+import java.time.Duration
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+class TotalTimeoutHandler(val timeout: Duration) : ChannelHandlerAdapter() {
+    private var timeoutTask: ScheduledFuture<*>? = null
+
+    override fun handlerAdded(ctx: ChannelHandlerContext) {
+        timeoutTask = ctx.executor().schedule({ onTimeout(ctx) }, timeout.toMillis(), TimeUnit.MILLISECONDS)
+    }
+
+    override fun handlerRemoved(ctx: ChannelHandlerContext) {
+        cancel()
+    }
+
+    private fun cancel() {
+        timeoutTask?.cancel(false)
+    }
+
+    private fun onTimeout(ctx: ChannelHandlerContext) {
+        ctx.fireExceptionCaught(TotalTimeoutException())
+        ctx.close()
+        timeoutTask = null
+    }
+}
+
+class TotalTimeoutException : ChannelException()

--- a/src/main/kotlin/io/libp2p/etc/util/netty/TotalTimeoutHandler.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/netty/TotalTimeoutHandler.kt
@@ -7,6 +7,9 @@ import java.time.Duration
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
+/**
+ * Handler which closes connection on timeout unless removed
+ */
 class TotalTimeoutHandler(val timeout: Duration) : ChannelHandlerAdapter() {
     private var timeoutTask: ScheduledFuture<*>? = null
 

--- a/src/main/kotlin/io/libp2p/multistream/MultistreamImpl.kt
+++ b/src/main/kotlin/io/libp2p/multistream/MultistreamImpl.kt
@@ -25,11 +25,15 @@ class MultistreamImpl<TController>(
             }
             pushHandler(
                 if (ch.isInitiator) {
-                    Negotiator.createRequesterInitializer(negotiationTimeLimit,
-                        *bindings.flatMap { it.protocolDescriptor.announceProtocols }.toTypedArray())
+                    Negotiator.createRequesterInitializer(
+                        negotiationTimeLimit,
+                        *bindings.flatMap { it.protocolDescriptor.announceProtocols }.toTypedArray()
+                    )
                 } else {
-                    Negotiator.createResponderInitializer(negotiationTimeLimit,
-                        bindings.map { it.protocolDescriptor.protocolMatcher })
+                    Negotiator.createResponderInitializer(
+                        negotiationTimeLimit,
+                        bindings.map { it.protocolDescriptor.protocolMatcher }
+                    )
                 }
             )
             postHandler?.also {

--- a/src/main/kotlin/io/libp2p/multistream/MultistreamImpl.kt
+++ b/src/main/kotlin/io/libp2p/multistream/MultistreamImpl.kt
@@ -4,13 +4,15 @@ import io.libp2p.core.P2PChannel
 import io.libp2p.core.P2PChannelHandler
 import io.libp2p.core.multistream.Multistream
 import io.libp2p.core.multistream.ProtocolBinding
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
 
 class MultistreamImpl<TController>(
     initList: List<ProtocolBinding<TController>> = listOf(),
     val preHandler: P2PChannelHandler<*>? = null,
-    val postHandler: P2PChannelHandler<*>? = null
+    val postHandler: P2PChannelHandler<*>? = null,
+    val negotiationTimeLimit: Duration = DEFAULT_NEGOTIATION_TIME_LIMIT
 ) : Multistream<TController> {
 
     override val bindings: MutableList<ProtocolBinding<TController>> =
@@ -23,9 +25,11 @@ class MultistreamImpl<TController>(
             }
             pushHandler(
                 if (ch.isInitiator) {
-                    Negotiator.createRequesterInitializer(*bindings.flatMap { it.protocolDescriptor.announceProtocols }.toTypedArray())
+                    Negotiator.createRequesterInitializer(negotiationTimeLimit,
+                        *bindings.flatMap { it.protocolDescriptor.announceProtocols }.toTypedArray())
                 } else {
-                    Negotiator.createResponderInitializer(bindings.map { it.protocolDescriptor.protocolMatcher })
+                    Negotiator.createResponderInitializer(negotiationTimeLimit,
+                        bindings.map { it.protocolDescriptor.protocolMatcher })
                 }
             )
             postHandler?.also {

--- a/src/main/kotlin/io/libp2p/multistream/MultistreamProtocolDebug.kt
+++ b/src/main/kotlin/io/libp2p/multistream/MultistreamProtocolDebug.kt
@@ -7,8 +7,6 @@ import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.etc.types.seconds
 import java.time.Duration
 
-val MultistreamProtocolV1Impl: MultistreamProtocolDebug = MultistreamProtocolDebugV1()
-
 val DEFAULT_NEGOTIATION_TIME_LIMIT = 10.seconds
 
 class MultistreamProtocolDebugV1(

--- a/src/main/kotlin/io/libp2p/multistream/MultistreamProtocolDebug.kt
+++ b/src/main/kotlin/io/libp2p/multistream/MultistreamProtocolDebug.kt
@@ -4,29 +4,26 @@ import io.libp2p.core.P2PChannelHandler
 import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.multistream.MultistreamProtocolDebug
 import io.libp2p.core.multistream.ProtocolBinding
+import io.libp2p.etc.types.seconds
+import java.time.Duration
 
 val MultistreamProtocolV1Impl: MultistreamProtocolDebug = MultistreamProtocolDebugV1()
 
-private class MultistreamProtocolDebugV1 : MultistreamProtocolDebug {
+val DEFAULT_NEGOTIATION_TIME_LIMIT = 10.seconds
+
+class MultistreamProtocolDebugV1(
+    private val negotiationTimeLimit: Duration = DEFAULT_NEGOTIATION_TIME_LIMIT,
+    private val preHandler: P2PChannelHandler<*>? = null,
+    private val postHandler: P2PChannelHandler<*>? = null
+) : MultistreamProtocolDebug {
 
     override val version = "1.0.0"
 
     override fun <TController> createMultistream(bindings: List<ProtocolBinding<TController>>) =
-        MultistreamImpl(bindings)
+        MultistreamImpl(bindings, preHandler, postHandler, negotiationTimeLimit)
 
     override fun copyWithHandlers(
         preHandler: P2PChannelHandler<*>?,
         postHandler: P2PChannelHandler<*>?
-    ): MultistreamProtocol = MultistreamProtocolHandledV1(preHandler, postHandler)
-}
-
-private class MultistreamProtocolHandledV1(
-    private val preHandler: P2PChannelHandler<*>? = null,
-    private val postHandler: P2PChannelHandler<*>? = null
-) : MultistreamProtocol {
-
-    override val version = "1.0.0"
-
-    override fun <TController> createMultistream(bindings: List<ProtocolBinding<TController>>) =
-        MultistreamImpl(bindings, preHandler, postHandler)
+    ): MultistreamProtocol = MultistreamProtocolDebugV1(negotiationTimeLimit, preHandler, postHandler)
 }

--- a/src/main/kotlin/io/libp2p/multistream/Negotiator.kt
+++ b/src/main/kotlin/io/libp2p/multistream/Negotiator.kt
@@ -39,14 +39,16 @@ class ProtocolNegotiationException(message: String) : RuntimeException(message)
  * We set a read timeout of 10 seconds.
  */
 object Negotiator {
-    const val MAX_MULTISTREAM_MESSAGE_LENGTH = 1024
-    const val MAX_PROTOCOL_ID_LENGTH = MAX_MULTISTREAM_MESSAGE_LENGTH - 1
-
     private const val TIMEOUT_MILLIS: Long = 10_000
     private const val MULTISTREAM_PROTO = "/multistream/1.0.0"
 
+    private val MESSAGE_SUFFIX = '\n'
     private val NA = "na"
     private val LS = "ls"
+
+    val MAX_MULTISTREAM_MESSAGE_LENGTH = 1024
+    val MESSAGE_SUFFIX_LENGTH = MESSAGE_SUFFIX.toString().toByteArray(Charsets.UTF_8).size
+    val MAX_PROTOCOL_ID_LENGTH = MAX_MULTISTREAM_MESSAGE_LENGTH - MESSAGE_SUFFIX_LENGTH
 
     fun createRequesterInitializer(vararg protocols: String): ChannelInitializer<Channel> {
         return nettyInitializer {
@@ -80,7 +82,7 @@ object Negotiator {
             ProtobufVarint32LengthFieldPrepender(),
             StringDecoder(Charsets.UTF_8),
             StringEncoder(Charsets.UTF_8),
-            StringSuffixCodec('\n')
+            StringSuffixCodec(MESSAGE_SUFFIX)
         )
 
         var headerRead = false

--- a/src/main/kotlin/io/libp2p/multistream/Negotiator.kt
+++ b/src/main/kotlin/io/libp2p/multistream/Negotiator.kt
@@ -36,7 +36,7 @@ class ProtocolNegotiationException(message: String) : RuntimeException(message)
  * user event on the context. If we exhaust all our options without agreement, we emit the [ProtocolNegotiationFailed]
  * event.
  *
- * We set a read timeout of 10 seconds.
+ * The negotiation is expected to complete within specified time limit else the connection is closed
  */
 object Negotiator {
     private const val MULTISTREAM_PROTO = "/multistream/1.0.0"

--- a/src/test/kotlin/io/libp2p/core/HostTranportsTest.kt
+++ b/src/test/kotlin/io/libp2p/core/HostTranportsTest.kt
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledIf
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import java.util.concurrent.TimeUnit
 
@@ -63,7 +62,22 @@ abstract class TcpTransportHostTest(
     secureChannelCtor,
     ::TcpTransport,
     "/ip4/127.0.0.1/tcp/4002"
-)
+) {
+
+    @Test
+    fun largeEchoOverSecureConnection() {
+        val echo = Echo().dial(
+            clientHost,
+            serverHost.peerId,
+            Multiaddr(listenAddress)
+        )
+
+        val echoController = echo.controller.get(5, TimeUnit.SECONDS)
+        val largeMsg = (0..20000).map { "Hello" }.joinToString("")
+
+        assertEquals(largeMsg, echoController.echo(largeMsg).get(10, TimeUnit.SECONDS))
+    }
+}
 
 abstract class HostTransportsTest(
     val secureChannelCtor: SecureChannelCtor,
@@ -268,21 +282,6 @@ abstract class HostTransportsTest(
 
         assertEquals("hello", echoController.echo("hello").get(1, TimeUnit.SECONDS))
         assertEquals("world", echoController.echo("world").get(1, TimeUnit.SECONDS))
-    }
-
-    @DisabledIf("junitTags.contains('ws-transport')")
-    @Test
-    fun largeEchoOverSecureConnection() {
-        val echo = Echo().dial(
-            clientHost,
-            serverHost.peerId,
-            Multiaddr(listenAddress)
-        )
-
-        val echoController = echo.controller.get(5, TimeUnit.SECONDS)
-        val largeMsg = (0..20000).map { "Hello" }.joinToString("")
-
-        assertEquals(largeMsg, echoController.echo(largeMsg).get(10, TimeUnit.SECONDS))
     }
 
     @Test

--- a/src/test/kotlin/io/libp2p/multistream/MultistreamTest.kt
+++ b/src/test/kotlin/io/libp2p/multistream/MultistreamTest.kt
@@ -1,5 +1,7 @@
 package io.libp2p.multistream
 
+import io.libp2p.etc.types.millis
+import io.libp2p.etc.types.seconds
 import io.libp2p.etc.types.writeUvarint
 import io.libp2p.multistream.Negotiator.MAX_MULTISTREAM_MESSAGE_LENGTH
 import io.libp2p.tools.Echo
@@ -10,9 +12,63 @@ import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.nio.charset.StandardCharsets
 
 class MultistreamTest {
+
+    @Timeout(10)
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testShouldTimeoutOnTooLongNegotiation(initiator: Boolean) {
+        val channel = TestStreamChannel(
+            initiator,
+            Echo(),
+            LoggingHandler("1", LogLevel.ERROR),
+            multistreamProtocol = MultistreamProtocolDebugV1(500.millis)
+        )
+
+        Assertions.assertTrue(channel.isOpen)
+
+        while (!Thread.currentThread().isInterrupted) {
+            if (channel.runScheduledPendingTasks() < 0) {
+                break
+            }
+        }
+
+        Assertions.assertFalse(channel.isOpen)
+    }
+
+    @Test
+    fun testShouldNotTimeoutWhenNegotiationSucceeds() {
+        val channel1 = TestStreamChannel(
+            true,
+            Echo(),
+            LoggingHandler("1", LogLevel.ERROR),
+            multistreamProtocol = MultistreamProtocolDebugV1(1.seconds)
+        )
+
+        val channel2 = TestStreamChannel(
+            false,
+            Echo(),
+            LoggingHandler("2", LogLevel.ERROR),
+            multistreamProtocol = MultistreamProtocolDebugV1(1.seconds)
+        )
+
+        while (!channel1.controllerFuture.isDone) {
+            channel2.writeInbound(channel1.readOutbound())
+            channel1.writeInbound(channel2.readOutbound())
+        }
+
+        // timeout tasks should be cancelled
+        Assertions.assertTrue(channel1.runScheduledPendingTasks() < 0)
+        Assertions.assertTrue(channel2.runScheduledPendingTasks() < 0)
+
+        Assertions.assertTrue(channel1.isOpen)
+        Assertions.assertTrue(channel2.isOpen)
+    }
 
     @Test
     fun testShouldCloseConnectionOnLongMessage() {

--- a/src/test/kotlin/io/libp2p/multistream/MultistreamTest.kt
+++ b/src/test/kotlin/io/libp2p/multistream/MultistreamTest.kt
@@ -1,5 +1,7 @@
 package io.libp2p.multistream
 
+import io.libp2p.etc.types.writeUvarint
+import io.libp2p.multistream.Negotiator.MAX_MULTISTREAM_MESSAGE_LENGTH
 import io.libp2p.tools.Echo
 import io.libp2p.tools.TestStreamChannel
 import io.netty.buffer.ByteBuf
@@ -11,6 +13,20 @@ import org.junit.jupiter.api.Test
 import java.nio.charset.StandardCharsets
 
 class MultistreamTest {
+
+    @Test
+    fun testShouldCloseConnectionOnLongMessage() {
+        val channel1 = TestStreamChannel(
+            false,
+            Echo(),
+            LoggingHandler("1", LogLevel.ERROR)
+        )
+
+        val buf = Unpooled.buffer().writeUvarint(MAX_MULTISTREAM_MESSAGE_LENGTH + 1)
+        channel1.writeInbound(buf)
+
+        Assertions.assertFalse(channel1.isOpen)
+    }
 
     @Test
     fun testZeroRoundtripNegotiation() {

--- a/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/SecureChannelTest.kt
@@ -5,6 +5,7 @@ import io.libp2p.core.crypto.PrivKey
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multistream.ProtocolMatcher
 import io.libp2p.core.security.SecureChannel
+import io.libp2p.etc.types.seconds
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
 import io.libp2p.multistream.Negotiator
@@ -123,9 +124,9 @@ abstract class SecureChannelTest(
         selector: ChannelInboundHandlerAdapter
     ): TestChannel {
         val negotiator = if (initiator) {
-            Negotiator.createRequesterInitializer(announce)
+            Negotiator.createRequesterInitializer(10.seconds, announce)
         } else {
-            Negotiator.createResponderInitializer(listOf(ProtocolMatcher.strict(announce)))
+            Negotiator.createResponderInitializer(10.seconds, listOf(ProtocolMatcher.strict(announce)))
         }
 
         return TestChannel(


### PR DESCRIPTION
- Limit the length of a single protocol id string to 1024
- Limit the total time spend for a protocol negotiation 