### PR TITLE
Cache pubsub message hashCode

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -40,7 +40,7 @@ abstract class AbstractPubsubMessage : PubsubMessage {
     override fun hashCode(): Int {
         val cached = hashCode
         if (cached != null) {
-            return cached;
+            return cached
         }
         val result = sha256(protobufMessage.toByteArray()).toWBytes().hashCode()
         hashCode = result

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -35,8 +35,17 @@ interface PubsubMessage {
 }
 
 abstract class AbstractPubsubMessage : PubsubMessage {
+    @Volatile var hashCode: Int? = null
     override fun equals(other: Any?) = protobufMessage == (other as? PubsubMessage)?.protobufMessage
-    override fun hashCode() = sha256(protobufMessage.toByteArray()).toWBytes().hashCode()
+    override fun hashCode(): Int {
+        val cached = hashCode
+        if (cached != null) {
+            return cached;
+        }
+        val result = sha256(protobufMessage.toByteArray()).toWBytes().hashCode()
+        hashCode = result
+        return result
+    }
     override fun toString() = "PubsubMessage{$protobufMessage}"
 }
 


### PR DESCRIPTION
To make the hashCode collisions resistant, AbstractPubsubMessage uses sha256 as part of calculating the hashCode. That makes it fairly expensive and hashCode is intended to be very cheap. Reduce the number of sha256 calculations by caching the result.