### PR TITLE
Add listen/dial `preHandler` optional parameter

### DIFF
--- a/src/main/kotlin/io/libp2p/core/Network.kt
+++ b/src/main/kotlin/io/libp2p/core/Network.kt
@@ -75,9 +75,15 @@ interface Network {
         connect(id, null, *addrs)
 
     /**
-     * Dials the specified multiaddr via [Proxy] and returns a promise of a Connection.
-     * [preHandler] is invoked prior to any other handlers (including security negotiation)
-     * upon every connection
+     * Tries to connect to the remote peer with [id] PeerId by specified addresses
+     * If connection to this peer already exist, returns existing connection
+     * Else tries to connect the peer by all supplied addresses in parallel
+     * and completes the returned [Future] when any of connections succeeds
+     *
+     * If the connection is established it is handled by [connectionHandler]
+     *
+     * @param preHandler is invoked prior to any other handlers (including security negotiation) on a newly created raw Channel
+     * @throws TransportNotSupportedException if any of [addrs] represents the transport which is not supported
      */
     fun connect(id: PeerId, preHandler: ChannelVisitor<P2PChannel>?, vararg addrs: Multiaddr): CompletableFuture<Connection>
 

--- a/src/main/kotlin/io/libp2p/core/Network.kt
+++ b/src/main/kotlin/io/libp2p/core/Network.kt
@@ -28,7 +28,7 @@ interface Network {
      * notifies on success or error
      * All the incoming connections are handled with [connectionHandler]
      */
-    fun listen(addr: Multiaddr): CompletableFuture<Unit>
+    fun listen(addr: Multiaddr, preHandler: ChannelVisitor<P2PChannel>? = null): CompletableFuture<Unit>
 
     /**
      * Stops listening on specified address. The returned future asynchronously
@@ -62,7 +62,13 @@ interface Network {
      *
      * @throws TransportNotSupportedException if any of [addrs] represents the transport which is not supported
      */
-    fun connect(id: PeerId, vararg addrs: Multiaddr): CompletableFuture<Connection>
+    fun connect(id: PeerId, vararg addrs: Multiaddr): CompletableFuture<Connection> =
+        connect(id, null, *addrs)
+
+    /**
+     * Dials the specified multiaddr via [Proxy] and returns a promise of a Connection.
+     */
+    fun connect(id: PeerId, preHandler: ChannelVisitor<P2PChannel>? = null, vararg addrs: Multiaddr): CompletableFuture<Connection>
 
     /**
      * Closes the specified [Connection]

--- a/src/main/kotlin/io/libp2p/core/Network.kt
+++ b/src/main/kotlin/io/libp2p/core/Network.kt
@@ -28,7 +28,16 @@ interface Network {
      * notifies on success or error
      * All the incoming connections are handled with [connectionHandler]
      */
-    fun listen(addr: Multiaddr, preHandler: ChannelVisitor<P2PChannel>? = null): CompletableFuture<Unit>
+    fun listen(addr: Multiaddr) = listen(addr, null)
+
+    /**
+     * Starts listening on specified address. The returned future asynchronously
+     * notifies on success or error
+     * All the incoming connections are handled with [connectionHandler]
+     * [preHandler] is invoked prior to any other handlers (including security negotiation)
+     * upon every connection
+     */
+    fun listen(addr: Multiaddr, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Unit>
 
     /**
      * Stops listening on specified address. The returned future asynchronously
@@ -67,8 +76,10 @@ interface Network {
 
     /**
      * Dials the specified multiaddr via [Proxy] and returns a promise of a Connection.
+     * [preHandler] is invoked prior to any other handlers (including security negotiation)
+     * upon every connection
      */
-    fun connect(id: PeerId, preHandler: ChannelVisitor<P2PChannel>? = null, vararg addrs: Multiaddr): CompletableFuture<Connection>
+    fun connect(id: PeerId, preHandler: ChannelVisitor<P2PChannel>?, vararg addrs: Multiaddr): CompletableFuture<Connection>
 
     /**
      * Closes the specified [Connection]

--- a/src/main/kotlin/io/libp2p/core/transport/Transport.kt
+++ b/src/main/kotlin/io/libp2p/core/transport/Transport.kt
@@ -38,7 +38,14 @@ interface Transport {
     /**
      * Makes this transport listen on this multiaddr. The future completes once the endpoint is effectively listening.
      */
-    fun listen(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>? = null): CompletableFuture<Unit>
+    fun listen(addr: Multiaddr, connHandler: ConnectionHandler) = listen(addr, connHandler, null)
+
+    /**
+     * Makes this transport listen on this multiaddr. The future completes once the endpoint is effectively listening.
+     * [preHandler] is invoked prior to any other handlers (including security negotiation)
+     * upon every connection
+     */
+    fun listen(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Unit>
 
     /**
      * Makes this transport stop listening on this multiaddr. Any connections maintained from this source host and port
@@ -50,5 +57,12 @@ interface Transport {
     /**
      * Dials the specified multiaddr and returns a promise of a Connection.
      */
-    fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>? = null): CompletableFuture<Connection>
+    fun dial(addr: Multiaddr, connHandler: ConnectionHandler) = dial(addr, connHandler, null)
+
+    /**
+     * Dials the specified multiaddr and returns a promise of a Connection.
+     * [preHandler] is invoked prior to any other handlers (including security negotiation)
+     * upon every connection
+     */
+    fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Connection>
 }

--- a/src/main/kotlin/io/libp2p/core/transport/Transport.kt
+++ b/src/main/kotlin/io/libp2p/core/transport/Transport.kt
@@ -37,13 +37,14 @@ interface Transport {
 
     /**
      * Makes this transport listen on this multiaddr. The future completes once the endpoint is effectively listening.
+     * @param connHandler is invoked on every complete (secured and multiplexed) [Connection]
      */
     fun listen(addr: Multiaddr, connHandler: ConnectionHandler) = listen(addr, connHandler, null)
 
     /**
      * Makes this transport listen on this multiaddr. The future completes once the endpoint is effectively listening.
-     * [preHandler] is invoked prior to any other handlers (including security negotiation)
-     * upon every connection
+     * @param connHandler is invoked on every complete (secured and multiplexed) [Connection]
+     * @param preHandler is invoked prior to any other handlers (including security negotiation) on every newly created raw Channel
      */
     fun listen(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Unit>
 
@@ -61,8 +62,8 @@ interface Transport {
 
     /**
      * Dials the specified multiaddr and returns a promise of a Connection.
-     * [preHandler] is invoked prior to any other handlers (including security negotiation)
-     * upon every connection
+     * @param connHandler is invoked on a complete (secured and multiplexed) [Connection]
+     * @param preHandler is invoked prior to any other handlers (including security negotiation) on a newly created raw Channel
      */
     fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Connection>
 }

--- a/src/main/kotlin/io/libp2p/core/transport/Transport.kt
+++ b/src/main/kotlin/io/libp2p/core/transport/Transport.kt
@@ -1,7 +1,9 @@
 package io.libp2p.core.transport
 
+import io.libp2p.core.ChannelVisitor
 import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
+import io.libp2p.core.P2PChannel
 import io.libp2p.core.multiformats.Multiaddr
 import java.util.concurrent.CompletableFuture
 
@@ -36,7 +38,7 @@ interface Transport {
     /**
      * Makes this transport listen on this multiaddr. The future completes once the endpoint is effectively listening.
      */
-    fun listen(addr: Multiaddr, connHandler: ConnectionHandler): CompletableFuture<Unit>
+    fun listen(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>? = null): CompletableFuture<Unit>
 
     /**
      * Makes this transport stop listening on this multiaddr. Any connections maintained from this source host and port
@@ -48,10 +50,5 @@ interface Transport {
     /**
      * Dials the specified multiaddr and returns a promise of a Connection.
      */
-    fun dial(addr: Multiaddr, connHandler: ConnectionHandler): CompletableFuture<Connection>
-
-    /**
-     * Dials the specified multiaddr and returns a promise of a Connection.
-     */
-    fun dial(addr: Multiaddr): CompletableFuture<Connection> = dial(addr, { })
+    fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>? = null): CompletableFuture<Connection>
 }

--- a/src/main/kotlin/io/libp2p/transport/implementation/NettyTransport.kt
+++ b/src/main/kotlin/io/libp2p/transport/implementation/NettyTransport.kt
@@ -1,8 +1,10 @@
 package io.libp2p.transport.implementation
 
+import io.libp2p.core.ChannelVisitor
 import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
 import io.libp2p.core.Libp2pException
+import io.libp2p.core.P2PChannel
 import io.libp2p.core.PeerId
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.multiformats.MultiaddrDns
@@ -87,10 +89,10 @@ abstract class NettyTransport(
         }
     } // close
 
-    override fun listen(addr: Multiaddr, connHandler: ConnectionHandler): CompletableFuture<Unit> {
+    override fun listen(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Unit> {
         if (closed) throw Libp2pException("Transport is closed")
 
-        val connectionBuilder = makeConnectionBuilder(connHandler, false)
+        val connectionBuilder = makeConnectionBuilder(connHandler, false, preHandler = preHandler)
         val channelHandler = serverTransportBuilder(connectionBuilder, addr) ?: connectionBuilder
 
         val listener = server.clone()
@@ -127,12 +129,12 @@ abstract class NettyTransport(
             ?: throw Libp2pException("No listeners on address $addr")
     } // unlisten
 
-    override fun dial(addr: Multiaddr, connHandler: ConnectionHandler):
+    override fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?):
         CompletableFuture<Connection> {
         if (closed) throw Libp2pException("Transport is closed")
 
         val remotePeerId = addr.getPeerId()
-        val connectionBuilder = makeConnectionBuilder(connHandler, true, remotePeerId)
+        val connectionBuilder = makeConnectionBuilder(connHandler, true, remotePeerId, preHandler)
         val channelHandler = clientTransportBuilder(connectionBuilder, addr) ?: connectionBuilder
 
         val chanFuture = client.clone()
@@ -168,13 +170,15 @@ abstract class NettyTransport(
     private fun makeConnectionBuilder(
         connHandler: ConnectionHandler,
         initiator: Boolean,
-        remotePeerId: PeerId? = null
+        remotePeerId: PeerId? = null,
+        preHandler: ChannelVisitor<P2PChannel>?
     ) = ConnectionBuilder(
         this,
         upgrader,
         connHandler,
         initiator,
-        remotePeerId
+        remotePeerId,
+        preHandler
     )
 
     protected fun handlesHost(addr: Multiaddr) =

--- a/src/test/java/io/libp2p/tools/schedulers/Scheduler.java
+++ b/src/test/java/io/libp2p/tools/schedulers/Scheduler.java
@@ -39,6 +39,7 @@ public interface Scheduler {
     return executeWithDelay(delay, () -> {task.run(); return null;});
   }
 
+  @SuppressWarnings("unchecked")
   default <C> CompletableFuture<C> orTimeout(CompletableFuture<C> future, Duration futureTimeout,
                                              Supplier<Exception> exceptionSupplier) {
     return (CompletableFuture<C>) CompletableFuture.anyOf(

--- a/src/test/kotlin/io/libp2p/pubsub/GoInteropTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/GoInteropTest.kt
@@ -146,7 +146,7 @@ class GoInteropTest {
             val tcpTransport = TcpTransport(upgrader)
             logger.info("Dialing...")
             val connFuture = tcpTransport.dial(
-                Multiaddr("/ip4/127.0.0.1/tcp/45555/p2p/$pdPeerId")
+                Multiaddr("/ip4/127.0.0.1/tcp/45555/p2p/$pdPeerId"), { }
             )
 
             var pingRes: Long? = null

--- a/src/test/kotlin/io/libp2p/security/secio/EchoSampleTest.kt
+++ b/src/test/kotlin/io/libp2p/security/secio/EchoSampleTest.kt
@@ -71,7 +71,7 @@ class EchoSampleTest {
         val tcpTransport = TcpTransport(upgrader)
 
         logger.info("Dialing...")
-        val connFuture: CompletableFuture<Connection> = tcpTransport.dial(Multiaddr("/ip4/127.0.0.1/tcp/10000"))
+        val connFuture: CompletableFuture<Connection> = tcpTransport.dial(Multiaddr("/ip4/127.0.0.1/tcp/10000"), { })
 
         val echoString = "Helooooooooooooooooooooooooo\n"
         connFuture.thenCompose {

--- a/src/test/kotlin/io/libp2p/tools/NullTransport.kt
+++ b/src/test/kotlin/io/libp2p/tools/NullTransport.kt
@@ -1,7 +1,9 @@
 package io.libp2p.tools
 
+import io.libp2p.core.ChannelVisitor
 import io.libp2p.core.Connection
 import io.libp2p.core.ConnectionHandler
+import io.libp2p.core.P2PChannel
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.transport.Transport
 import java.util.concurrent.CompletableFuture
@@ -15,9 +17,17 @@ class NullTransport : Transport {
     override fun initialize() = stub()
     override fun listenAddresses() = stub()
     override fun close(): CompletableFuture<Unit> = stub()
-    override fun listen(addr: Multiaddr, connHandler: ConnectionHandler): CompletableFuture<Unit> = stub()
+    override fun listen(
+        addr: Multiaddr,
+        connHandler: ConnectionHandler,
+        preHandler: ChannelVisitor<P2PChannel>?
+    ): CompletableFuture<Unit> = stub()
     override fun unlisten(addr: Multiaddr): CompletableFuture<Unit> = stub()
-    override fun dial(addr: Multiaddr, connHandler: ConnectionHandler): CompletableFuture<Connection> = stub()
+    override fun dial(
+        addr: Multiaddr,
+        connHandler: ConnectionHandler,
+        preHandler: ChannelVisitor<P2PChannel>?
+    ): CompletableFuture<Connection> = stub()
     override fun handles(addr: Multiaddr): Boolean = stub()
 
     private fun stub(): Nothing {

--- a/src/test/kotlin/io/libp2p/transport/TransportTests.kt
+++ b/src/test/kotlin/io/libp2p/transport/TransportTests.kt
@@ -113,7 +113,7 @@ abstract class TransportTests {
         val preHandlerCalled = AtomicBoolean(false)
         val connectionHandlerFuture = CompletableFuture<Unit>()
         transportUnderTest.listen(address, {
-            if(preHandlerCalled.get()) {
+            if (preHandlerCalled.get()) {
                 connectionHandlerFuture.complete(null)
             } else {
                 connectionHandlerFuture.completeExceptionally(AssertionError("preHandler was not called"))

--- a/src/test/kotlin/io/libp2p/transport/TransportTests.kt
+++ b/src/test/kotlin/io/libp2p/transport/TransportTests.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Tag("transport")
 abstract class TransportTests {
@@ -23,13 +24,11 @@ abstract class TransportTests {
     protected abstract fun badAddress(): Multiaddr
     protected lateinit var transportUnderTest: Transport
 
-    protected val nullConnHandler = object : ConnectionHandler {
-        override fun handleConnection(conn: Connection) { }
-    }
+    protected val nullConnHandler = ConnectionHandler { }
     protected val logger = LogManager.getLogger("test")
 
     protected fun startListeners(server: Transport, startPortNumber: Int, howMany: Int) {
-        val listening = (1..howMany).map {
+        val listening = (0 until howMany).map {
             val bindComplete = server.listen(
                 localAddress(startPortNumber + it),
                 nullConnHandler
@@ -97,6 +96,37 @@ abstract class TransportTests {
     }
 
     @Test
+    fun `dial should invoke preHandler before connection handlers`() {
+        startListeners(transportUnderTest, 21100, 1)
+        val address = localAddress(21100)
+        val preHandlerCalled = AtomicBoolean(false)
+        transportUnderTest.dial(address, {
+            assert(preHandlerCalled.get())
+        }, {
+            preHandlerCalled.set(true)
+        }).join()
+    }
+
+    @Test
+    fun `listen should invoke preHandler before connection handlers`() {
+        val address = localAddress(21100)
+        val preHandlerCalled = AtomicBoolean(false)
+        val connectionHandlerFuture = CompletableFuture<Unit>()
+        transportUnderTest.listen(address, {
+            if(preHandlerCalled.get()) {
+                connectionHandlerFuture.complete(null)
+            } else {
+                connectionHandlerFuture.completeExceptionally(AssertionError("preHandler was not called"))
+            }
+        }, {
+            preHandlerCalled.set(true)
+        }).join()
+        transportUnderTest.dial(address, { })
+
+        connectionHandlerFuture.join()
+    }
+
+    @Test
     fun `cannot listen on closed transport`() {
         transportUnderTest.close()
 
@@ -136,7 +166,7 @@ abstract class TransportTests {
         val listenerCount = 5
         startListeners(transportUnderTest, portNumber, listenerCount)
 
-        val unlistening = (1..listenerCount).map {
+        val unlistening = (0 until listenerCount).map {
             val unbindComplete = transportUnderTest.unlisten(
                 localAddress(portNumber + it)
             )


### PR DESCRIPTION
This is more generic version of `DebugBuilder.beforeSecureHandler`: the raw channel pre-handler which could be specified per `listen()/dial()` call individually.

Add unit test for new `Transport` methods.
Also piggy tailing suppress unchecked warning for the test