### PR TITLE
Fix various typos

### DIFF
--- a/src/main/kotlin/io/libp2p/core/Network.kt
+++ b/src/main/kotlin/io/libp2p/core/Network.kt
@@ -53,7 +53,7 @@ interface Network {
     }
 
     /**
-     * Tries ot connect to the remote peer with [id] PeerId by specified addresses
+     * Tries to connect to the remote peer with [id] PeerId by specified addresses
      * If connection to this peer already exist, returns existing connection
      * Else tries to connect the peer by all supplied addresses in parallel
      * and completes the returned [Future] when any of connections succeeds

--- a/src/main/kotlin/io/libp2p/core/P2PChannel.kt
+++ b/src/main/kotlin/io/libp2p/core/P2PChannel.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture
 
 interface P2PChannel {
     /**
-     * Indicates whether this peer is ether _initiator_ or _responder_ of the underlying channel
+     * Indicates whether this peer is either _initiator_ or _responder_ of the underlying channel
      * Most of the protocols behave either as a _client_ or _server_ correspondingly depending
      * on this flag
      */

--- a/src/main/kotlin/io/libp2p/core/PeerId.kt
+++ b/src/main/kotlin/io/libp2p/core/PeerId.kt
@@ -12,7 +12,7 @@ import kotlin.random.Random
 
 /**
  * Represents the peer identity which is basically derived from the peer public key
- * @property bytes The peer id bytes which size should be  >= 32 and <= 50
+ * @property bytes The peer id bytes which size should be >= 32 and <= 50
  */
 class PeerId(val bytes: ByteArray) {
 

--- a/src/main/kotlin/io/libp2p/core/StreamHandler.kt
+++ b/src/main/kotlin/io/libp2p/core/StreamHandler.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletableFuture
  * @property controller Is completed when the underlying client protocol is initiated.
  *           When the [stream] future is failed this future is also failed
  *           While the [stream] can be created successfully the protocol may fail
- *           to instantiateand this future would fail
+ *           to instantiate and this future would fail
  */
 data class StreamPromise<T>(
     val stream: CompletableFuture<Stream> = CompletableFuture(),

--- a/src/main/kotlin/io/libp2p/core/crypto/Key.kt
+++ b/src/main/kotlin/io/libp2p/core/crypto/Key.kt
@@ -158,7 +158,7 @@ fun marshalPublicKey(pubKey: PubKey): ByteArray =
 
 /**
  * Converts a protobuf serialized private key into its representative object.
- * @param data the byte array of hte protobuf private key.
+ * @param data the byte array of the protobuf private key.
  * @return the equivalent private key.
  */
 fun unmarshalPrivateKey(data: ByteArray): PrivKey {

--- a/src/main/kotlin/io/libp2p/core/multiformats/Multihash.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Multihash.kt
@@ -114,7 +114,7 @@ class Multihash(val bytes: ByteBuf, val desc: Descriptor, val lengthBits: Int, v
         }
         @JvmStatic
         fun digest(desc: Descriptor, content: ByteBuf, lengthBits: Int? = null): Multihash {
-            val entry = REGISTRY[desc] ?: throw InvalidMultihashException("Unrecognized multihash descriptor")
+            val entry = REGISTRY[desc] ?: throw InvalidMultihashException("Unrecognised multihash descriptor")
             val digest = entry.hashFunc(content)
             val l: Int = when {
                 lengthBits == null ->

--- a/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
+++ b/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
@@ -62,7 +62,7 @@ interface PubsubSubscriberApi {
      * result either synchronously ([RESULT_VALID], [RESULT_INVALID] or [RESULT_IGNORE])
      * or asynchronously.
      *
-     * If the [receiver] doesn't validates it should just return [RESULT_VALID]
+     * If the [receiver] doesn't validate it should just return [RESULT_VALID]
      *
      * **Note** the message is not propagated to other peers until **all** receivers
      * subscribed to the topic return [true]. Too long validation procedure may significantly

--- a/src/main/kotlin/io/libp2p/pubsub/Errors.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/Errors.kt
@@ -8,7 +8,7 @@ import io.libp2p.core.Libp2pException
 open class PubsubException(message: String) : Libp2pException(message)
 
 /**
- * Is thrown whe a client sends duplicate message
+ * Is thrown when a client sends duplicate message
  */
 class MessageAlreadySeenException(message: String) : PubsubException(message)
 

--- a/src/main/kotlin/io/libp2p/pubsub/SeenCache.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/SeenCache.kt
@@ -9,7 +9,7 @@ import java.util.LinkedList
 
 /**
  * The interface which is very similar to `Map<PubsubMessage, TValue>`
- * (and can behave as a regular `Map`see [SimpleSeenCache] for example)
+ * (and can behave as a regular `Map` see [SimpleSeenCache] for example)
  * Though the 'key' [PubsubMessage] may be handled slightly differently here in the sense
  * its [PubsubMessage.messageId] can be accessed lazily (see [FastIdSeenCache] for example)
  * and thus [PubsubMessage.hashCode] can't be calculated as for regular `Map`

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -54,7 +54,7 @@ data class GossipParams(
     val DScore: Int = defaultDScore(D),
 
     /**
-     * 	[DOut] sets the quota for the number of outbound connections to maintain in a topic mesh.
+     * [DOut] sets the quota for the number of outbound connections to maintain in a topic mesh.
      * When the mesh is pruned due to over subscription, we make sure that we have outbound connections
      * to at least [DOut] of the survivor peers. This prevents sybil attackers from overwhelming
      * our mesh with incoming connections.
@@ -79,7 +79,7 @@ data class GossipParams(
     val fanoutTTL: Duration = 60.seconds,
 
     /**
-     * [maxGossipMessageSize] determines the max acceptable gossip message size.  Messages larger than this will
+     * [maxGossipMessageSize] determines the max acceptable gossip message size. Messages larger than this will
      * be ignored.
      */
     val maxGossipMessageSize: Int = DEFAULT_MAX_PUBSUB_MESSAGE_SIZE,
@@ -170,7 +170,7 @@ data class GossipParams(
     val maxIHaveLength: Int = 5000,
 
     /**
-     *  [maxIHaveMessages] is the maximum number of IHAVE messages to accept from a peer within a heartbeat.
+     * [maxIHaveMessages] is the maximum number of IHAVE messages to accept from a peer within a heartbeat.
      */
     val maxIHaveMessages: Int = 10,
 
@@ -366,7 +366,7 @@ data class GossipPeerScoreParams(
      * - not following up in IWANT requests for messages advertised with IHAVE.
      *
      * The value of the parameter is the square of the counter over the threshold,
-     * which decays with  [behaviourPenaltyDecay].
+     * which decays with [behaviourPenaltyDecay].
      * The weight of the parameter MUST be negative (or zero to disable).
      */
     val behaviourPenaltyWeight: Weight = 0.0,
@@ -387,9 +387,9 @@ data class GossipPeerScoreParams(
     val retainScore: Duration = 10.minutes
 ) {
     init {
-        check(topicScoreCap >= 0.0, "topicScoreCap should be > 0")
-        check(appSpecificWeight >= 0.0, "appSpecificWeight should be > 0")
-        check(ipColocationFactorWeight <= 0.0, "ipColocationFactorWeight should be < 0")
+        check(topicScoreCap >= 0.0, "topicScoreCap should be >= 0")
+        check(appSpecificWeight >= 0.0, "appSpecificWeight should be >= 0")
+        check(ipColocationFactorWeight <= 0.0, "ipColocationFactorWeight should be <= 0")
         check(
             ipColocationFactorWeight == 0.0 || ipColocationFactorThreshold >= 1,
             "ipColocationFactorThreshold should be >= 1"
@@ -439,7 +439,7 @@ data class GossipTopicScoreParams(
 
     /**
      * P1: time in the mesh
-     * This is the time the peer has ben grafted in the mesh.
+     * This is the time the peer has been grafted in the mesh.
      * The value of of the parameter is the `time/TimeInMeshQuantum`, capped by [timeInMeshCap]
      * The weight of the parameter MUST be positive (or zero to disable).
      */


### PR DESCRIPTION
Two notable exceptions:

  (1) Changed "unrecognized" to "unrecognised" because there are two other
      instances of that word in the same file and this one stood out.

  (2) Added equal sign to a few gossip param error messages. Other params that
      accept zero for disabled values include "=" in the error message.