### PR TITLE
Optimizate GossipScore IP colocation calculation

### DIFF
--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -2,6 +2,7 @@ package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
+import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.anyComplete
 import io.libp2p.etc.types.completedExceptionally
@@ -26,6 +27,7 @@ const val MaxIAskedEntries = 256
 const val MaxPeerIHaveEntries = 256
 const val MaxIWantRequestsEntries = 10 * 1024
 
+fun P2PService.PeerHandler.getRemoteAddress(): Multiaddr = streamHandler.stream.connection.remoteAddress()
 fun P2PService.PeerHandler.isOutbound() = streamHandler.stream.connection.isInitiator
 
 fun P2PService.PeerHandler.getPeerProtocol(): PubsubProtocol {
@@ -116,7 +118,7 @@ open class GossipRouter @JvmOverloads constructor(
 
     override fun onPeerActive(peer: PeerHandler) {
         super.onPeerActive(peer)
-        eventBroadcaster.notifyConnected(peer.peerId, peer.getIP())
+        eventBroadcaster.notifyConnected(peer.peerId, peer.getRemoteAddress())
         heartbeatTask.hashCode() // force lazy initialization
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -5,7 +5,6 @@ import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.Topic
-import kotlinx.coroutines.supervisorScope
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -1,9 +1,11 @@
 package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.PeerId
+import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.Topic
+import kotlinx.coroutines.supervisorScope
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -11,7 +13,7 @@ interface GossipRouterEventListener {
 
     fun notifyDisconnected(peerId: PeerId)
 
-    fun notifyConnected(peerId: PeerId, ipAddress: String?)
+    fun notifyConnected(peerId: PeerId, peerAddress: Multiaddr)
 
     fun notifyUnseenMessage(peerId: PeerId, msg: PubsubMessage)
 
@@ -35,8 +37,8 @@ class GossipRouterEventBroadcaster : GossipRouterEventListener {
         listeners.forEach { it.notifyDisconnected(peerId) }
     }
 
-    override fun notifyConnected(peerId: PeerId, ipAddress: String?) {
-        listeners.forEach { it.notifyConnected(peerId, ipAddress) }
+    override fun notifyConnected(peerId: PeerId, peerAddress: Multiaddr) {
+        listeners.forEach { it.notifyConnected(peerId, peerAddress) }
     }
 
     override fun notifyUnseenMessage(peerId: PeerId, msg: PubsubMessage) {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -305,16 +305,16 @@ class DefaultGossipScore(
     }
 
     internal class PeerColocations {
-        private val map = mutableMapOf<PeerIP, MutableSet<PeerId>>()
+        private val colocatedPeers = mutableMapOf<PeerIP, MutableSet<PeerId>>()
 
         fun add(peerId: PeerId, peerIp: PeerIP) {
-            map.computeIfAbsent(peerIp) { mutableSetOf() } += peerId
+            colocatedPeers.computeIfAbsent(peerIp) { mutableSetOf() } += peerId
         }
 
         fun remove(peerId: PeerId, peerIp: PeerIP) {
-            map[peerIp]?.also { it -= peerId }
+            colocatedPeers[peerIp]?.also { it -= peerId }
         }
 
-        fun getPeerCountForIp(ip: PeerIP) = map[ip]?.size ?: 0
+        fun getPeerCountForIp(ip: PeerIP) = colocatedPeers[ip]?.size ?: 0
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/DefaultGossipScoreTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/DefaultGossipScoreTest.kt
@@ -2,6 +2,7 @@ package io.libp2p.pubsub.gossip
 
 import com.google.protobuf.ByteString
 import io.libp2p.core.PeerId
+import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.etc.types.hours
 import io.libp2p.etc.types.millis
 import io.libp2p.etc.types.minutes
@@ -732,6 +733,8 @@ class DefaultGossipScoreTest {
     @Test
     fun `test IP colocation penalty`() {
 
+        val addr1 = Multiaddr.fromString("/ip4/0.0.0.1")
+        val addr2 = Multiaddr.fromString("/ip4/0.0.0.2")
         val peer1 = PeerId.random()
         val peer2 = PeerId.random()
         val peer3 = PeerId.random()
@@ -756,24 +759,24 @@ class DefaultGossipScoreTest {
 
         // Check initial value
         val score = DefaultGossipScore(scoreParams, executor, { timeController.time })
-        score.notifyConnected(peer1, "0.0.0.1")
-        score.notifyConnected(peer2, "0.0.0.1")
+        score.notifyConnected(peer1, addr1)
+        score.notifyConnected(peer2, addr1)
         assertEquals(0.0, score.score(peer1))
         assertEquals(0.0, score.score(peer2))
 
-        score.notifyConnected(peer3, "0.0.0.2")
+        score.notifyConnected(peer3, addr2)
         assertEquals(0.0, score.score(peer1))
         assertEquals(0.0, score.score(peer2))
         assertEquals(0.0, score.score(peer3))
 
-        score.notifyConnected(peer4, "0.0.0.1")
+        score.notifyConnected(peer4, addr1)
 
         assertEquals(-1.0, score.score(peer1))
         assertEquals(-1.0, score.score(peer2))
         assertEquals(0.0, score.score(peer3))
         assertEquals(-1.0, score.score(peer4))
 
-        score.notifyConnected(peer5, "0.0.0.1")
+        score.notifyConnected(peer5, addr1)
 
         assertEquals(-4.0, score.score(peer1))
         assertEquals(-4.0, score.score(peer2))
@@ -809,7 +812,7 @@ class DefaultGossipScoreTest {
         assertEquals(0.0, score.score(peer4))
         assertEquals(0.0, score.score(peer5))
 
-        score.notifyConnected(peer1, "0.0.0.1")
+        score.notifyConnected(peer1, addr1)
 
         assertEquals(-1.0, score.score(peer1))
         assertEquals(0.0, score.score(peer3))
@@ -829,7 +832,7 @@ class DefaultGossipScoreTest {
         val peerId = PeerId.random()
         val peer = mockk<P2PService.PeerHandler>()
         every { peer.peerId } returns peerId
-        every { peer.getIP() } returns "127.0.0.1"
+        every { peer.getRemoteAddress() } returns Multiaddr.fromString("/ip4/127.0.0.1")
         return peer
     }
 }


### PR DESCRIPTION
The current algorithm of IP colocation score calculation has `O(n^2)` complexity and consumes significant CPU with lots of peer connections

This PR:
- Modifies the algorithm to `O(n)` complexity 
- Extracts the `PeerIP` class (which could be adjusted to IPv6 and colocation criteria later) 
- Pass more specific `Multiaddr` type for the `onConnected()` event