### PR TITLE
Fix build warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -247,4 +247,5 @@ fun findProperty(s: String) = project.findProperty(s) as String?
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {
     languageVersion = "1.6"
+    allWarningsAsErrors = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,5 +246,5 @@ fun findProperty(s: String) = project.findProperty(s) as String?
 
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {
-    languageVersion = "1.4"
+    languageVersion = "1.6"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ java {
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
     kotlinOptions {
-        freeCompilerArgs = listOf("-Xjvm-default=enable")
+        freeCompilerArgs = listOf("-Xjvm-default=all")
     }
 }
 tasks.withType<Copy> {

--- a/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt
+++ b/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt
@@ -16,7 +16,6 @@ fun interface P2PChannelHandler<TController> {
      */
     fun initChannel(ch: P2PChannel): CompletableFuture<TController>
 
-    @JvmDefault
     fun toStreamHandler(): StreamHandler<TController> = StreamHandler { stream -> initChannel(stream) }
 }
 
@@ -24,7 +23,6 @@ fun interface ChannelVisitor<TChannel : P2PChannel> {
 
     fun visit(channel: TChannel)
 
-    @JvmDefault
     fun toChannelHandler(): P2PChannelHandler<Unit> = P2PChannelHandler {
         visit(it as TChannel)
         CompletableFuture.completedFuture(Unit)

--- a/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt
+++ b/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt
@@ -24,6 +24,7 @@ fun interface ChannelVisitor<TChannel : P2PChannel> {
     fun visit(channel: TChannel)
 
     fun toChannelHandler(): P2PChannelHandler<Unit> = P2PChannelHandler {
+        @Suppress("UNCHECKED_CAST")
         visit(it as TChannel)
         CompletableFuture.completedFuture(Unit)
     }

--- a/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -187,7 +187,7 @@ private val ONION_PARSER: (Protocol, String) -> ByteArray = { _, addr ->
     if (split[0].length != 16) throw IllegalArgumentException("failed to parse addr: $addr not a Tor onion address.")
 
     val base32 = Base32()
-    val base32Text = split[0].toUpperCase()
+    val base32Text = split[0].uppercase()
     if (!base32.isInAlphabet(base32Text)) throw IllegalArgumentException("Invalid Base32 string in the Onion address: $base32Text")
     val onionHostBytes = base32.decode(base32Text)
     val port = split[1].toInt()
@@ -203,5 +203,5 @@ private val ONION_STRINGIFIER: (Protocol, ByteArray) -> String = { _, bytes ->
     val byteBuf = bytes.toByteBuf()
     val host = byteBuf.readBytes(10).toByteArray()
     val port = byteBuf.readUnsignedShort()
-    String(Base32().encode(host)).toLowerCase() + ":" + port
+    String(Base32().encode(host)).lowercase() + ":" + port
 }

--- a/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt
+++ b/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt
@@ -27,14 +27,12 @@ interface ProtocolBinding<out TController> {
     /**
      * Dials the specified peer, and attempts to connect this Protocol
      */
-    @JvmDefault
     fun dial(host: Host, addrWithPeer: Multiaddr): StreamPromise<out TController> {
         val peerId = addrWithPeer.getPeerId()
             ?: throw IllegalArgumentException("Expected remote peer ID in the dial Multiaddr: $addrWithPeer")
         return dial(host, peerId, addrWithPeer)
     }
 
-    @JvmDefault
     fun dial(host: Host, peer: PeerId, vararg addr: Multiaddr): StreamPromise<out TController> {
         return host.newStream(
             protocolDescriptor.announceProtocols,
@@ -53,7 +51,6 @@ interface ProtocolBinding<out TController> {
      * it doesn't know the exact protocol ids. This method converts this binding to
      * _initiator_ binding with explicit protocol id
      */
-    @JvmDefault
     fun toInitiator(protocols: List<ProtocolId>): ProtocolBinding<TController> {
         if (!protocolDescriptor.matchesAny(protocols)) throw Libp2pException("This binding doesn't support $protocols")
         val srcBinding = this

--- a/src/main/kotlin/io/libp2p/core/mux/StreamMuxer.kt
+++ b/src/main/kotlin/io/libp2p/core/mux/StreamMuxer.kt
@@ -40,7 +40,6 @@ interface StreamMuxer : ProtocolBinding<StreamMuxer.Session> {
          */
         fun <T> createStream(protocols: List<ProtocolBinding<T>>): StreamPromise<T>
 
-        @JvmDefault
         fun <T> createStream(protocol: ProtocolBinding<T>): StreamPromise<T> = createStream(listOf(protocol))
     }
 }

--- a/src/main/kotlin/io/libp2p/etc/encode/Base58.kt
+++ b/src/main/kotlin/io/libp2p/etc/encode/Base58.kt
@@ -12,7 +12,7 @@ object Base58 {
     init {
         Arrays.fill(INDEXES, -1)
         for (i in 0 until ALPHABET.length) {
-            INDEXES[ALPHABET[i].toInt()] = i
+            INDEXES[ALPHABET[i].code] = i
         }
     }
 
@@ -62,7 +62,7 @@ object Base58 {
         // Convert the base58-encoded ASCII chars to a base58 byte sequence (base58 digits).
         val input58 = ByteArray(input.length)
         for ((i, c) in input.withIndex()) {
-            val v = if (c.toInt() < 128) INDEXES[c.toInt()].toByte() else -1
+            val v = if (c.code < 128) INDEXES[c.code].toByte() else -1
             if (v < 0) throw RuntimeException("invalid base58 encoded form")
             input58[i] = v
         }

--- a/src/main/kotlin/io/libp2p/host/HostImpl.kt
+++ b/src/main/kotlin/io/libp2p/host/HostImpl.kt
@@ -93,8 +93,8 @@ class HostImpl(
     }
 
     override fun <TController> newStream(protocols: List<String>, conn: Connection): StreamPromise<TController> {
+        @Suppress("UNCHECKED_CAST")
         val binding =
-            @Suppress("UNCHECKED_CAST")
             protocolHandlers.find { it.protocolDescriptor.matchesAny(protocols) } as? ProtocolBinding<TController>
                 ?: throw NoSuchLocalProtocolException("Protocol handler not found: $protocols")
         return conn.muxerSession().createStream(listOf(binding.toInitiator(protocols)))

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -22,7 +22,6 @@ interface PubsubMessage {
     val protobufMessage: Rpc.Message
     val messageId: MessageId
 
-    @JvmDefault
     val topics: List<Topic>
         get() = protobufMessage.topicIDsList
 

--- a/src/main/kotlin/io/libp2p/pubsub/TopicSubscriptionFilter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/TopicSubscriptionFilter.kt
@@ -4,7 +4,6 @@ interface TopicSubscriptionFilter {
 
     fun canSubscribe(topic: Topic): Boolean
 
-    @JvmDefault
     fun filterIncomingSubscriptions(
         subscriptions: Collection<PubsubSubscription>,
         currentlySubscribedTopics: Collection<Topic>

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -224,6 +224,7 @@ class GossipScore(
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun notifyUnseenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
     }
 

--- a/src/test/kotlin/io/libp2p/core/HostTest.kt
+++ b/src/test/kotlin/io/libp2p/core/HostTest.kt
@@ -262,9 +262,9 @@ class HostTest {
         abstract fun interceptRead(buf: ByteBuf): ByteBuf
         abstract fun interceptWrite(buf: ByteBuf): ByteBuf
 
-        override fun visit(stream: Stream) {
+        override fun visit(channel: Stream) {
             var matched = false
-            stream.pushHandler(object : ChannelDuplexHandler() {
+            channel.pushHandler(object : ChannelDuplexHandler() {
 
                 override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
                     if (match(ctx)) {

--- a/src/test/kotlin/io/libp2p/core/HostTest.kt
+++ b/src/test/kotlin/io/libp2p/core/HostTest.kt
@@ -236,6 +236,7 @@ class HostTest {
         override fun visit(channel: TChannel) {
             channel.pushHandler(object : ChannelDuplexHandler() {
                 override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+                    @Suppress("UNCHECKED_CAST")
                     msg as TMessage
                     inboundData += retainMessage(msg)
                     println("####   --> [$id]: $msg")
@@ -243,6 +244,7 @@ class HostTest {
                 }
 
                 override fun write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise) {
+                    @Suppress("UNCHECKED_CAST")
                     msg as TMessage
                     outboundData += retainMessage(msg)
                     println("#### <--   [$id]: $msg")

--- a/src/test/kotlin/io/libp2p/core/multiformats/MultihashTest.kt
+++ b/src/test/kotlin/io/libp2p/core/multiformats/MultihashTest.kt
@@ -113,7 +113,7 @@ class MultihashTest {
     fun `Multihash digest and of`(desc: Multihash.Descriptor, length: Int, content: String, expected: String) {
         val hex = BaseEncoding.base16()
         val mh = Multihash.digest(desc, content.toByteArray().toByteBuf(), if (length == -1) null else length).bytes
-        val decodedMh = hex.decode(expected.toUpperCase()).toByteBuf()
+        val decodedMh = hex.decode(expected.uppercase()).toByteBuf()
         assertEquals(decodedMh, mh)
         with(Multihash.of(mh)) {
             assertEquals(desc, this.desc)

--- a/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -221,7 +221,7 @@ abstract class PubsubRouterTest(val router: RouterCtor) {
 
         val receiveRouters = allRouters - routerCenter
 
-        val msgCount = receiveRouters.sumBy { it.inboundMessages.size }
+        val msgCount = receiveRouters.sumOf { it.inboundMessages.size }
         println("Messages received: $msgCount")
 
         Assertions.assertEquals(receiveRouters.size, msgCount)
@@ -257,8 +257,8 @@ abstract class PubsubRouterTest(val router: RouterCtor) {
             Assertions.assertTrue(routerCenter.inboundMessages.isEmpty())
 
             val receiveRouters = allRouters - routerCenter
-            val msgCount = receiveRouters.sumBy { it.inboundMessages.size }
-            val wireMsgCount = allConnections.sumBy { it.getMessageCount().toInt() }
+            val msgCount = receiveRouters.sumOf { it.inboundMessages.size }
+            val wireMsgCount = allConnections.sumOf { it.getMessageCount().toInt() }
 
             println("Messages received: $msgCount, total wire count: $wireMsgCount")
 
@@ -273,8 +273,8 @@ abstract class PubsubRouterTest(val router: RouterCtor) {
             Assertions.assertTrue(routerCenter.inboundMessages.isEmpty())
 
             val receiveRouters = allRouters - routerCenter
-            val msgCount = receiveRouters.sumBy { it.inboundMessages.size }
-            val wireMsgCount = allConnections.sumBy { it.getMessageCount().toInt() }
+            val msgCount = receiveRouters.sumOf { it.inboundMessages.size }
+            val wireMsgCount = allConnections.sumOf { it.getMessageCount().toInt() }
 
             println("Messages received: $msgCount, total wire count: $wireMsgCount")
 
@@ -324,8 +324,8 @@ abstract class PubsubRouterTest(val router: RouterCtor) {
             fuzz.timeController.addTime(Duration.ofSeconds(5))
 
             val receiveRouters = allRouters - allRouters[0]
-            val msgCount = receiveRouters.sumBy { it.inboundMessages.size }
-            firstCount = allConnections.sumBy { it.getMessageCount().toInt() }
+            val msgCount = receiveRouters.sumOf { it.inboundMessages.size }
+            firstCount = allConnections.sumOf { it.getMessageCount().toInt() }
 
             Assertions.assertEquals(receiveRouters.size, msgCount)
             receiveRouters.forEach { it.inboundMessages.clear() }
@@ -341,8 +341,8 @@ abstract class PubsubRouterTest(val router: RouterCtor) {
             fuzz.timeController.addTime(Duration.ofSeconds(5))
 
             val receiveRouters = allRouters - allRouters[0]
-            val msgCount = receiveRouters.sumBy { it.inboundMessages.size }
-            val wireMsgCount = allConnections.sumBy { it.getMessageCount().toInt() }
+            val msgCount = receiveRouters.sumOf { it.inboundMessages.size }
+            val wireMsgCount = allConnections.sumOf { it.getMessageCount().toInt() }
 
             println(" Messages received: $msgCount, wire count: warm up: $firstCount, regular: ${wireMsgCount - firstCount}")
 //           val missingRouters = receiveRouters.filter { it.inboundMessages.isEmpty() }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -76,7 +76,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
         Assertions.assertTrue(routerCenter.inboundMessages.isEmpty())
 
-        val msgCount1 = receiveRouters.sumBy { it.inboundMessages.size }
+        val msgCount1 = receiveRouters.sumOf { it.inboundMessages.size }
         println("Messages received on first turn: $msgCount1")
 
         // The message shouldn't be broadcasted to all peers (mesh size is limited to 3)
@@ -86,7 +86,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         // heartbeat where ihave/iwant should be used to deliver to all peers
         fuzz.timeController.addTime(Duration.ofSeconds(1))
 
-        val msgCount2 = receiveRouters.sumBy { it.inboundMessages.size }
+        val msgCount2 = receiveRouters.sumOf { it.inboundMessages.size }
         println("Messages received on second turn: $msgCount2")
 
         // now all peers should receive the message
@@ -102,7 +102,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         // all routers should receive after 100 sec
         fuzz.timeController.addTime(Duration.ofSeconds(100))
 
-        val msgCount3 = receiveRouters.sumBy { it.inboundMessages.size }
+        val msgCount3 = receiveRouters.sumOf { it.inboundMessages.size }
         println("Messages received on third turn: $msgCount3")
 
         // now all peers should receive the message

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -52,7 +52,7 @@ class GossipV1_1Tests {
     private fun newMessage(topic: Topic, seqNo: Long, data: ByteArray) =
         DefaultPubsubMessage(newProtoMessage(topic, seqNo, data))
 
-    protected open fun getMessageId(msg: Rpc.Message): MessageId = msg.from.toWBytes() + msg.seqno.toWBytes()
+    protected fun getMessageId(msg: Rpc.Message): MessageId = msg.from.toWBytes() + msg.seqno.toWBytes()
 
     class ManyRoutersTest(
         val mockRouterCount: Int = 10,

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -68,7 +68,7 @@ class GossipV1_1Tests {
         val gossipRouter = router0.router as GossipRouter
         val mockRouters = routers.map { it.router as MockRouter }
 
-        fun connectAll(outbound: Boolean = true) = connect(routers.indices)
+        fun connectAll() = connect(routers.indices)
         fun connect(routerIndexes: IntRange, outbound: Boolean = true): List<SemiduplexConnection> {
             val list =
                 routers.slice(routerIndexes).map {
@@ -349,7 +349,7 @@ class GossipV1_1Tests {
         assertTrue(test.gossipRouter.peers.isEmpty())
         test.fuzz.timeController.addTime(1.seconds)
 
-        val connection = test.router1.connectSemiDuplex(test.router2)
+        test.router1.connectSemiDuplex(test.router2)
         test.fuzz.timeController.addTime(1.seconds)
 
         assertEquals(1, test.gossipRouter.score.peerScores.size)

--- a/src/test/kotlin/io/libp2p/tools/NullHost.kt
+++ b/src/test/kotlin/io/libp2p/tools/NullHost.kt
@@ -39,11 +39,11 @@ open class NullHost : Host {
         TODO("not implemented")
     }
 
-    override fun addStreamVisitor(handler: ChannelVisitor<Stream>) {
+    override fun addStreamVisitor(streamVisitor: ChannelVisitor<Stream>) {
         TODO("Not yet implemented")
     }
 
-    override fun removeStreamVisitor(handler: ChannelVisitor<Stream>) {
+    override fun removeStreamVisitor(streamVisitor: ChannelVisitor<Stream>) {
         TODO("Not yet implemented")
     }
 

--- a/src/test/kotlin/io/libp2p/tools/TestChannel.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestChannel.kt
@@ -86,6 +86,7 @@ class TestChannel(
 
     override fun localAddress(): SocketAddress {
         // dummyIp can actually be null when this method is called in super constructor
+        @Suppress("USELESS_ELVIS")
         return InetSocketAddress(dummyIp ?: "255.255.255.255", 777)
     }
 

--- a/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
+++ b/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt
@@ -7,7 +7,7 @@ import org.apache.logging.log4j.core.Logger
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import java.util.ArrayList
 
-class TestLogAppender : AbstractAppender("test", null, null), AutoCloseable {
+class TestLogAppender : AbstractAppender("test", null, null, false, null), AutoCloseable {
     val logs: MutableList<LogEvent> = ArrayList()
 
     fun install(): TestLogAppender {

--- a/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt
+++ b/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt
@@ -25,19 +25,19 @@ fun parseProtobufBytesToString(str: String): ByteArray {
                         r
                     }
                     'a' -> 0x07
-                    'b' -> '\b'.toByte()
+                    'b' -> '\b'.code.toByte()
                     'f' -> 0xC
-                    'n' -> '\n'.toByte()
-                    'r' -> '\r'.toByte()
-                    't' -> '\t'.toByte()
+                    'n' -> '\n'.code.toByte()
+                    'r' -> '\r'.code.toByte()
+                    't' -> '\t'.code.toByte()
                     'v' -> 0x0b
-                    '\\' -> '\\'.toByte()
-                    '\'' -> '\''.toByte()
-                    '"' -> '"'.toByte()
+                    '\\' -> '\\'.code.toByte()
+                    '\'' -> '\''.code.toByte()
+                    '"' -> '"'.code.toByte()
                     else -> throw IllegalArgumentException("Invalid escape char")
                 }.also { pos++ }
             }
-            else -> str[pos++].toByte()
+            else -> str[pos++].code.toByte()
         }
     }
     return bytes.toByteArray()


### PR DESCRIPTION
Fixed all of the build-time warnings for `compileKotlin` and `compileTestKotlin`. I tried to actually fix as much as I could, but everything else is just suppressed. For suppressed warnings, if there is a better way to handle these let me know.

For reference, here are the warnings I saw:

<details closed>
<summary>Task :compileKotlin</summary>

```
w: Language version 1.4 is deprecated and its support will be removed in a future version of Kotlin
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt: (19, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt: (27, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/P2PChannelHandler.kt: (29, 18): Unchecked cast: P2PChannel to TChannel
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt: (30, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt: (37, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/multistream/ProtocolBinding.kt: (56, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxer.kt: (43, 10): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/host/HostImpl.kt: (98, 83): Unchecked cast: ProtocolBinding<Any>? to ProtocolBinding<TController>
w: jvm-libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt: (25, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/pubsub/TopicSubscriptionFilter.kt: (7, 6): 'JvmDefault' is deprecated. Switch to new -Xjvm-default modes: `all` or `all-compatibility`
w: jvm-libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt: (227, 29): Parameter 'peer' is never used
w: jvm-libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt: (227, 59): Parameter 'msg' is never used
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt: (190, 31): 'toUpperCase(): String' is deprecated. Use uppercase() instead.
w: jvm-libp2p/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt: (206, 35): 'toLowerCase(): String' is deprecated. Use lowercase() instead.
w: jvm-libp2p/src/main/kotlin/io/libp2p/etc/encode/Base58.kt: (15, 33): 'toInt(): Int' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/main/kotlin/io/libp2p/etc/encode/Base58.kt: (65, 27): 'toInt(): Int' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/main/kotlin/io/libp2p/etc/encode/Base58.kt: (65, 52): 'toInt(): Int' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
```
</details>

<details closed>
<summary>Task :compileTestKotlin</summary>

```
w: jvm-libp2p/src/test/kotlin/io/libp2p/core/HostTest.kt: (239, 25): Unchecked cast: Any to TMessage
w: jvm-libp2p/src/test/kotlin/io/libp2p/core/HostTest.kt: (246, 25): Unchecked cast: Any to TMessage
w: jvm-libp2p/src/test/kotlin/io/libp2p/core/HostTest.kt: (265, 28): The corresponding parameter in the supertype 'ChannelVisitor' is named 'channel'. This may cause problems when calling this function with named arguments.
w: jvm-libp2p/src/test/kotlin/io/libp2p/core/multiformats/MultihashTest.kt: (116, 45): 'toUpperCase(): String' is deprecated. Use uppercase() instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (224, 39): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (260, 43): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (261, 47): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (276, 43): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (277, 47): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (327, 43): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (328, 41): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (344, 43): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt: (345, 47): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt: (79, 40): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt: (89, 40): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt: (105, 40): 'sumBy((T) -> Int): Int' is deprecated. Use sumOf instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt: (55, 15): 'open' has no effect in a final class
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt: (71, 24): Parameter 'outbound' is never used
w: jvm-libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt: (352, 13): Variable 'connection' is never used
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/NullHost.kt: (42, 35): The corresponding parameter in the supertype 'Host' is named 'streamVisitor'. This may cause problems when calling this function with named arguments.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/NullHost.kt: (46, 38): The corresponding parameter in the supertype 'Host' is named 'streamVisitor'. This may cause problems when calling this function with named arguments.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/TestChannel.kt: (89, 42): Elvis operator (?:) always returns the left operand of non-nullable type String
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/TestLogAppender.kt: (10, 25): 'constructor AbstractAppender(String!, Filter!, Layout<out Serializable!>!)' is deprecated. Deprecated in Java
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (28, 33): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (30, 33): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (31, 33): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (32, 33): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (34, 34): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (35, 34): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (36, 32): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
w: jvm-libp2p/src/test/kotlin/io/libp2p/tools/protobuf/ProtobufUtils.kt: (40, 32): 'toByte(): Byte' is deprecated. Conversion of Char to Number is deprecated. Use Char.code property instead.
```
</details>