### PR TITLE
Optimization: no need to instantiate SecureRandom on sign() calls

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 kotlin.code.style=official
+
+org.gradle.jvmargs=-Xmx1G

--- a/src/main/kotlin/io/libp2p/crypto/keys/Secp256k1.kt
+++ b/src/main/kotlin/io/libp2p/crypto/keys/Secp256k1.kt
@@ -18,11 +18,7 @@ import io.libp2p.core.crypto.PrivKey
 import io.libp2p.core.crypto.PubKey
 import io.libp2p.core.crypto.sha256
 import io.libp2p.crypto.SECP_256K1_ALGORITHM
-import org.bouncycastle.asn1.ASN1InputStream
-import org.bouncycastle.asn1.ASN1Integer
-import org.bouncycastle.asn1.ASN1Primitive
-import org.bouncycastle.asn1.ASN1Sequence
-import org.bouncycastle.asn1.DERSequenceGenerator
+import org.bouncycastle.asn1.*
 import org.bouncycastle.asn1.sec.SECNamedCurves
 import org.bouncycastle.crypto.ec.CustomNamedCurves
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator
@@ -30,7 +26,6 @@ import org.bouncycastle.crypto.params.ECDomainParameters
 import org.bouncycastle.crypto.params.ECKeyGenerationParameters
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters
 import org.bouncycastle.crypto.params.ECPublicKeyParameters
-import org.bouncycastle.crypto.params.ParametersWithRandom
 import org.bouncycastle.crypto.signers.ECDSASigner
 import org.bouncycastle.math.ec.FixedPointCombMultiplier
 import org.bouncycastle.math.ec.FixedPointUtil
@@ -61,7 +56,7 @@ class Secp256k1PrivateKey(private val privateKey: ECPrivateKeyParameters) : Priv
 
     override fun sign(data: ByteArray): ByteArray {
         val (r, s) = with(ECDSASigner()) {
-            init(true, ParametersWithRandom(privateKey, SecureRandom()))
+            init(true, privateKey)
             generateSignature(sha256(data)).let {
                 Pair(it[0], it[1])
             }


### PR DESCRIPTION
Currently `Secp256k1PrivateKey.sign()` instantiates `SecureRandom` on every call. 
It's obsolete, as BouncyCastle uses it's own `SecureRandom` singleton when not supplied one. 