### PR TITLE
GossipScore refactor

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -106,7 +106,7 @@ open class GossipRouter @JvmOverloads constructor(
     private fun isConnected(peerId: PeerId) = peers.any { it.peerId == peerId }
 
     override fun onPeerDisconnected(peer: PeerHandler) {
-        eventBroadcaster.notifyDisconnected(peer)
+        eventBroadcaster.notifyDisconnected(peer.peerId)
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
@@ -116,12 +116,12 @@ open class GossipRouter @JvmOverloads constructor(
 
     override fun onPeerActive(peer: PeerHandler) {
         super.onPeerActive(peer)
-        eventBroadcaster.notifyConnected(peer)
+        eventBroadcaster.notifyConnected(peer.peerId, peer.getIP())
         heartbeatTask.hashCode() // force lazy initialization
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
-        eventBroadcaster.notifyUnseenMessage(peer, msg)
+        eventBroadcaster.notifyUnseenMessage(peer.peerId, msg)
         notifyAnyMessage(peer, msg)
     }
 
@@ -130,7 +130,7 @@ open class GossipRouter @JvmOverloads constructor(
         msg: PubsubMessage,
         validationResult: Optional<ValidationResult>
     ) {
-        eventBroadcaster.notifySeenMessage(peer, msg, validationResult)
+        eventBroadcaster.notifySeenMessage(peer.peerId, msg, validationResult)
         notifyAnyMessage(peer, msg)
         if (validationResult.isPresent && validationResult.get() != ValidationResult.Invalid) {
             notifyAnyValidMessage(peer, msg)
@@ -138,11 +138,11 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     override fun notifyUnseenInvalidMessage(peer: PeerHandler, msg: PubsubMessage) {
-        eventBroadcaster.notifyUnseenInvalidMessage(peer, msg)
+        eventBroadcaster.notifyUnseenInvalidMessage(peer.peerId, msg)
     }
 
     override fun notifyUnseenValidMessage(peer: PeerHandler, msg: PubsubMessage) {
-        eventBroadcaster.notifyUnseenValidMessage(peer, msg)
+        eventBroadcaster.notifyUnseenValidMessage(peer.peerId, msg)
         notifyAnyValidMessage(peer, msg)
     }
 
@@ -167,15 +167,15 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     protected open fun notifyMeshed(peer: PeerHandler, topic: Topic) {
-        eventBroadcaster.notifyMeshed(peer, topic)
+        eventBroadcaster.notifyMeshed(peer.peerId, topic)
     }
 
     fun notifyPruned(peer: PeerHandler, topic: Topic) {
-        eventBroadcaster.notifyPruned(peer, topic)
+        eventBroadcaster.notifyPruned(peer.peerId, topic)
     }
 
     fun notifyRouterMisbehavior(peer: PeerHandler, penalty: Int) {
-        eventBroadcaster.notifyRouterMisbehavior(peer, penalty)
+        eventBroadcaster.notifyRouterMisbehavior(peer.peerId, penalty)
     }
 
     override fun acceptRequestsFrom(peer: PeerHandler): Boolean {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -56,9 +56,15 @@ open class GossipRouter @JvmOverloads constructor(
     val acceptRequestsWhitelistMaxMessages = 128
     val acceptRequestsWhitelistDuration = 1.seconds
 
-    val score: GossipScoreIfc by lazy { GossipScore(scoreParams, executor, curTimeMillis) }
+    open val score: GossipScore by lazy {
+        DefaultGossipScore(scoreParams, executor, curTimeMillis).also {
+            eventBroadcaster.listeners += it
+        }
+    }
+
     val fanout: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
     val mesh: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
+    val eventBroadcaster = GossipRouterEventBroadcaster()
 
     private val mCache = MCache(params.gossipSize, params.gossipHistoryLength)
     private val lastPublished = linkedMapOf<Topic, Long>()
@@ -100,7 +106,7 @@ open class GossipRouter @JvmOverloads constructor(
     private fun isConnected(peerId: PeerId) = peers.any { it.peerId == peerId }
 
     override fun onPeerDisconnected(peer: PeerHandler) {
-        score.notifyDisconnected(peer)
+        eventBroadcaster.notifyDisconnected(peer)
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
@@ -110,12 +116,12 @@ open class GossipRouter @JvmOverloads constructor(
 
     override fun onPeerActive(peer: PeerHandler) {
         super.onPeerActive(peer)
-        score.notifyConnected(peer)
+        eventBroadcaster.notifyConnected(peer)
         heartbeatTask.hashCode() // force lazy initialization
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
-        score.notifyUnseenMessage(peer, msg)
+        eventBroadcaster.notifyUnseenMessage(peer, msg)
         notifyAnyMessage(peer, msg)
     }
 
@@ -124,7 +130,7 @@ open class GossipRouter @JvmOverloads constructor(
         msg: PubsubMessage,
         validationResult: Optional<ValidationResult>
     ) {
-        score.notifySeenMessage(peer, msg, validationResult)
+        eventBroadcaster.notifySeenMessage(peer, msg, validationResult)
         notifyAnyMessage(peer, msg)
         if (validationResult.isPresent && validationResult.get() != ValidationResult.Invalid) {
             notifyAnyValidMessage(peer, msg)
@@ -132,11 +138,11 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     override fun notifyUnseenInvalidMessage(peer: PeerHandler, msg: PubsubMessage) {
-        score.notifyUnseenInvalidMessage(peer, msg)
+        eventBroadcaster.notifyUnseenInvalidMessage(peer, msg)
     }
 
     override fun notifyUnseenValidMessage(peer: PeerHandler, msg: PubsubMessage) {
-        score.notifyUnseenValidMessage(peer, msg)
+        eventBroadcaster.notifyUnseenValidMessage(peer, msg)
         notifyAnyValidMessage(peer, msg)
     }
 
@@ -161,15 +167,15 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     protected open fun notifyMeshed(peer: PeerHandler, topic: Topic) {
-        score.notifyMeshed(peer, topic)
+        eventBroadcaster.notifyMeshed(peer, topic)
     }
 
     fun notifyPruned(peer: PeerHandler, topic: Topic) {
-        score.notifyPruned(peer, topic)
+        eventBroadcaster.notifyPruned(peer, topic)
     }
 
     fun notifyRouterMisbehavior(peer: PeerHandler, penalty: Int) {
-        score.notifyRouterMisbehavior(peer, penalty)
+        eventBroadcaster.notifyRouterMisbehavior(peer, penalty)
     }
 
     override fun acceptRequestsFrom(peer: PeerHandler): Boolean {
@@ -188,7 +194,7 @@ open class GossipRouter @JvmOverloads constructor(
             return true
         }
 
-        val peerScore = score.score(peer)
+        val peerScore = score.score(peer.peerId)
         if (peerScore >= acceptRequestsWhitelistThresholdScore) {
             acceptRequestsWhitelist[peer] =
                 AcceptRequestsWhitelistEntry(curTime + acceptRequestsWhitelistDuration.toMillis())
@@ -236,7 +242,7 @@ open class GossipRouter @JvmOverloads constructor(
                 }
                 prune(peer, topic)
             }
-            score.score(peer) < 0 ->
+            score.score(peer.peerId) < 0 ->
                 prune(peer, topic)
             meshPeers.size >= params.DHigh && !peer.isOutbound() ->
                 prune(peer, topic)
@@ -256,7 +262,7 @@ open class GossipRouter @JvmOverloads constructor(
             } else {
                 setBackOff(peer, topic)
             }
-            if (score.score(peer) >= scoreParams.acceptPXThreshold) {
+            if (score.score(peer.peerId) >= scoreParams.acceptPXThreshold) {
                 processPrunePeers(msg.peersList)
             }
         } else {
@@ -267,7 +273,7 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     private fun handleIHave(msg: Rpc.ControlIHave, peer: PeerHandler) {
-        val peerScore = score.score(peer)
+        val peerScore = score.score(peer.peerId)
         // we ignore IHAVE gossip from any peer whose score is below the gossip threshold
         if (peerScore < scoreParams.gossipThreshold) return
         if (peerIHave.computeIfAbsent(peer) { AtomicInteger() }.incrementAndGet() > params.maxIHaveMessages) {
@@ -289,7 +295,7 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     private fun handleIWant(msg: Rpc.ControlIWant, peer: PeerHandler) {
-        val peerScore = score.score(peer)
+        val peerScore = score.score(peer.peerId)
         if (peerScore < scoreParams.gossipThreshold) return
         msg.messageIDsList
             .mapNotNull { mCache.getMessageForPeer(peer.peerId, it.toWBytes()) }
@@ -332,7 +338,7 @@ open class GossipRouter @JvmOverloads constructor(
             if (params.floodPublish) {
                 msg.topics
                     .flatMap { getTopicPeers(it) }
-                    .filter { score.score(it) >= scoreParams.publishThreshold }
+                    .filter { score.score(it.peerId) >= scoreParams.publishThreshold }
                     .plus(getDirectPeers())
             } else {
                 msg.topics
@@ -361,10 +367,10 @@ open class GossipRouter @JvmOverloads constructor(
     override fun subscribe(topic: Topic) {
         super.subscribe(topic)
         val fanoutPeers = (fanout[topic] ?: mutableSetOf())
-            .filter { score.score(it) >= 0 && !isDirect(it) }
+            .filter { score.score(it.peerId) >= 0 && !isDirect(it) }
         val meshPeers = mesh.getOrPut(topic) { mutableSetOf() }
         val otherPeers = (getTopicPeers(topic) - meshPeers - fanoutPeers)
-            .filter { score.score(it) >= 0 && !isDirect(it) }
+            .filter { score.score(it.peerId) >= 0 && !isDirect(it) }
 
         if (meshPeers.size < params.D) {
             val addFromFanout = fanoutPeers.shuffled(random)
@@ -409,13 +415,13 @@ open class GossipRouter @JvmOverloads constructor(
             mesh.entries.forEach { (topic, peers) ->
 
                 // drop underscored peers from mesh
-                peers.filter { score.score(it) < 0 }
+                peers.filter { score.score(it.peerId) < 0 }
                     .forEach { prune(it, topic) }
 
                 if (peers.size < params.DLow) {
                     // need more mesh peers
                     (getTopicPeers(topic) - peers)
-                        .filter { score.score(it) >= 0 && !isDirect(it) && !isBackOff(it, topic) }
+                        .filter { score.score(it.peerId) >= 0 && !isDirect(it) && !isBackOff(it, topic) }
                         .shuffled(random)
                         .take(params.D - peers.size)
                         .forEach { graft(it, topic) }
@@ -423,7 +429,7 @@ open class GossipRouter @JvmOverloads constructor(
                     // too many mesh peers
                     val sortedPeers = peers
                         .shuffled(random)
-                        .sortedBy { score.score(it) }
+                        .sortedBy { score.score(it.peerId) }
                         .reversed()
 
                     val bestDPeers = sortedPeers.take(params.DScore)
@@ -440,17 +446,17 @@ open class GossipRouter @JvmOverloads constructor(
                 // keep outbound peers > DOut
                 val outboundCount = peers.count { it.isOutbound() }
                 (getTopicPeers(topic) - peers)
-                    .filter { it.isOutbound() && score.score(it) >= 0 && !isDirect(it) && !isBackOff(it, topic) }
+                    .filter { it.isOutbound() && score.score(it.peerId) >= 0 && !isDirect(it) && !isBackOff(it, topic) }
                     .shuffled(random)
                     .take(max(0, params.DOut - outboundCount))
                     .forEach { graft(it, topic) }
 
                 // opportunistic grafting
                 if (heartbeatsCount % params.opportunisticGraftTicks == 0 && peers.size > 1) {
-                    val scoreMedian = peers.map { score.score(it) }.median()
+                    val scoreMedian = peers.map { score.score(it.peerId) }.median()
                     if (scoreMedian < scoreParams.opportunisticGraftThreshold) {
                         (getTopicPeers(topic) - peers)
-                            .filter { score.score(it) > scoreMedian && !isDirect(it) && !isBackOff(it, topic) }
+                            .filter { score.score(it.peerId) > scoreMedian && !isDirect(it) && !isBackOff(it, topic) }
                             .take(params.opportunisticGraftPeers)
                             .forEach { graft(it, topic) }
                     }
@@ -460,12 +466,12 @@ open class GossipRouter @JvmOverloads constructor(
             }
             fanout.entries.forEach { (topic, peers) ->
                 peers.removeIf {
-                    it !in getTopicPeers(topic) || score.score(it) < scoreParams.publishThreshold
+                    it !in getTopicPeers(topic) || score.score(it.peerId) < scoreParams.publishThreshold
                 }
                 val needMore = params.D - peers.size
                 if (needMore > 0) {
                     peers += (getTopicPeers(topic) - peers)
-                        .filter { score.score(it) >= scoreParams.publishThreshold && !isDirect(it) }
+                        .filter { score.score(it.peerId) >= scoreParams.publishThreshold && !isDirect(it) }
                         .shuffled(random)
                         .take(needMore)
                 }
@@ -490,7 +496,7 @@ open class GossipRouter @JvmOverloads constructor(
 
         val shuffledMessageIds = ids.shuffled(random).take(params.maxIHaveLength)
         val peers = (getTopicPeers(topic) - excludePeers)
-            .filter { score.score(it) >= scoreParams.gossipThreshold && !isDirect(it) }
+            .filter { score.score(it.peerId) >= scoreParams.gossipThreshold && !isDirect(it) }
 
         peers.shuffled(random)
             .take(max((params.gossipFactor * peers.size).toInt(), params.DLazy))
@@ -522,7 +528,7 @@ open class GossipRouter @JvmOverloads constructor(
         val peerQueue = pendingRpcParts.getQueue(peer)
         if (peer.getPeerProtocol() == PubsubProtocol.Gossip_V_1_1 && this.protocol == PubsubProtocol.Gossip_V_1_1) {
             val backoffPeers = (getTopicPeers(topic) - peer)
-                .filter { score.score(it) >= 0 }
+                .filter { score.score(it.peerId) >= 0 }
                 .map { it.peerId }
             peerQueue.addPrune(topic, params.pruneBackoff.seconds, backoffPeers)
         } else {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -56,6 +56,7 @@ open class GossipRouter @JvmOverloads constructor(
     val acceptRequestsWhitelistMaxMessages = 128
     val acceptRequestsWhitelistDuration = 1.seconds
 
+    val eventBroadcaster = GossipRouterEventBroadcaster()
     open val score: GossipScore by lazy {
         DefaultGossipScore(scoreParams, executor, curTimeMillis).also {
             eventBroadcaster.listeners += it
@@ -64,7 +65,6 @@ open class GossipRouter @JvmOverloads constructor(
 
     val fanout: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
     val mesh: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
-    val eventBroadcaster = GossipRouterEventBroadcaster()
 
     private val mCache = MCache(params.gossipSize, params.gossipHistoryLength)
     private val lastPublished = linkedMapOf<Topic, Long>()

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.core.PeerId
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.PubsubMessage
@@ -9,65 +10,65 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 interface GossipRouterEventListener {
 
-    fun notifyDisconnected(peer: P2PService.PeerHandler)
+    fun notifyDisconnected(peerId: PeerId)
 
-    fun notifyConnected(peer: P2PService.PeerHandler)
+    fun notifyConnected(peerId: PeerId, ipAddress: String?)
 
-    fun notifyUnseenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage)
+    fun notifyUnseenMessage(peerId: PeerId, msg: PubsubMessage)
 
-    fun notifySeenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage, validationResult: Optional<ValidationResult>)
+    fun notifySeenMessage(peerId: PeerId, msg: PubsubMessage, validationResult: Optional<ValidationResult>)
 
-    fun notifyUnseenInvalidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage)
+    fun notifyUnseenInvalidMessage(peerId: PeerId, msg: PubsubMessage)
 
-    fun notifyUnseenValidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage)
+    fun notifyUnseenValidMessage(peerId: PeerId, msg: PubsubMessage)
 
-    fun notifyMeshed(peer: P2PService.PeerHandler, topic: Topic)
+    fun notifyMeshed(peerId: PeerId, topic: Topic)
 
-    fun notifyPruned(peer: P2PService.PeerHandler, topic: Topic)
+    fun notifyPruned(peerId: PeerId, topic: Topic)
 
-    fun notifyRouterMisbehavior(peer: P2PService.PeerHandler, count: Int)
+    fun notifyRouterMisbehavior(peerId: PeerId, count: Int)
 }
 
 class GossipRouterEventBroadcaster : GossipRouterEventListener {
     val listeners = CopyOnWriteArrayList<GossipRouterEventListener>()
 
-    override fun notifyDisconnected(peer: P2PService.PeerHandler) {
-        listeners.forEach { it.notifyDisconnected(peer) }
+    override fun notifyDisconnected(peerId: PeerId) {
+        listeners.forEach { it.notifyDisconnected(peerId) }
     }
 
-    override fun notifyConnected(peer: P2PService.PeerHandler) {
-        listeners.forEach { it.notifyConnected(peer) }
+    override fun notifyConnected(peerId: PeerId, ipAddress: String?) {
+        listeners.forEach { it.notifyConnected(peerId, ipAddress) }
     }
 
-    override fun notifyUnseenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
-        listeners.forEach { it.notifyUnseenMessage(peer, msg) }
+    override fun notifyUnseenMessage(peerId: PeerId, msg: PubsubMessage) {
+        listeners.forEach { it.notifyUnseenMessage(peerId, msg) }
     }
 
     override fun notifySeenMessage(
-        peer: P2PService.PeerHandler,
+        peerId: PeerId,
         msg: PubsubMessage,
         validationResult: Optional<ValidationResult>
     ) {
-        listeners.forEach { it.notifySeenMessage(peer, msg, validationResult) }
+        listeners.forEach { it.notifySeenMessage(peerId, msg, validationResult) }
     }
 
-    override fun notifyUnseenInvalidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
-        listeners.forEach { it.notifyUnseenInvalidMessage(peer, msg) }
+    override fun notifyUnseenInvalidMessage(peerId: PeerId, msg: PubsubMessage) {
+        listeners.forEach { it.notifyUnseenInvalidMessage(peerId, msg) }
     }
 
-    override fun notifyUnseenValidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
-        listeners.forEach { it.notifyUnseenValidMessage(peer, msg) }
+    override fun notifyUnseenValidMessage(peerId: PeerId, msg: PubsubMessage) {
+        listeners.forEach { it.notifyUnseenValidMessage(peerId, msg) }
     }
 
-    override fun notifyMeshed(peer: P2PService.PeerHandler, topic: Topic) {
-        listeners.forEach { it.notifyMeshed(peer, topic) }
+    override fun notifyMeshed(peerId: PeerId, topic: Topic) {
+        listeners.forEach { it.notifyMeshed(peerId, topic) }
     }
 
-    override fun notifyPruned(peer: P2PService.PeerHandler, topic: Topic) {
-        listeners.forEach { it.notifyPruned(peer, topic) }
+    override fun notifyPruned(peerId: PeerId, topic: Topic) {
+        listeners.forEach { it.notifyPruned(peerId, topic) }
     }
 
-    override fun notifyRouterMisbehavior(peer: P2PService.PeerHandler, count: Int) {
-        listeners.forEach { it.notifyRouterMisbehavior(peer, count) }
+    override fun notifyRouterMisbehavior(peerId: PeerId, count: Int) {
+        listeners.forEach { it.notifyRouterMisbehavior(peerId, count) }
     }
 }

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -1,0 +1,73 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.pubsub.ValidationResult
+import io.libp2p.etc.util.P2PService
+import io.libp2p.pubsub.PubsubMessage
+import io.libp2p.pubsub.Topic
+import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
+
+interface GossipRouterEventListener {
+
+    fun notifyDisconnected(peer: P2PService.PeerHandler)
+
+    fun notifyConnected(peer: P2PService.PeerHandler)
+
+    fun notifyUnseenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage)
+
+    fun notifySeenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage, validationResult: Optional<ValidationResult>)
+
+    fun notifyUnseenInvalidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage)
+
+    fun notifyUnseenValidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage)
+
+    fun notifyMeshed(peer: P2PService.PeerHandler, topic: Topic)
+
+    fun notifyPruned(peer: P2PService.PeerHandler, topic: Topic)
+
+    fun notifyRouterMisbehavior(peer: P2PService.PeerHandler, count: Int)
+}
+
+class GossipRouterEventBroadcaster : GossipRouterEventListener {
+    val listeners = CopyOnWriteArrayList<GossipRouterEventListener>()
+
+    override fun notifyDisconnected(peer: P2PService.PeerHandler) {
+        listeners.forEach { it.notifyDisconnected(peer) }
+    }
+
+    override fun notifyConnected(peer: P2PService.PeerHandler) {
+        listeners.forEach { it.notifyConnected(peer) }
+    }
+
+    override fun notifyUnseenMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
+        listeners.forEach { it.notifyUnseenMessage(peer, msg) }
+    }
+
+    override fun notifySeenMessage(
+        peer: P2PService.PeerHandler,
+        msg: PubsubMessage,
+        validationResult: Optional<ValidationResult>
+    ) {
+        listeners.forEach { it.notifySeenMessage(peer, msg, validationResult) }
+    }
+
+    override fun notifyUnseenInvalidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
+        listeners.forEach { it.notifyUnseenInvalidMessage(peer, msg) }
+    }
+
+    override fun notifyUnseenValidMessage(peer: P2PService.PeerHandler, msg: PubsubMessage) {
+        listeners.forEach { it.notifyUnseenValidMessage(peer, msg) }
+    }
+
+    override fun notifyMeshed(peer: P2PService.PeerHandler, topic: Topic) {
+        listeners.forEach { it.notifyMeshed(peer, topic) }
+    }
+
+    override fun notifyPruned(peer: P2PService.PeerHandler, topic: Topic) {
+        listeners.forEach { it.notifyPruned(peer, topic) }
+    }
+
+    override fun notifyRouterMisbehavior(peer: P2PService.PeerHandler, count: Int) {
+        listeners.forEach { it.notifyRouterMisbehavior(peer, count) }
+    }
+}

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -2,7 +2,6 @@ package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.PeerId
 import io.libp2p.core.pubsub.ValidationResult
-import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.Topic
 import java.util.*

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/DefaultGossipScoreTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/DefaultGossipScoreTest.kt
@@ -44,15 +44,15 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // not hit threshold yet
-        score.notifyRouterMisbehavior(peer, 5)
+        score.notifyRouterMisbehavior(peer.peerId, 5)
         assertEquals(0.0, score.score(peer.peerId))
 
         // behaviourPenaltyThreshold reached
-        score.notifyRouterMisbehavior(peer, 1)
+        score.notifyRouterMisbehavior(peer.peerId, 1)
         assertTrue(score.score(peer.peerId) < 0)
 
         // quadratic penalty
-        score.notifyRouterMisbehavior(peer, 10)
+        score.notifyRouterMisbehavior(peer.peerId, 10)
         assertTrue(score.score(peer.peerId) < -50)
 
         // negative behaviour should not be forgotten so fast
@@ -107,7 +107,7 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // After 1 quantum of time in the mesh, we should increment the score by timeInMeshWeight
@@ -116,22 +116,22 @@ class DefaultGossipScoreTest {
 
         // After delivering a message, we should increase our score by firstMessageDeliveriesWeight
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
-        score.notifyUnseenValidMessage(peer, msg)
+        score.notifyUnseenValidMessage(peer.peerId, msg)
         assertThat(score.score(peer.peerId)).isEqualTo(3.0)
 
         // Message for an unknown topic should be scored using default (disabled) scoring, so score should not change
         val unknownTopicMsg = DefaultPubsubMessage(createRpcMessage(otherTopic))
-        score.notifyUnseenValidMessage(peer, unknownTopicMsg)
+        score.notifyUnseenValidMessage(peer.peerId, unknownTopicMsg)
         assertThat(score.score(peer.peerId)).isEqualTo(3.0)
 
         // Invalid msg should decrement score
         val invalidMsg = DefaultPubsubMessage(createRpcMessage(topic, 2))
-        score.notifyUnseenInvalidMessage(peer, invalidMsg)
+        score.notifyUnseenInvalidMessage(peer.peerId, invalidMsg)
         assertThat(score.score(peer.peerId)).isEqualTo(2.5)
 
         // Invalid msg for unknown topic should not decrement score
         val unknownInvalidMsg = DefaultPubsubMessage(createRpcMessage(otherTopic, 2))
-        score.notifyUnseenInvalidMessage(peer, unknownInvalidMsg)
+        score.notifyUnseenInvalidMessage(peer.peerId, unknownInvalidMsg)
         assertThat(score.score(peer.peerId)).isEqualTo(2.5)
 
         // Advance time to activate low delivery penalty
@@ -173,12 +173,12 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // After delivering a message, we should increase our score by firstMessageDeliveriesWeight
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
-        score.notifyUnseenValidMessage(peer, msg)
+        score.notifyUnseenValidMessage(peer.peerId, msg)
         assertThat(score.score(peer.peerId)).isEqualTo(2.0)
 
         // Refresh to decay score
@@ -223,13 +223,13 @@ class DefaultGossipScoreTest {
         assertThat(score.getCachedScore(peer.peerId)).isEqualTo(0.0)
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
         assertThat(score.getCachedScore(peer.peerId)).isEqualTo(0.0)
 
         // After delivering a message, we should increase our score by firstMessageDeliveriesWeight
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
-        score.notifyUnseenValidMessage(peer, msg)
+        score.notifyUnseenValidMessage(peer.peerId, msg)
         assertThat(score.score(peer.peerId)).isEqualTo(2.0)
         assertThat(score.getCachedScore(peer.peerId)).isEqualTo(2.0)
 
@@ -278,16 +278,16 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // Deliver first message from other peer
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
-        score.notifyUnseenValidMessage(otherPeer, msg)
+        score.notifyUnseenValidMessage(otherPeer.peerId, msg)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // Deliver same message from target peer
-        score.notifySeenMessage(peer, msg, Optional.empty())
+        score.notifySeenMessage(peer.peerId, msg, Optional.empty())
         // Score should not change yet because we haven't passed the activation window
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
@@ -333,12 +333,12 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // After delivering an invalid message, we should get a penalty
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
-        score.notifyUnseenInvalidMessage(peer, msg)
+        score.notifyUnseenInvalidMessage(peer.peerId, msg)
         assertThat(score.score(peer.peerId)).isEqualTo(-2.0)
 
         // Refresh to decay score
@@ -384,7 +384,7 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // Increase time in mesh beyond max
@@ -435,7 +435,7 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // Increase time in mesh beyond max
@@ -487,13 +487,13 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // Deliver several message
         for (i in 0..5) {
             val msg = DefaultPubsubMessage(createRpcMessage(topic, i))
-            score.notifyUnseenValidMessage(peer, msg)
+            score.notifyUnseenValidMessage(peer.peerId, msg)
         }
         assertThat(score.score(peer.peerId)).isEqualTo(8.0)
 
@@ -558,18 +558,18 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // Deliver a bunch of invalid messages
         for (i in 0..5) {
             // Deliver first message from other peer
             val msg = DefaultPubsubMessage(createRpcMessage(topic, i))
-            score.notifyUnseenValidMessage(otherPeer, msg)
+            score.notifyUnseenValidMessage(otherPeer.peerId, msg)
             assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
             // Deliver same message from target peer
-            score.notifySeenMessage(peer, msg, Optional.empty())
+            score.notifySeenMessage(peer.peerId, msg, Optional.empty())
             // Score should not change yet because we haven't passed the activation window
             assertThat(score.score(peer.peerId)).isEqualTo(0.0)
         }
@@ -628,12 +628,12 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer.peerId))
 
         // Add peer to mesh
-        score.notifyMeshed(peer, topic)
+        score.notifyMeshed(peer.peerId, topic)
         assertThat(score.score(peer.peerId)).isEqualTo(0.0)
 
         // After delivering an invalid message, we should get a penalty
         val msg = DefaultPubsubMessage(createRpcMessage(topic))
-        score.notifyUnseenInvalidMessage(peer, msg)
+        score.notifyUnseenInvalidMessage(peer.peerId, msg)
         assertThat(score.score(peer.peerId)).isEqualTo(-2.0)
 
         // Update params and check score is updated
@@ -707,15 +707,15 @@ class DefaultGossipScoreTest {
         // Generate same activity for topic a and b
         for (curTopic in arrayOf(topicA, topicB)) {
             // Add peer to mesh
-            score.notifyMeshed(peer, curTopic)
+            score.notifyMeshed(peer.peerId, curTopic)
 
             // Deliver a valid first message
             val msg = DefaultPubsubMessage(createRpcMessage(curTopic))
-            score.notifyUnseenValidMessage(peer, msg)
+            score.notifyUnseenValidMessage(peer.peerId, msg)
 
             // Deliver an invalid message
             val invalidMsg = DefaultPubsubMessage(createRpcMessage(curTopic, 2))
-            score.notifyUnseenInvalidMessage(peer, invalidMsg)
+            score.notifyUnseenInvalidMessage(peer.peerId, invalidMsg)
         }
 
         // Increase time in mesh past activation period
@@ -727,6 +727,11 @@ class DefaultGossipScoreTest {
         // Update params and now second topic should contribute to the score (doubling it)
         score.updateTopicParams(mapOf(Pair(topicB, topicScoreParams)))
         assertThat(score.score(peer.peerId)).isEqualTo(-3.0)
+    }
+
+    @Test
+    fun `test IP colocation`() {
+        TODO()
     }
 
     private fun createRpcMessage(topic: String, seqNo: Int = 1): Rpc.Message {

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -256,7 +256,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
         val gossipRouter = scoringRouter.router as GossipRouter
         gossipRouter.peers.forEach {
-            assertThat(gossipRouter.score.score(it)).isGreaterThanOrEqualTo(0.0)
+            assertThat(gossipRouter.score.score(it.peerId)).isGreaterThanOrEqualTo(0.0)
         }
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicReference
 
 class GossipV1_1Tests {
 
+    private val GossipScore.testPeerScores get() = (this as DefaultGossipScore).peerScores
+
     private fun newProtoMessage(topic: Topic, seqNo: Long, data: ByteArray) =
         Rpc.Message.newBuilder()
             .addTopicIDs(topic)
@@ -184,7 +186,7 @@ class GossipV1_1Tests {
             .build()
         mockRouter.malform = true
 
-        val peerScores = test.gossipRouter.score.peerScores.values.first()
+        val peerScores = test.gossipRouter.score.testPeerScores.values.first()
         // no behavior penalty before flooding
         assertEquals(0.0, peerScores.behaviorPenalty)
 
@@ -331,8 +333,8 @@ class GossipV1_1Tests {
             )
         ).build()
 
-        assertEquals(1, test.gossipRouter.score.peerScores.size)
-        val peerScores = test.gossipRouter.score.peerScores.values.first()
+        assertEquals(1, test.gossipRouter.score.testPeerScores.size)
+        val peerScores = test.gossipRouter.score.testPeerScores.values.first()
         // no behavior penalty before flooding
         assertEquals(0.0, peerScores.behaviorPenalty)
 
@@ -352,13 +354,13 @@ class GossipV1_1Tests {
         test.router1.connectSemiDuplex(test.router2)
         test.fuzz.timeController.addTime(1.seconds)
 
-        assertEquals(1, test.gossipRouter.score.peerScores.size)
-        val peerScores1 = test.gossipRouter.score.peerScores.values.first()
+        assertEquals(1, test.gossipRouter.score.testPeerScores.size)
+        val peerScores1 = test.gossipRouter.score.testPeerScores.values.first()
         assertTrue(peerScores1.behaviorPenalty > 0.0)
 
         // check the penalty is decayed with time
         val origPenalty = peerScores1.behaviorPenalty
-        test.fuzz.timeController.addTime(test.gossipRouter.score.peerParams.decayInterval * 2)
+        test.fuzz.timeController.addTime(test.scoreParams.peerScoreParams.decayInterval * 2)
         assertTrue(peerScores1.behaviorPenalty < origPenalty)
     }
 
@@ -419,7 +421,7 @@ class GossipV1_1Tests {
         test.gossipRouter.subscribe("topic1")
 
         test.fuzz.timeController.addTime(2.seconds)
-        val peerScores1 = test.gossipRouter.score.peerScores.values.first()
+        val peerScores1 = test.gossipRouter.score.testPeerScores.values.first()
 
         val msg1 = Rpc.RPC.newBuilder().addPublish(newProtoMessage("topic1", 0L, "Hello-1".toByteArray())).build()
         test.mockRouter.sendToSingle(msg1)
@@ -456,7 +458,7 @@ class GossipV1_1Tests {
         assertTrue(invalidMessages4 > invalidMessages3)
 
         // check invalid message counter is decayed
-        test.fuzz.timeController.addTime(test.gossipRouter.score.peerParams.decayInterval * 2)
+        test.fuzz.timeController.addTime(test.scoreParams.peerScoreParams.decayInterval * 2)
         val invalidMessages5 = peerScores1.topicScores["topic1"]?.invalidMessages ?: 0.0
         assertTrue(invalidMessages5 < invalidMessages4)
     }
@@ -644,7 +646,7 @@ class GossipV1_1Tests {
         val publishedCount = test.mockRouters.flatMap { it.inboundMessages }.count { it.publishCount > 0 }
         assertTrue(publishedCount <= topicMesh.size)
 
-        val scores1 = test.gossipRouter.peers.map { it.peerId to test.gossipRouter.score.score(it) }.toMap()
+        val scores1 = test.gossipRouter.peers.map { it.peerId to test.gossipRouter.score.score(it.peerId) }.toMap()
 
         // peers 0 and 1 should not receive flood publish
         appScore[test.routers[0].peerId] =
@@ -660,7 +662,7 @@ class GossipV1_1Tests {
         println(appScore.keys)
 
         // check if scores are correctly calculated
-        val scores2 = test.gossipRouter.peers.map { it.peerId to test.gossipRouter.score.score(it) }.toMap()
+        val scores2 = test.gossipRouter.peers.map { it.peerId to test.gossipRouter.score.score(it.peerId) }.toMap()
         assertTrue(scores2[test.routers[0].peerId]!! < scoreParams.publishThreshold)
         assertTrue(scores2[test.routers[1].peerId]!! < scoreParams.publishThreshold)
         assertTrue(scores2[test.routers[2].peerId]!! > scoreParams.publishThreshold)
@@ -865,7 +867,7 @@ class GossipV1_1Tests {
         assertEquals(0, test.mockRouters[1].inboundMessages.count { it.publishCount > 0 })
         assertEquals(
             0.0,
-            test.gossipRouter.score.peerScores[test.routers[0].peerId]!!.topicScores["topic1"]!!.invalidMessages
+            test.gossipRouter.score.testPeerScores[test.routers[0].peerId]!!.topicScores["topic1"]!!.invalidMessages
         )
     }
 
@@ -878,13 +880,13 @@ class GossipV1_1Tests {
 
         val idToPeerHandlers = test.gossipRouter.peers.map { it.peerId to it }.toMap()
         var curScores = idToPeerHandlers
-            .mapValues { (_, handler) -> test.gossipRouter.score.score(handler) }
+            .mapValues { (_, handler) -> test.gossipRouter.score.score(handler.peerId) }
         assertEquals(0, curScores.values.count { it < 0 })
         for (i in 0..360) {
             assertEquals(20, curScores.size)
             test.fuzz.timeController.addTime(1.seconds)
             val newScores = idToPeerHandlers
-                .mapValues { (_, handler) -> test.gossipRouter.score.score(handler) }
+                .mapValues { (_, handler) -> test.gossipRouter.score.score(handler.peerId) }
             for (id in curScores.keys) {
                 assertTrue(newScores[id]!! >= curScores[id]!!)
             }
@@ -924,7 +926,7 @@ class GossipV1_1Tests {
         test.fuzz.timeController.addTime(10.seconds)
 
         // responded to IWANT in time - no penalties should be applied
-        assertEquals(0.0, test.gossipRouter.score.peerScores[test.router2.peerId]!!.behaviorPenalty)
+        assertEquals(0.0, test.gossipRouter.score.testPeerScores[test.router2.peerId]!!.behaviorPenalty)
 
         test.mockRouter.sendToSingle(
             Rpc.RPC.newBuilder().setControl(
@@ -943,7 +945,7 @@ class GossipV1_1Tests {
         test.fuzz.timeController.addTime(10.seconds)
 
         // messages were sent too late - penalty points should be applied
-        val penalty1 = test.gossipRouter.score.peerScores[test.router2.peerId]!!.behaviorPenalty
+        val penalty1 = test.gossipRouter.score.testPeerScores[test.router2.peerId]!!.behaviorPenalty
         assertTrue(penalty1 > 0)
 
         test.mockRouter.sendToSingle(
@@ -955,7 +957,7 @@ class GossipV1_1Tests {
         )
         test.fuzz.timeController.addTime(10.seconds)
         // all IWANT were ignored
-        assertTrue(test.gossipRouter.score.peerScores[test.router2.peerId]!!.behaviorPenalty > penalty1)
+        assertTrue(test.gossipRouter.score.testPeerScores[test.router2.peerId]!!.behaviorPenalty > penalty1)
     }
 
     @Test
@@ -1006,7 +1008,7 @@ class GossipV1_1Tests {
         // ... but should remove IWANT request timeout entry for 'gossiper' peer
         test.fuzz.timeController.addTime(10.seconds)
         // and the peer shouldn't be penalized
-        assertTrue(test.gossipRouter.score.peerScores[gossiperRouter.peerId]!!.behaviorPenalty == 0.0)
+        assertTrue(test.gossipRouter.score.testPeerScores[gossiperRouter.peerId]!!.behaviorPenalty == 0.0)
     }
 
     @Test


### PR DESCRIPTION
`GossipScore` consumes significant CPU time under high network load. 
This is initial refactoring before optimizations 

- Make `GossipRouter.score` property overridable 
- Extract 2 interfaces `GossipRouterEventListener` and `GossipScore`. Rename implementation to `DefaultGossipScore`
- Make them deal with `PeerId` instead of `PeerHandler`
- To retain the possibility to access `PeerHandler` add `P2PService:.peerIdToPeerHandlerMap`
- `P2PService`: hide mutable collections, expose immutable
