### PR TITLE
Forbid negative uvarint values

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/types/ByteArrayExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/ByteArrayExt.kt
@@ -77,12 +77,9 @@ fun ByteArray.readUvarint(): Pair<Long, ByteArray>? {
 
     var index = 0
     var result: Long? = null
-    for (i in 0..9) {
+    for (i in 0..8) {
         val b = this.get(index++).toUByte().toShort()
         if (b < 0x80) {
-            if (i == 9 && b > 1) {
-                return null
-            }
             result = x or (b.toLong() shl s)
             break
         }
@@ -90,9 +87,10 @@ fun ByteArray.readUvarint(): Pair<Long, ByteArray>? {
         s += 7
     }
 
-    if (result != null && result <= size) {
+    // Check that we didn't break early.
+    if (result != null && index <= size) {
         return Pair(result, slice(IntRange(index, size - 1)).toByteArray())
     }
 
-    return null
+    throw IllegalStateException("uvarint too long")
 }

--- a/src/main/kotlin/io/libp2p/etc/types/ByteBufExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/ByteBufExt.kt
@@ -29,7 +29,7 @@ fun ByteBuf.readUvarint(): Long {
     var s = 0
 
     val originalReaderIndex = readerIndex()
-    for (i in 0..9) {
+    for (i in 0..8) {
         if (!this.isReadable) {
             // buffer contains just a fragment of uint
             readerIndex(originalReaderIndex)
@@ -37,9 +37,6 @@ fun ByteBuf.readUvarint(): Long {
         }
         val b = this.readUnsignedByte()
         if (b < 0x80) {
-            if (i == 9 && b > 1) {
-                throw IllegalStateException("Overflow reading uvarint")
-            }
             return x or (b.toLong() shl s)
         }
         x = x or (b.toLong() and 0x7f shl s)

--- a/src/main/kotlin/io/libp2p/etc/types/ByteBufExt.kt
+++ b/src/main/kotlin/io/libp2p/etc/types/ByteBufExt.kt
@@ -9,6 +9,10 @@ import java.lang.Integer.min
 fun ByteBuf.writeUvarint(value: Int): ByteBuf = writeUvarint(value.toLong())
 
 fun ByteBuf.writeUvarint(value: Long): ByteBuf {
+    if (value < 0) {
+        throw IllegalArgumentException("uvarint value must be positive")
+    }
+
     var v = value
     while (v >= 0x80) {
         this.writeByte((v or 0x80).toInt())

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrTest.kt
@@ -191,7 +191,6 @@ class MultiaddrTest {
         fun invalidSerializations() = listOf(
             // Invalid var lengths
             Arguments.of(Protocol.DNS4.encoded + 1L.toVarInt()),
-            Arguments.of(Protocol.DNS4.encoded + (-1L).toVarInt()),
             Arguments.of(Protocol.DNS4.encoded + 10L.toVarInt() + ByteArray(9, { 0 })),
             Arguments.of(Protocol.DNS4.encoded + 65535L.toVarInt() + ByteArray(9, { 0 })),
             Arguments.of(Protocol.DNS4.encoded + Int.MAX_VALUE.toLong().toVarInt() + ByteArray(9, { 0 })),

--- a/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
@@ -59,6 +59,13 @@ class UvarintTest {
     }
 
     @Test
+    fun testRoundTripMaximumValue() {
+        val buf = Unpooled.buffer()
+        buf.writeUvarint(Long.MAX_VALUE)
+        assertEquals(Long.MAX_VALUE, buf.readUvarint())
+    }
+
+    @Test
     fun testEncodeNegativeValue() {
         val buf = Unpooled.buffer()
         val exception = assertThrows<IllegalArgumentException> { buf.writeUvarint(-1) }

--- a/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
@@ -34,9 +34,25 @@ class UvarintTest {
 
     @Test
     fun testDecodeInvalid() {
-        val buf = Unpooled.buffer()
-        buf.writeBytes(ByteArray(11) { 0x81.toByte() })
+        // Helper function for creating uvarint buffer.
+        fun byteArrayOfInts(vararg ints: Int) = ByteArray(ints.size) {
+            pos ->
+            ints[pos].toByte()
+        }
 
+        val arr: ByteArray = byteArrayOfInts(
+            Integer.parseInt("10000000", 2), // 1
+            Integer.parseInt("10000000", 2), // 2
+            Integer.parseInt("10000000", 2), // 3
+            Integer.parseInt("10000000", 2), // 4
+            Integer.parseInt("10000000", 2), // 5
+            Integer.parseInt("10000000", 2), // 6
+            Integer.parseInt("10000000", 2), // 7
+            Integer.parseInt("10000000", 2), // 8
+            Integer.parseInt("10000000", 2), // 9
+            Integer.parseInt("00000001", 2) // 10
+        )
+        val buf = Unpooled.copiedBuffer(arr)
         val exception = assertThrows<IllegalStateException> { buf.readUvarint() }
         assertEquals("uvarint too long", exception.message)
     }

--- a/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
@@ -33,13 +33,14 @@ class UvarintTest {
     }
 
     @Test
-    fun testDecodeInvalid() {
+    fun testDecodeTooManyBytes() {
         // Helper function for creating uvarint buffer.
         fun byteArrayOfInts(vararg ints: Int) = ByteArray(ints.size) {
             pos ->
             ints[pos].toByte()
         }
 
+        // Try to decode a uvarint with 10 bytes.
         val arr: ByteArray = byteArrayOfInts(
             Integer.parseInt("10000000", 2), // 1
             Integer.parseInt("10000000", 2), // 2
@@ -55,5 +56,12 @@ class UvarintTest {
         val buf = Unpooled.copiedBuffer(arr)
         val exception = assertThrows<IllegalStateException> { buf.readUvarint() }
         assertEquals("uvarint too long", exception.message)
+    }
+
+    @Test
+    fun testEncodeNegativeValue() {
+        val buf = Unpooled.buffer()
+        val exception = assertThrows<IllegalArgumentException> { buf.writeUvarint(-1) }
+        assertEquals("uvarint value must be positive", exception.message)
     }
 }


### PR DESCRIPTION
When reading over code, I noticed that it was possible to provide a 10-byte
uvarint (variable length integer) instead of the 9-byte maximum. The functions
did not properly catch it.

Also, fix what I believe is a typo in the ByteArray version. It checked the
wrong variable (result vs index) which would almost always result in a null
value. Might as well throw an exception there like the other implementation.

Fixes #225.