### PR TITLE
Remove duplicate test

### DIFF
--- a/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
+++ b/src/test/kotlin/io/libp2p/etc/types/UvarintTest.kt
@@ -59,13 +59,6 @@ class UvarintTest {
     }
 
     @Test
-    fun testRoundTripMaximumValue() {
-        val buf = Unpooled.buffer()
-        buf.writeUvarint(Long.MAX_VALUE)
-        assertEquals(Long.MAX_VALUE, buf.readUvarint())
-    }
-
-    @Test
     fun testEncodeNegativeValue() {
         val buf = Unpooled.buffer()
         val exception = assertThrows<IllegalArgumentException> { buf.writeUvarint(-1) }


### PR DESCRIPTION
I added a duplicate test for round tripping encoding of a max long value.  Remove the duplicate.