### PR TITLE
Fix detekt's EqualsWithHashCodeExist warnings

### DIFF
--- a/detekt/baseline.xml
+++ b/detekt/baseline.xml
@@ -2,18 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>EqualsWithHashCodeExist:Curve25519.kt$Curve25519PrivateKey : PrivKey</ID>
-    <ID>EqualsWithHashCodeExist:Curve25519.kt$Curve25519PublicKey : PubKey</ID>
-    <ID>EqualsWithHashCodeExist:Ecdsa.kt$EcdsaPrivateKey : PrivKey</ID>
-    <ID>EqualsWithHashCodeExist:Ecdsa.kt$EcdsaPublicKey : PubKey</ID>
-    <ID>EqualsWithHashCodeExist:Ed25519.kt$Ed25519PrivateKey : PrivKey</ID>
-    <ID>EqualsWithHashCodeExist:Ed25519.kt$Ed25519PublicKey : PubKey</ID>
-    <ID>EqualsWithHashCodeExist:Key.kt$PrivKey : Key</ID>
-    <ID>EqualsWithHashCodeExist:Key.kt$PubKey : Key</ID>
-    <ID>EqualsWithHashCodeExist:Rsa.kt$RsaPrivateKey : PrivKey</ID>
-    <ID>EqualsWithHashCodeExist:Rsa.kt$RsaPublicKey : PubKey</ID>
-    <ID>EqualsWithHashCodeExist:Secp256k1.kt$Secp256k1PrivateKey : PrivKey</ID>
-    <ID>EqualsWithHashCodeExist:Secp256k1.kt$Secp256k1PublicKey : PubKey</ID>
     <ID>SwallowedException:AsyncExt.kt$t: Exception</ID>
     <ID>SwallowedException:MultiaddrDns.kt$MultiaddrDns.Companion$e: UnknownHostException</ID>
   </CurrentIssues>

--- a/src/main/kotlin/io/libp2p/core/crypto/Key.kt
+++ b/src/main/kotlin/io/libp2p/core/crypto/Key.kt
@@ -89,6 +89,10 @@ abstract class PrivKey(override val keyType: Crypto.KeyType) : Key {
         if (javaClass != other?.javaClass) return false
         return bytes().contentEquals((other as PrivKey).bytes())
     }
+
+    override fun hashCode(): Int {
+        return raw().contentHashCode()
+    }
 }
 
 /**
@@ -107,6 +111,10 @@ abstract class PubKey(override val keyType: Crypto.KeyType) : Key {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
         return bytes().contentEquals((other as PubKey).bytes())
+    }
+
+    override fun hashCode(): Int {
+        return raw().contentHashCode()
     }
 }
 

--- a/src/main/kotlin/io/libp2p/crypto/keys/Curve25519.kt
+++ b/src/main/kotlin/io/libp2p/crypto/keys/Curve25519.kt
@@ -38,8 +38,6 @@ class Curve25519PrivateKey(private val state: DHState) : PrivKey(Crypto.KeyType.
         state.getPublicKey(ba, 0)
         return Curve25519PublicKey(state)
     }
-
-    override fun hashCode(): Int = raw().contentHashCode()
 }
 
 /**
@@ -56,8 +54,6 @@ class Curve25519PublicKey(private val state: DHState) : PubKey(Crypto.KeyType.Cu
     override fun verify(data: ByteArray, signature: ByteArray): Boolean {
         throw NotImplementedError("Verifying with Curve25519 public key currently unsupported.")
     }
-
-    override fun hashCode(): Int = raw().contentHashCode()
 }
 
 /**

--- a/src/main/kotlin/io/libp2p/crypto/keys/Ecdsa.kt
+++ b/src/main/kotlin/io/libp2p/crypto/keys/Ecdsa.kt
@@ -79,6 +79,8 @@ class EcdsaPrivateKey(val priv: JavaECPrivateKey) : PrivKey(Crypto.KeyType.ECDSA
         }
     }
 
+    override fun equals(other: Any?): Boolean = super.equals(other)
+
     override fun hashCode(): Int = priv.hashCode()
 }
 
@@ -98,6 +100,8 @@ class EcdsaPublicKey(val pub: JavaECPublicKey) : PubKey(Crypto.KeyType.ECDSA) {
             update(data)
             verify(signature)
         }
+
+    override fun equals(other: Any?): Boolean = super.equals(other)
 
     override fun hashCode(): Int = pub.hashCode()
 }

--- a/src/main/kotlin/io/libp2p/crypto/keys/Ed25519.kt
+++ b/src/main/kotlin/io/libp2p/crypto/keys/Ed25519.kt
@@ -37,6 +37,8 @@ class Ed25519PrivateKey(private val priv: Ed25519PrivateKeyParameters) : PrivKey
 
     override fun publicKey(): PubKey = Ed25519PublicKey(priv.generatePublicKey())
 
+    override fun equals(other: Any?): Boolean = super.equals(other)
+
     override fun hashCode(): Int = priv.hashCode()
 }
 
@@ -52,6 +54,8 @@ class Ed25519PublicKey(private val pub: Ed25519PublicKeyParameters) : PubKey(Cry
         update(data, 0, data.size)
         verifySignature(signature)
     }
+
+    override fun equals(other: Any?): Boolean = super.equals(other)
 
     override fun hashCode(): Int = pub.hashCode()
 }

--- a/src/main/kotlin/io/libp2p/crypto/keys/Rsa.kt
+++ b/src/main/kotlin/io/libp2p/crypto/keys/Rsa.kt
@@ -68,6 +68,8 @@ class RsaPrivateKey(private val sk: JavaPrivateKey, private val pk: JavaPublicKe
 
     override fun publicKey(): PubKey = rsaPublicKey
 
+    override fun equals(other: Any?): Boolean = super.equals(other)
+
     override fun hashCode(): Int = pk.hashCode()
 }
 
@@ -84,6 +86,8 @@ class RsaPublicKey(private val k: JavaPublicKey) : PubKey(Crypto.KeyType.RSA) {
             update(data)
             verify(signature)
         }
+
+    override fun equals(other: Any?): Boolean = super.equals(other)
 
     override fun hashCode(): Int = k.hashCode()
 }

--- a/src/main/kotlin/io/libp2p/crypto/keys/Secp256k1.kt
+++ b/src/main/kotlin/io/libp2p/crypto/keys/Secp256k1.kt
@@ -85,6 +85,8 @@ class Secp256k1PrivateKey(private val privateKey: ECPrivateKeyParameters) : Priv
         return Secp256k1PublicKey(ECPublicKeyParameters(publicPoint, CURVE))
     }
 
+    override fun equals(other: Any?): Boolean = super.equals(other)
+
     override fun hashCode(): Int = priv.hashCode()
 }
 
@@ -119,6 +121,8 @@ class Secp256k1PublicKey(private val pub: ECPublicKeyParameters) : PubKey(Crypto
         val s = (asn1Encodables[1].toASN1Primitive() as ASN1Integer).value
         return signer.verifySignature(sha256(data), r.abs(), s.abs())
     }
+
+    override fun equals(other: Any?): Boolean = super.equals(other)
 
     override fun hashCode(): Int = pub.hashCode()
 }


### PR DESCRIPTION
This PR fixes the [EqualsWithHashCodeExist](https://detekt.dev/potential-bugs.html#equalswithhashcodeexist) according to what detekt says should be done in cases of inheritance.

> All hash-based collections depend on objects meeting the equals-contract. Two equal objects must produce the same hashcode. **When inheriting equals or hashcode, override the inherited and call the super method for clarification.**

Also added a default `Key.hashCode()` function.