### PR TITLE
Change hardcoded sleep to waiter pattern

### DIFF
--- a/src/test/kotlin/io/libp2p/transport/TransportTests.kt
+++ b/src/test/kotlin/io/libp2p/transport/TransportTests.kt
@@ -70,7 +70,14 @@ abstract class TransportTests {
         dialConnections(client, address, connectionCount)
         assertEquals(connectionCount, client.activeConnections)
 
-        SECONDS.sleep(5) // let things settle
+        // give the server time to acknowledge connections
+        for (attempt in 1..30) {
+            if (connectionCount == inboundConnections.count) {
+                break
+            }
+            SECONDS.sleep(1)
+        }
+
         assertEquals(connectionCount, inboundConnections.count, "Connections not acknowledged by server")
         assertEquals(connectionCount, server.activeConnections)
 


### PR DESCRIPTION
There was a test that was failing on my laptop that was due to a timed sleep that was not long enough. Changing the wait to 20 seconds would fix the problem, but that makes the build slow for everyone. This will bail within a second of acknowledging all of the connections. If it hasn't acknowledged all of the connections within 30 seconds, the test will fail.