### PR TITLE
Respect message list limits when creating messages to send

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -94,9 +94,11 @@ abstract class AbstractRouter(
         addPendingRpcPart(
             toPeer,
             Rpc.RPC.newBuilder()
-                .addSubscriptions(Rpc.RPC.SubOpts.newBuilder()
-                    .setSubscribe(subscriptionStatus == SubscriptionStatus.Subscribed)
-                    .setTopicid(topic))
+                .addSubscriptions(
+                    Rpc.RPC.SubOpts.newBuilder()
+                        .setSubscribe(subscriptionStatus == SubscriptionStatus.Subscribed)
+                        .setTopicid(topic)
+                )
                 .build()
         )
     }
@@ -370,7 +372,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun subscribe(topic: Topic) {
-        activePeers.forEach { addPendingSubscription(it, topic, SubscriptionStatus.Subscribed)}
+        activePeers.forEach { addPendingSubscription(it, topic, SubscriptionStatus.Subscribed) }
         subscribedTopics += topic
     }
 
@@ -382,7 +384,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun unsubscribe(topic: Topic) {
-        activePeers.forEach { addPendingSubscription(it, topic, SubscriptionStatus.Unsubscribed)}
+        activePeers.forEach { addPendingSubscription(it, topic, SubscriptionStatus.Unsubscribed) }
         subscribedTopics -= topic
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -97,7 +97,13 @@ abstract class AbstractRouter(
         if (msgs.isEmpty()) return null
 
         val bld = Rpc.RPC.newBuilder()
-        msgs.forEach { bld.mergeFrom(it) }
+        msgs.forEach {
+            if (validateMergedMessageListLimits(it, bld)) {
+                bld.mergeFrom(it)
+            } else {
+                addPendingRpcPart(toPeer, it)
+            }
+        }
         return bld.build()
     }
 
@@ -284,6 +290,10 @@ abstract class AbstractRouter(
     }
 
     internal open fun validateMessageListLimits(msg: Rpc.RPC): Boolean {
+        return true
+    }
+
+    internal open fun validateMergedMessageListLimits(msg1: Rpc.RPCOrBuilder, msg2: Rpc.RPCOrBuilder): Boolean {
         return true
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -113,7 +113,7 @@ open class GossipRouter @JvmOverloads constructor(
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
-        collectPeerMessage(peer) // discard them
+        collectPeerMessages(peer) // discard them
         super.onPeerDisconnected(peer)
     }
 
@@ -208,7 +208,7 @@ open class GossipRouter @JvmOverloads constructor(
         return peerScore >= score.params.graylistThreshold
     }
 
-    override fun validateMessageListLimits(msg: Rpc.RPC): Boolean {
+    override fun validateMessageListLimits(msg: Rpc.RPCOrBuilder): Boolean {
         return params.maxPublishedMessages?.let { msg.publishCount <= it } ?: true &&
             params.maxTopicsPerPublishedMessage?.let { msg.publishList.none { m -> m.topicIDsCount > it } } ?: true &&
             params.maxSubscriptions?.let { msg.subscriptionsCount <= it } ?: true &&
@@ -217,26 +217,6 @@ open class GossipRouter @JvmOverloads constructor(
             params.maxGraftMessages?.let { msg.control?.graftCount ?: 0 <= it } ?: true &&
             params.maxPruneMessages?.let { msg.control?.pruneCount ?: 0 <= it } ?: true &&
             params.maxPeersPerPruneMessage?.let { msg.control?.pruneList?.none { p -> p.peersCount > it } } ?: true
-    }
-
-    override fun validateMergedMessageListLimits(msg1: Rpc.RPCOrBuilder, msg2: Rpc.RPCOrBuilder): Boolean {
-        return params.maxPublishedMessages?.let { msg1.publishCount + msg2.publishCount <= it } ?: true &&
-
-            params.maxTopicsPerPublishedMessage?.let { msg1.publishList.none { m -> m.topicIDsCount > it } } ?: true &&
-            params.maxTopicsPerPublishedMessage?.let { msg2.publishList.none { m -> m.topicIDsCount > it } } ?: true &&
-
-            params.maxSubscriptions?.let { msg1.subscriptionsCount + msg2.subscriptionsCount <= it } ?: true &&
-            params.maxIHaveLength.let { countIHaveMessageIds(msg1) + countIHaveMessageIds(msg2) <= it } &&
-            params.maxIWantMessageIds?.let { countIWantMessageIds(msg1) + countIWantMessageIds(msg2) <= it } ?: true &&
-            params.maxGraftMessages?.let {
-                (msg1.control?.graftCount ?: 0) + (msg2.control?.graftCount ?: 0) <= it
-            } ?: true &&
-            params.maxPruneMessages?.let {
-                (msg1.control?.pruneCount ?: 0) + (msg2.control?.pruneCount ?: 0) <= it
-            } ?: true &&
-
-            params.maxPeersPerPruneMessage?.let { msg1.control?.pruneList?.none { p -> p.peersCount > it } } ?: true &&
-            params.maxPeersPerPruneMessage?.let { msg2.control?.pruneList?.none { p -> p.peersCount > it } } ?: true
     }
 
     private fun countIWantMessageIds(msg: Rpc.RPCOrBuilder): Int {

--- a/src/test/kotlin/io/libp2p/pubsub/AbstractRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/AbstractRouterTest.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub
 
+import io.libp2p.etc.types.toProtobuf
 import io.libp2p.pubsub.TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -8,7 +9,7 @@ import java.util.concurrent.CompletableFuture
 
 class AbstractRouterTest {
 
-    class TestRouter(val msgValidator: (Rpc.RPCOrBuilder) -> Boolean) :
+    private class TestRouter(val msgValidator: (Rpc.RPCOrBuilder) -> Boolean) :
         AbstractRouter(AllowAllTopicSubscriptionFilter()) {
         override val protocol = PubsubProtocol.Floodsub
         override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> =
@@ -21,7 +22,8 @@ class AbstractRouterTest {
         fun testMerge(parts: List<Rpc.RPC>): List<Rpc.RPC> = mergeMessageParts(parts)
     }
 
-    fun Collection<Rpc.RPC>.merge() = this.fold(Rpc.RPC.newBuilder()) { bld, part -> bld.mergeFrom(part) }.build()
+    private fun Collection<Rpc.RPC>.merge(): Rpc.RPC =
+        this.fold(Rpc.RPC.newBuilder()) { bld, part -> bld.mergeFrom(part) }.build()
 
     @Test
     fun `test many subscriptions split to several messages`() {
@@ -57,6 +59,29 @@ class AbstractRouterTest {
         val msgs = router.testMerge(parts)
 
         assertThat(msgs).hasSize(1)
+        assertThat(msgs.merge()).isEqualTo(parts.merge())
+    }
+
+    @Test
+    fun `test that split doesn't result in topic publish before subscribe`() {
+        val router = TestRouter { it.subscriptionsCount <= 5 }
+        val parts = (0 until 6).map {
+            Rpc.RPC.newBuilder().addSubscriptions(
+                Rpc.RPC.SubOpts.newBuilder()
+                    .setTopicid("topic-$it")
+                    .setSubscribe(true)
+                    .build()
+            ).build()
+        } + Rpc.RPC.newBuilder().addPublish(
+            Rpc.Message.newBuilder()
+                .addTopicIDs("topic-5")
+                .setData(byteArrayOf(11).toProtobuf())
+        ).build()
+        val msgs = router.testMerge(parts)
+
+        assertThat(msgs).hasSize(2)
+        assertThat(msgs[0].publishCount).isZero()
+        assertThat(msgs[1].publishCount).isEqualTo(1)
         assertThat(msgs.merge()).isEqualTo(parts.merge())
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/AbstractRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/AbstractRouterTest.kt
@@ -1,0 +1,62 @@
+package io.libp2p.pubsub
+
+import io.libp2p.pubsub.TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+import java.util.concurrent.CompletableFuture
+
+class AbstractRouterTest {
+
+    class TestRouter(val msgValidator: (Rpc.RPCOrBuilder) -> Boolean) :
+        AbstractRouter(AllowAllTopicSubscriptionFilter()) {
+        override val protocol = PubsubProtocol.Floodsub
+        override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> =
+            CompletableFuture.completedFuture(null)
+
+        override fun broadcastInbound(msgs: List<PubsubMessage>, receivedFrom: PeerHandler) {}
+        override fun processControl(ctrl: Rpc.ControlMessage, receivedFrom: PeerHandler) {}
+
+        override fun validateMessageListLimits(msg: Rpc.RPCOrBuilder) = msgValidator(msg)
+        fun testMerge(parts: List<Rpc.RPC>): List<Rpc.RPC> = mergeMessageParts(parts)
+    }
+
+    fun Collection<Rpc.RPC>.merge() = this.fold(Rpc.RPC.newBuilder()) { bld, part -> bld.mergeFrom(part) }.build()
+
+    @Test
+    fun `test many subscriptions split to several messages`() {
+        val router = TestRouter { it.subscriptionsCount <= 5 }
+        val parts = (0 until 14).map {
+            Rpc.RPC.newBuilder().addSubscriptions(
+                Rpc.RPC.SubOpts.newBuilder()
+                    .setTopicid("topic-$it")
+                    .setSubscribe(true)
+                    .build()
+            ).build()
+        }
+        val msgs = router.testMerge(parts)
+
+        assertThat(msgs)
+            .hasSize(3)
+            .allMatch { it.subscriptionsCount <= 5 }
+
+        assertThat(msgs.merge()).isEqualTo(parts.merge())
+    }
+
+    @Test
+    fun `test few subscriptions don't split to several messages`() {
+        val router = TestRouter { it.subscriptionsCount <= 5 }
+        val parts = (0 until 5).map {
+            Rpc.RPC.newBuilder().addSubscriptions(
+                Rpc.RPC.SubOpts.newBuilder()
+                    .setTopicid("topic-$it")
+                    .setSubscribe(true)
+                    .build()
+            ).build()
+        }
+        val msgs = router.testMerge(parts)
+
+        assertThat(msgs).hasSize(1)
+        assertThat(msgs.merge()).isEqualTo(parts.merge())
+    }
+}

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/SubscriptionsLimitTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/SubscriptionsLimitTest.kt
@@ -1,0 +1,81 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.pubsub.MessageApi
+import io.libp2p.core.pubsub.Subscriber
+import io.libp2p.core.pubsub.Topic
+import io.libp2p.etc.types.toByteArray
+import io.libp2p.etc.types.toByteBuf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class SubscriptionsLimitTest : TwoGossipHostTestBase() {
+    override val params = GossipParams(maxSubscriptions = 5, floodPublish = true)
+
+    @Test
+    fun `new peer subscribed to many topics`() {
+        val topics = (0..13).map { Topic("topic-$it") }.toTypedArray()
+        gossip1.subscribe( Subscriber {}, *topics)
+        val messages2 = mutableListOf<MessageApi>()
+        gossip2.subscribe( Subscriber { messages2 += it }, *topics)
+
+        connect()
+        waitForSubscribed(router1, "topic-13")
+        waitForSubscribed(router2, "topic-13")
+
+        val topics1 = router1.getPeerTopics().join().values.first()
+        assertThat(topics1).containsExactlyInAnyOrderElementsOf(topics.map { it.topic })
+        val topics2 = router2.getPeerTopics().join().values.first()
+        assertThat(topics2).containsExactlyInAnyOrderElementsOf(topics.map { it.topic })
+
+        val msg1Promise =
+            gossip1.createPublisher(null).publish(byteArrayOf(11).toByteBuf(), Topic("topic-13"))
+
+        assertDoesNotThrow { msg1Promise.join() }
+        waitFor { messages2.isNotEmpty() }
+        assertThat(messages2)
+            .hasSize(1)
+            .allMatch {
+                it.topics == listOf(Topic("topic-13")) &&
+                        it.data.toByteArray().contentEquals(byteArrayOf(11))
+            }
+    }
+
+    @Test
+    fun `new peer subscribed to few topics`() {
+        val topics = (0..4).map { Topic("topic-$it") }.toTypedArray()
+        gossip1.subscribe( Subscriber { }, *topics)
+        gossip2.subscribe( Subscriber { }, *topics)
+
+        connect()
+        waitForSubscribed(router1, "topic-4")
+        waitForSubscribed(router2, "topic-4")
+
+        val topics1 = router1.getPeerTopics().join().values.first()
+        assertThat(topics1).containsExactlyInAnyOrderElementsOf(topics.map { it.topic })
+        val topics2 = router2.getPeerTopics().join().values.first()
+        assertThat(topics2).containsExactlyInAnyOrderElementsOf(topics.map { it.topic })
+    }
+
+    @Test
+    fun `existing peer subscribed to many topics`() {
+        gossip1.subscribe( Subscriber { }, Topic("test-topic"))
+        gossip2.subscribe( Subscriber { }, Topic("test-topic"))
+
+        connect()
+        waitForSubscribed(router1, "test-topic")
+        waitForSubscribed(router2, "test-topic")
+
+        val topics = (0..13).map { Topic("topic-$it") }.toTypedArray()
+        gossip1.subscribe( Subscriber { }, *topics)
+        gossip2.subscribe( Subscriber { }, *topics)
+
+        waitForSubscribed(router1, "topic-13")
+        waitForSubscribed(router2, "topic-13")
+
+        val topics1 = router1.getPeerTopics().join().values.first()
+        assertThat(topics1).containsExactlyInAnyOrderElementsOf(topics.map { it.topic } + "test-topic")
+        val topics2 = router2.getPeerTopics().join().values.first()
+        assertThat(topics2).containsExactlyInAnyOrderElementsOf(topics.map { it.topic } + "test-topic")
+    }
+}

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/SubscriptionsLimitTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/SubscriptionsLimitTest.kt
@@ -15,9 +15,9 @@ class SubscriptionsLimitTest : TwoGossipHostTestBase() {
     @Test
     fun `new peer subscribed to many topics`() {
         val topics = (0..13).map { Topic("topic-$it") }.toTypedArray()
-        gossip1.subscribe( Subscriber {}, *topics)
+        gossip1.subscribe(Subscriber {}, *topics)
         val messages2 = mutableListOf<MessageApi>()
-        gossip2.subscribe( Subscriber { messages2 += it }, *topics)
+        gossip2.subscribe(Subscriber { messages2 += it }, *topics)
 
         connect()
         waitForSubscribed(router1, "topic-13")
@@ -37,15 +37,15 @@ class SubscriptionsLimitTest : TwoGossipHostTestBase() {
             .hasSize(1)
             .allMatch {
                 it.topics == listOf(Topic("topic-13")) &&
-                        it.data.toByteArray().contentEquals(byteArrayOf(11))
+                    it.data.toByteArray().contentEquals(byteArrayOf(11))
             }
     }
 
     @Test
     fun `new peer subscribed to few topics`() {
         val topics = (0..4).map { Topic("topic-$it") }.toTypedArray()
-        gossip1.subscribe( Subscriber { }, *topics)
-        gossip2.subscribe( Subscriber { }, *topics)
+        gossip1.subscribe(Subscriber { }, *topics)
+        gossip2.subscribe(Subscriber { }, *topics)
 
         connect()
         waitForSubscribed(router1, "topic-4")
@@ -59,16 +59,16 @@ class SubscriptionsLimitTest : TwoGossipHostTestBase() {
 
     @Test
     fun `existing peer subscribed to many topics`() {
-        gossip1.subscribe( Subscriber { }, Topic("test-topic"))
-        gossip2.subscribe( Subscriber { }, Topic("test-topic"))
+        gossip1.subscribe(Subscriber { }, Topic("test-topic"))
+        gossip2.subscribe(Subscriber { }, Topic("test-topic"))
 
         connect()
         waitForSubscribed(router1, "test-topic")
         waitForSubscribed(router2, "test-topic")
 
         val topics = (0..13).map { Topic("topic-$it") }.toTypedArray()
-        gossip1.subscribe( Subscriber { }, *topics)
-        gossip2.subscribe( Subscriber { }, *topics)
+        gossip1.subscribe(Subscriber { }, *topics)
+        gossip2.subscribe(Subscriber { }, *topics)
 
         waitForSubscribed(router1, "topic-13")
         waitForSubscribed(router2, "topic-13")


### PR DESCRIPTION
Somewhat naive approach to ensuring created messages are within the message list limits.  Before adding each message part to the new message all list limits are checked. If limits would be exceeded the message part is re-added to the pending pool.

Some concerns:
1. Is it too expensive to perform these checks for every part we add?
2. Is it possible to deduplicate the checks in `validateMessageListLimits` (single message) and `validateMergedMessageListLimits` (two messages)?
3. Is there a better approach to handling parts that don't fit than just adding them back to the queue?
4. Will something actually trigger sending the remaining parts in a later message or do they get stuck?
5. How do we test this properly?