### PR TITLE
Fix remote PeerId check on dial 

### DIFF
--- a/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
@@ -100,7 +100,7 @@ class Multiaddr(val components: List<Pair<Protocol, ByteArray>>) {
      * Appends `/p2p/` component if absent or checks that existing and supplied ids are equal
      * @throws IllegalArgumentException if existing `/p2p/` identity doesn't match [peerId]
      */
-    fun withPeerId(peerId: PeerId) = withComponent(PEER_ID_PROTOCOL, peerId.bytes)
+    fun withP2P(peerId: PeerId) = withComponent(Protocol.P2P, peerId.bytes)
 
     /**
      * Appends new component if absent or checks that existing and supplied component values are equal

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multiaddr.kt
@@ -114,6 +114,12 @@ class Multiaddr(val components: List<Pair<Protocol, ByteArray>>) {
     }
 
     /**
+     * Returns [Multiaddr] with concatenated components of `this` and [other] `Multiaddr`
+     * No cross component checks or merge is performed
+     */
+    fun concatenated(other: Multiaddr) = Multiaddr(this.components + other.components)
+
+    /**
      * Merges components of this [Multiaddr] with [other]
      * Has the same effect as appending [other] components subsequently by [withComponent]
      * @throws IllegalArgumentException if any of `this` component value doesn't match the value for the same protocol in [other]

--- a/src/main/kotlin/io/libp2p/core/multiformats/MultiaddrDns.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/MultiaddrDns.kt
@@ -72,7 +72,7 @@ class MultiaddrDns {
             else
                 addressMatrix[0].flatMap { parent ->
                     crossProduct(addressMatrix.subList(1, addressMatrix.size))
-                        .map { child -> Multiaddr(parent, child) }
+                        .map { child -> parent.merged(child) }
                 }
         }
 

--- a/src/main/kotlin/io/libp2p/core/multiformats/MultiaddrDns.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/MultiaddrDns.kt
@@ -72,7 +72,7 @@ class MultiaddrDns {
             else
                 addressMatrix[0].flatMap { parent ->
                     crossProduct(addressMatrix.subList(1, addressMatrix.size))
-                        .map { child -> parent.merged(child) }
+                        .map { child -> parent.concatenated(child) }
                 }
         }
 

--- a/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -147,6 +147,9 @@ enum class Protocol(val code: Int, val size: Int, val typeName: String) {
     }
 
     companion object {
+        @JvmStatic
+        val PEER_ID_PROTOCOLS = listOf(P2P, IPFS)
+
         private val byCode = values().associate { p -> p.code to p }
         private val byName = values().associate { p -> p.typeName to p }
 

--- a/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt
+++ b/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt
@@ -29,8 +29,9 @@ interface ProtocolBinding<out TController> {
      */
     @JvmDefault
     fun dial(host: Host, addrWithPeer: Multiaddr): StreamPromise<out TController> {
-        val (peerId, addr) = addrWithPeer.toPeerIdAndAddr()
-        return dial(host, peerId, addr)
+        val peerId = addrWithPeer.getPeerId()
+            ?: throw IllegalArgumentException("Expected remote peer ID in the dial Multiaddr: $addrWithPeer")
+        return dial(host, peerId, addrWithPeer)
     }
 
     @JvmDefault

--- a/src/main/kotlin/io/libp2p/host/HostImpl.kt
+++ b/src/main/kotlin/io/libp2p/host/HostImpl.kt
@@ -43,7 +43,7 @@ class HostImpl(
 
         network.transports.forEach {
             listening.addAll(
-                it.listenAddresses().map { Multiaddr(it, peerId) }
+                it.listenAddresses().map { it.withPeerId(peerId) }
             )
         }
 

--- a/src/main/kotlin/io/libp2p/host/HostImpl.kt
+++ b/src/main/kotlin/io/libp2p/host/HostImpl.kt
@@ -43,7 +43,7 @@ class HostImpl(
 
         network.transports.forEach {
             listening.addAll(
-                it.listenAddresses().map { it.withPeerId(peerId) }
+                it.listenAddresses().map { it.withP2P(peerId) }
             )
         }
 

--- a/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
+++ b/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
@@ -71,7 +71,7 @@ class NetworkImpl(
         connections.find { it.secureSession().remoteId == id }
             ?.apply { return CompletableFuture.completedFuture(this) }
 
-        val addrsWithP2P = addrs.map { it.withPeerId(id) }
+        val addrsWithP2P = addrs.map { it.withP2P(id) }
 
         // 1. check that some transport can dial at least one addr.
         // 2. trigger dials in parallel via all transports.

--- a/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
+++ b/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
@@ -71,15 +71,17 @@ class NetworkImpl(
         connections.find { it.secureSession().remoteId == id }
             ?.apply { return CompletableFuture.completedFuture(this) }
 
+        val addrsWithP2P = addrs.map { it.withPeerId(id) }
+
         // 1. check that some transport can dial at least one addr.
         // 2. trigger dials in parallel via all transports.
         // 3. when the first dial succeeds, cancel all pending dials and return the connection. // TODO cancel
         // 4. if no emitted dial succeeds, or if we time out, fail the future. make sure to cancel
         //    pending dials to avoid leaking.
-        val connectionFuts = addrs.mapNotNull { addr ->
+        val connectionFuts = addrsWithP2P.mapNotNull { addr ->
             transports.firstOrNull { tpt -> tpt.handles(addr) }?.let { addr to it }
-        }.map {
-            it.second.dial(it.first, createHookedConnHandler(connectionHandler))
+        }.map { (addr, transport) ->
+            transport.dial(addr, createHookedConnHandler(connectionHandler))
         }
         return anyComplete(connectionFuts)
     }

--- a/src/main/kotlin/io/libp2p/security/SecureChannelError.kt
+++ b/src/main/kotlin/io/libp2p/security/SecureChannelError.kt
@@ -6,7 +6,10 @@ open class SecureChannelError : Exception {
     constructor(message: String) : super(message)
 }
 
-open class SecureHandshakeError : SecureChannelError()
+open class SecureHandshakeError : SecureChannelError {
+    constructor() : super()
+    constructor(message: String) : super(message)
+}
 
 class InvalidRemotePubKey : SecureHandshakeError()
 class InvalidInitialPacket : SecureHandshakeError()

--- a/src/test/java/io/libp2p/core/HostTestJava.java
+++ b/src/test/java/io/libp2p/core/HostTestJava.java
@@ -59,7 +59,7 @@ public class HostTestJava {
         Assertions.assertEquals(0, clientHost.listenAddresses().size());
         Assertions.assertEquals(1, serverHost.listenAddresses().size());
         Assertions.assertEquals(
-                localListenAddress + "/ipfs/" + serverHost.getPeerId(),
+                localListenAddress + "/p2p/" + serverHost.getPeerId(),
                 serverHost.listenAddresses().get(0).toString()
         );
 

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -196,20 +196,21 @@ class MultiaddrTest {
         val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
         val peerId = testPeerId()
 
-        val addr = Multiaddr(parentAddr, peerId)
-        assertEquals("/ip4/127.0.0.1/tcp/20000/ipfs/QmULzn6KtFUCKpkFymEUgUvkLtv9j2Eo4utZPELmQEebR6", addr.toString())
+        val addr = parentAddr.withPeerId(peerId)
+        assertEquals("/ip4/127.0.0.1/tcp/20000/p2p/QmULzn6KtFUCKpkFymEUgUvkLtv9j2Eo4utZPELmQEebR6", addr.toString())
+        assertEquals(addr.withPeerId(peerId), addr)
 
-        assertThrows(java.lang.IllegalArgumentException::class.java) {
-            Multiaddr(addr, peerId) // parent already has peer id
+        assertThrows(IllegalArgumentException::class.java) {
+            addr.withPeerId(PeerId.random()) // parent has another peer id
         }
     }
 
     @Test
-    fun concatTwoMultiaddrs() {
+    fun `merged() should succeed with distinct components`() {
         val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
         val childAddr = Multiaddr("/p2p-circuit/dns4/trousers.org")
 
-        val addr = Multiaddr(parentAddr, childAddr)
+        val addr = parentAddr.merged(childAddr)
         assertEquals(
             "/ip4/127.0.0.1/tcp/20000/p2p-circuit/dns4/trousers.org",
             addr.toString()
@@ -217,8 +218,30 @@ class MultiaddrTest {
     }
 
     @Test
+    fun `merged() should succeed with matching component values`() {
+        val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
+        val childAddr = Multiaddr("/ip4/127.0.0.1/p2p-circuit/dns4/trousers.org")
+
+        val addr = parentAddr.merged(childAddr)
+        assertEquals(
+            "/ip4/127.0.0.1/tcp/20000/p2p-circuit/dns4/trousers.org",
+            addr.toString()
+        )
+    }
+
+    @Test
+    fun `merged() should throw with non-matching component values`() {
+        val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
+        val childAddr = Multiaddr("/ip4/127.0.0.1/tcp/30000/p2p-circuit/dns4/trousers.org")
+
+        assertThrows(IllegalArgumentException::class.java) {
+            parentAddr.merged(childAddr)
+        }
+    }
+
+    @Test
     fun testSplitIntoPeerAndMultiaddr() {
-        val addr = Multiaddr("/ip4/127.0.0.1/tcp/20000/ipfs/QmULzn6KtFUCKpkFymEUgUvkLtv9j2Eo4utZPELmQEebR6")
+        val addr = Multiaddr("/ip4/127.0.0.1/tcp/20000/p2p/QmULzn6KtFUCKpkFymEUgUvkLtv9j2Eo4utZPELmQEebR6")
 
         val (splitPeerId, addrWithoutPeer) = addr.toPeerIdAndAddr()
         assertEquals(testPeerId(), splitPeerId)

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -240,16 +240,11 @@ class MultiaddrTest {
     }
 
     @Test
-    fun testSplitIntoPeerAndMultiaddr() {
+    fun testGetPeerId() {
         val addr = Multiaddr("/ip4/127.0.0.1/tcp/20000/p2p/QmULzn6KtFUCKpkFymEUgUvkLtv9j2Eo4utZPELmQEebR6")
 
-        val (splitPeerId, addrWithoutPeer) = addr.toPeerIdAndAddr()
-        assertEquals(testPeerId(), splitPeerId)
-        assertEquals("/ip4/127.0.0.1/tcp/20000", addrWithoutPeer.toString())
-
-        assertThrows(java.lang.IllegalArgumentException::class.java) {
-            addrWithoutPeer.toPeerIdAndAddr()
-        }
+        assertEquals(testPeerId(), addr.getPeerId())
+        assertEquals(Multiaddr("/ip4/127.0.0.1/tcp/20000").getPeerId(), null)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -206,6 +206,18 @@ class MultiaddrTest {
     }
 
     @Test
+    fun `concatenated() should just concat components`() {
+        val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
+        val childAddr = Multiaddr("/p2p-circuit/ip4/127.0.0.2")
+
+        val addr = parentAddr.concatenated(childAddr)
+        assertEquals(
+            "/ip4/127.0.0.1/tcp/20000/p2p-circuit/ip4/127.0.0.2",
+            addr.toString()
+        )
+    }
+
+    @Test
     fun `merged() should succeed with distinct components`() {
         val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
         val childAddr = Multiaddr("/p2p-circuit/dns4/trousers.org")

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -196,12 +196,12 @@ class MultiaddrTest {
         val parentAddr = Multiaddr("/ip4/127.0.0.1/tcp/20000")
         val peerId = testPeerId()
 
-        val addr = parentAddr.withPeerId(peerId)
+        val addr = parentAddr.withP2P(peerId)
         assertEquals("/ip4/127.0.0.1/tcp/20000/p2p/QmULzn6KtFUCKpkFymEUgUvkLtv9j2Eo4utZPELmQEebR6", addr.toString())
-        assertEquals(addr.withPeerId(peerId), addr)
+        assertEquals(addr.withP2P(peerId), addr)
 
         assertThrows(IllegalArgumentException::class.java) {
-            addr.withPeerId(PeerId.random()) // parent has another peer id
+            addr.withP2P(PeerId.random()) // parent has another peer id
         }
     }
 

--- a/src/test/kotlin/io/libp2p/pubsub/GoInteropTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/GoInteropTest.kt
@@ -89,7 +89,7 @@ class GoInteropTest {
 
     val idPrivateKey: PrivKey = generateKeyPair(KEY_TYPE.SECP256K1, random = SecureRandom(byteArrayOf(0))).first
     val daemonPeerId = PeerId.fromPubKey(idPrivateKey.publicKey())
-    val skFile = File.createTempFile("p2pd_pkey_",".bin").also { file ->
+    val skFile = File.createTempFile("p2pd_pkey_", ".bin").also { file ->
         file.outputStream().use { os ->
             os.write(idPrivateKey.bytes())
         }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/TwoGossipHostTestBase.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/TwoGossipHostTestBase.kt
@@ -103,7 +103,7 @@ abstract class TwoGossipHostTestBase {
 
     protected fun connect() {
         val connect = host1.network
-            .connect(host2.peerId, Multiaddr.fromString("/ip4/127.0.0.1/tcp/40001"))
+            .connect(host2.peerId, Multiaddr.fromString("/ip4/127.0.0.1/tcp/40001/p2p/" + host2.peerId))
         connect.get(10, TimeUnit.SECONDS)
 
         waitFor { gossipConnected(router1) }

--- a/src/test/kotlin/io/libp2p/security/plaintext/PlaintextInsecureChannelTest.kt
+++ b/src/test/kotlin/io/libp2p/security/plaintext/PlaintextInsecureChannelTest.kt
@@ -1,10 +1,10 @@
 package io.libp2p.security.plaintext
 
-import io.libp2p.security.SecureChannelTest
+import io.libp2p.security.SecureChannelTestBase
 import org.junit.jupiter.api.Tag
 
 @Tag("secure-channel")
-class PlaintextInsecureChannelTest : SecureChannelTest(
+class PlaintextInsecureChannelTest : SecureChannelTestBase(
     ::PlaintextInsecureChannel,
     "/plaintext/2.0.0"
 )

--- a/src/test/kotlin/io/libp2p/tools/TestChannel.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestChannel.kt
@@ -1,7 +1,9 @@
 package io.libp2p.tools
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import io.libp2p.core.PeerId
 import io.libp2p.etc.CONNECTION
+import io.libp2p.etc.REMOTE_PEER_ID
 import io.libp2p.etc.types.lazyVar
 import io.libp2p.etc.util.netty.nettyInitializer
 import io.libp2p.transport.implementation.ConnectionOverNetty
@@ -28,7 +30,8 @@ class TestChannel(
     id: String = "test",
     initiator: Boolean,
     vararg handlers: ChannelHandler?,
-    val dummyIp: String = "0.0.0.0"
+    val dummyIp: String = "0.0.0.0",
+    remotePeerId: PeerId? = null
 ) :
     EmbeddedChannel(
         TestChannelId(id),
@@ -43,6 +46,12 @@ class TestChannel(
         },
         *handlers
     ) {
+
+    init {
+        if (remotePeerId != null) {
+            attr(REMOTE_PEER_ID).set(remotePeerId)
+        }
+    }
 
     var link: TestChannel? = null
     val sentMsgCount = AtomicLong()


### PR DESCRIPTION
- Some `Multiaddr` class refactorings 
- Verify remote `PeerId` on connect