### PR TITLE
Make cached sha256 of message data available

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -5,7 +5,6 @@ import io.libp2p.core.Stream
 import io.libp2p.core.crypto.sha256
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.WBytes
-import io.libp2p.etc.types.toWBytes
 import io.netty.channel.ChannelHandler
 import pubsub.pb.Rpc
 import java.util.Random
@@ -25,6 +24,8 @@ interface PubsubMessage {
     val topics: List<Topic>
         get() = protobufMessage.topicIDsList
 
+    fun messageSha256() = sha256(protobufMessage.toByteArray())
+
     override fun equals(other: Any?): Boolean
 
     /**
@@ -35,17 +36,20 @@ interface PubsubMessage {
 }
 
 abstract class AbstractPubsubMessage : PubsubMessage {
-    @Volatile var hashCode: Int? = null
-    override fun equals(other: Any?) = protobufMessage == (other as? PubsubMessage)?.protobufMessage
-    override fun hashCode(): Int {
-        val cached = hashCode
+    @Volatile private var sha256: ByteArray? = null
+
+    override fun messageSha256(): ByteArray {
+        val cached = sha256
         if (cached != null) {
             return cached
         }
-        val result = sha256(protobufMessage.toByteArray()).toWBytes().hashCode()
-        hashCode = result
+        val result = sha256(protobufMessage.toByteArray())
+        sha256 = result
         return result
     }
+
+    override fun equals(other: Any?) = protobufMessage == (other as? PubsubMessage)?.protobufMessage
+    override fun hashCode() = messageSha256().contentHashCode()
     override fun toString() = "PubsubMessage{$protobufMessage}"
 }
 


### PR DESCRIPTION
Rather than caching the hashCode itself, caches the sha256 of the message content and makes it available via an API.  This enables applications using custom seen caches to leverage the same cached sha256 value for collision resistant hashing without having to recalculate the sha256.