### PR TITLE
Refactor GossipRouter: extract GossipRouterBuilder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,7 +248,7 @@ fun findProperty(s: String) = project.findProperty(s) as String?
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {
     languageVersion = "1.6"
-    allWarningsAsErrors = false
+    allWarningsAsErrors = true
 }
 
 detekt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,7 +248,7 @@ fun findProperty(s: String) = project.findProperty(s) as String?
 val compileKotlin: KotlinCompile by tasks
 compileKotlin.kotlinOptions {
     languageVersion = "1.6"
-    allWarningsAsErrors = true
+    allWarningsAsErrors = false
 }
 
 detekt {

--- a/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -139,6 +139,17 @@ abstract class P2PService(
      */
     open fun addNewStream(stream: Stream) = initChannel(StreamHandler(stream))
 
+    /**
+     * Callback to initialize the [Stream] underlying [io.netty.channel.Channel]
+     *
+     * Is invoked **not** on the event thread
+     * [io.netty.channel.Channel] initialization must be performed **synchronously on the caller thread**.
+     * **Don't** initialize the channel on event thread!
+     * Any service logic related to adding a new stream could be performed
+     * within overridden [streamAdded] callback (which is invoked on event thread)
+     */
+    protected abstract fun initChannel(streamHandler: StreamHandler)
+
     protected open fun streamAdded(streamHandler: StreamHandler) {
         val peerHandler = createPeerHandler(streamHandler)
         streamHandler.initPeerHandler(peerHandler)
@@ -172,17 +183,6 @@ abstract class P2PService(
         if (stream.aborted) return
         onInbound(stream.getPeerHandler(), msg)
     }
-
-    /**
-     * Callback to initialize the [Stream] underlying [io.netty.channel.Channel]
-     *
-     * Is invoked **not** on the event thread
-     * [io.netty.channel.Channel] initialization must be performed **synchronously on the caller thread**.
-     * **Don't** initialize the channel on event thread!
-     * Any service logic related to adding a new stream could be performed
-     * within overridden [streamAdded] callback (which is invoked on event thread)
-     */
-    protected abstract fun initChannel(streamHandler: StreamHandler)
 
     /**
      * Callback notifies that the peer is active and ready for writing data

--- a/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
@@ -5,13 +5,14 @@ import io.libp2p.core.SemiDuplexNoOutboundStreamException
 import io.libp2p.etc.types.completedExceptionally
 import io.libp2p.etc.types.toVoidCompletableFuture
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ScheduledExecutorService
 
 /**
  * The service where communication between peers is performed via two [io.libp2p.core.Stream]s
  * They are initiated asynchronously by each peer. Initiated stream is used solely for writing data
  * and accepted steam is used solely for reading
  */
-abstract class P2PServiceSemiDuplex : P2PService() {
+abstract class P2PServiceSemiDuplex(executor: ScheduledExecutorService) : P2PService(executor) {
 
     inner class SDPeerHandler(streamHandler: StreamHandler) : PeerHandler(streamHandler) {
 

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -3,7 +3,6 @@ package io.libp2p.pubsub
 import io.libp2p.core.BadPeerException
 import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
-import io.libp2p.core.pubsub.RESULT_VALID
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.MultiSet
 import io.libp2p.etc.types.completedExceptionally
@@ -112,7 +111,7 @@ abstract class AbstractRouter(
         addNewStreamWithHandler(peer, debugHandler)
     }
 
-    override fun addNewStream(stream: Stream)  = addNewStreamWithHandler(stream, null)
+    override fun addNewStream(stream: Stream) = addNewStreamWithHandler(stream, null)
     protected fun addNewStreamWithHandler(stream: Stream, handler: ChannelHandler?) {
         initChannelWithHandler(StreamHandler(stream), handler)
     }

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -44,7 +44,7 @@ const val DEFAULT_MAX_SEEN_MESSAGES_LIMIT: Int = 10000
 abstract class AbstractRouter(
     executor: ScheduledExecutorService,
     override val protocol: PubsubProtocol,
-    private val subscriptionFilter: TopicSubscriptionFilter,
+    private val subscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
     private val maxMsgSize: Int = DEFAULT_MAX_PUBSUB_MESSAGE_SIZE,
     override val messageFactory: PubsubMessageFactory = { DefaultPubsubMessage(it) },
     protected val seenMessages: SeenCache<Optional<ValidationResult>> = LRUSeenCache(SimpleSeenCache(), DEFAULT_MAX_SEEN_MESSAGES_LIMIT),
@@ -69,10 +69,6 @@ abstract class AbstractRouter(
         fun getQueue(peer: PeerHandler) = map.computeIfAbsent(peer) { queueFactory() }
         fun popQueue(peer: PeerHandler) = map.remove(peer) ?: queueFactory()
     }
-
-//    override var curTimeMillis: () -> Long by lazyVarInit { { System.currentTimeMillis() } }
-//    override var random by lazyVarInit { Random() }
-//    override var name: String = "router"
 
     override fun publish(msg: PubsubMessage): CompletableFuture<Unit> {
         return submitAsyncOnEventThread {

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -107,14 +107,17 @@ abstract class AbstractRouter(
         }
     }
 
-    override fun addPeer(peer: Stream) {
-        addPeerWithDebugHandler(peer, null)
-    }
-
+    override fun addPeer(peer: Stream) = addPeerWithDebugHandler(peer, null)
     override fun addPeerWithDebugHandler(peer: Stream, debugHandler: ChannelHandler?) {
-        initChannelWithHandler(StreamHandler(peer), debugHandler)
+        addNewStreamWithHandler(peer, debugHandler)
     }
 
+    override fun addNewStream(stream: Stream)  = addNewStreamWithHandler(stream, null)
+    protected fun addNewStreamWithHandler(stream: Stream, handler: ChannelHandler?) {
+        initChannelWithHandler(StreamHandler(stream), handler)
+    }
+
+    override fun initChannel(streamHandler: StreamHandler) = initChannelWithHandler(streamHandler, null)
     protected open fun initChannelWithHandler(streamHandler: StreamHandler, handler: ChannelHandler?) {
         with(streamHandler.stream) {
             pushHandler(LimitedProtobufVarint32FrameDecoder(maxMsgSize))
@@ -125,8 +128,6 @@ abstract class AbstractRouter(
             pushHandler(streamHandler)
         }
     }
-
-    override fun initChannel(streamHandler: StreamHandler) = initChannelWithHandler(streamHandler, null)
 
     override fun removePeer(peer: Stream) {
         peer.close()

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -116,7 +116,7 @@ abstract class AbstractRouter(
         initChannelWithHandler(StreamHandler(peer), debugHandler)
     }
 
-    private fun initChannelWithHandler(streamHandler: StreamHandler, handler: ChannelHandler?) {
+    protected open fun initChannelWithHandler(streamHandler: StreamHandler, handler: ChannelHandler?) {
         with(streamHandler.stream) {
             pushHandler(LimitedProtobufVarint32FrameDecoder(maxMsgSize))
             pushHandler(ProtobufVarint32LengthFieldPrepender())

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -50,7 +50,7 @@ abstract class AbstractRouter(
     protected val messageValidator: PubsubRouterMessageValidator
 ) : P2PServiceSemiDuplex(executor), PubsubRouter, PubsubRouterDebug {
 
-    protected var msgHandler: PubsubMessageHandler = { RESULT_VALID }
+    protected var msgHandler: PubsubMessageHandler = { throw IllegalStateException("Message handler is not initialized for PubsubRouter") }
 
     protected open val peerTopics = MultiSet<PeerHandler, Topic>()
     protected open val subscribedTopics = linkedSetOf<Topic>()

--- a/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -36,7 +36,6 @@ open class DefaultPubsubMessage(override val protobufMessage: Rpc.Message) : Abs
 }
 
 private val logger = LogManager.getLogger(AbstractRouter::class.java)
-const val DEFAULT_MAX_SEEN_MESSAGES_LIMIT: Int = 10000
 
 /**
  * Implements common logic for pubsub routers

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -9,7 +9,6 @@ import io.netty.channel.ChannelHandler
 import pubsub.pb.Rpc
 import java.util.Random
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ScheduledExecutorService
 
 typealias Topic = String
 typealias MessageId = WBytes
@@ -62,8 +61,8 @@ abstract class AbstractPubsubMessage : PubsubMessage {
 interface PubsubMessageRouter {
 
     val protocol: PubsubProtocol
-    var messageFactory: PubsubMessageFactory
-    var messageValidator: PubsubRouterMessageValidator
+    val messageFactory: PubsubMessageFactory
+//    var messageValidator: PubsubRouterMessageValidator
 
     /**
      * Validates and broadcasts the message to suitable peers
@@ -139,13 +138,13 @@ interface PubsubRouterDebug : PubsubRouter {
      * Adds ability to substitute the scheduler which is used for all async and periodic
      * tasks within the router
      */
-    var executor: ScheduledExecutorService
+//    var executor: ScheduledExecutorService
 
     /**
      * System time supplier. Normally defaults to [System.currentTimeMillis]
      * If router needs system time it should refer to this supplier
      */
-    var curTimeMillis: () -> Long
+//    var curTimeMillis: () -> Long
 
     /**
      * Randomness supplier
@@ -153,9 +152,9 @@ interface PubsubRouterDebug : PubsubRouter {
      * Tests may substitute this instance with a fixed-seed [Random]
      * to perform deterministic testing
      */
-    var random: Random
-
-    var name: String
+//    var random: Random
+//
+//    var name: String
 
     /**
      * The same as [PubsubRouter.addPeer] but adds the [debugHandler] right before

--- a/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -7,7 +7,6 @@ import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.WBytes
 import io.netty.channel.ChannelHandler
 import pubsub.pb.Rpc
-import java.util.Random
 import java.util.concurrent.CompletableFuture
 
 typealias Topic = String
@@ -62,7 +61,6 @@ interface PubsubMessageRouter {
 
     val protocol: PubsubProtocol
     val messageFactory: PubsubMessageFactory
-//    var messageValidator: PubsubRouterMessageValidator
 
     /**
      * Validates and broadcasts the message to suitable peers
@@ -133,28 +131,6 @@ interface PubsubRouter : PubsubMessageRouter, PubsubPeerRouter
  * helpful for testing and debugging
  */
 interface PubsubRouterDebug : PubsubRouter {
-
-    /**
-     * Adds ability to substitute the scheduler which is used for all async and periodic
-     * tasks within the router
-     */
-//    var executor: ScheduledExecutorService
-
-    /**
-     * System time supplier. Normally defaults to [System.currentTimeMillis]
-     * If router needs system time it should refer to this supplier
-     */
-//    var curTimeMillis: () -> Long
-
-    /**
-     * Randomness supplier
-     * Whenever router implementation needs random data it must refer to this var
-     * Tests may substitute this instance with a fixed-seed [Random]
-     * to perform deterministic testing
-     */
-//    var random: Random
-//
-//    var name: String
 
     /**
      * The same as [PubsubRouter.addPeer] but adds the [debugHandler] right before

--- a/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
@@ -8,10 +8,11 @@ import io.libp2p.pubsub.TopicSubscriptionFilter
 import pubsub.pb.Rpc
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
 
-class FloodRouter : AbstractRouter(
+class FloodRouter(executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()) : AbstractRouter(
     protocol = PubsubProtocol.Floodsub,
-    executor = Executors.newSingleThreadScheduledExecutor(),
+    executor = executor,
     subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()
 ) {
 

--- a/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
@@ -1,13 +1,13 @@
 package io.libp2p.pubsub.flood
 
-import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.anyComplete
 import io.libp2p.pubsub.*
 import pubsub.pb.Rpc
-import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
+
+const val DEFAULT_MAX_SEEN_MESSAGES_LIMIT: Int = 10000
 
 class FloodRouter(executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()) : AbstractRouter(
     protocol = PubsubProtocol.Floodsub,

--- a/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
@@ -1,11 +1,10 @@
 package io.libp2p.pubsub.flood
 
+import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.anyComplete
-import io.libp2p.pubsub.AbstractRouter
-import io.libp2p.pubsub.PubsubMessage
-import io.libp2p.pubsub.PubsubProtocol
-import io.libp2p.pubsub.TopicSubscriptionFilter
+import io.libp2p.pubsub.*
 import pubsub.pb.Rpc
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -13,7 +12,11 @@ import java.util.concurrent.ScheduledExecutorService
 class FloodRouter(executor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()) : AbstractRouter(
     protocol = PubsubProtocol.Floodsub,
     executor = executor,
-    subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()
+    subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
+    maxMsgSize = Int.MAX_VALUE,
+    messageFactory = { DefaultPubsubMessage(it) },
+    seenMessages = LRUSeenCache(SimpleSeenCache(), DEFAULT_MAX_SEEN_MESSAGES_LIMIT),
+    messageValidator = NOP_ROUTER_VALIDATOR
 ) {
 
     // msg: validated unseen messages received from api

--- a/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
@@ -7,10 +7,13 @@ import io.libp2p.pubsub.PubsubProtocol
 import io.libp2p.pubsub.TopicSubscriptionFilter
 import pubsub.pb.Rpc
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 
-class FloodRouter : AbstractRouter(subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()) {
-
-    override val protocol = PubsubProtocol.Floodsub
+class FloodRouter : AbstractRouter(
+    protocol = PubsubProtocol.Floodsub,
+    executor = Executors.newSingleThreadScheduledExecutor(),
+    subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()
+) {
 
     // msg: validated unseen messages received from api
     override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -22,11 +22,11 @@ class Gossip @JvmOverloads constructor(
     ProtocolBinding<Unit>, ConnectionHandler, PubsubApi by api {
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
-        router.currentTimeSupplier.updateTopicParams(scoreParams)
+        router.score.updateTopicParams(scoreParams)
     }
 
     fun getGossipScore(peerId: PeerId): Double {
-        return router.currentTimeSupplier.getCachedScore(peerId)
+        return router.score.getCachedScore(peerId)
     }
 
     override val protocolDescriptor =

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -10,22 +10,23 @@ import io.libp2p.core.multistream.ProtocolDescriptor
 import io.libp2p.core.pubsub.PubsubApi
 import io.libp2p.pubsub.PubsubApiImpl
 import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.netty.channel.ChannelHandler
 import java.util.concurrent.CompletableFuture
 
 class Gossip @JvmOverloads constructor(
-    private val router: GossipRouter = GossipRouter(),
+    private val router: GossipRouter = GossipRouterBuilder().build(),
     private val api: PubsubApi = PubsubApiImpl(router),
     private val debugGossipHandler: ChannelHandler? = null
 ) :
     ProtocolBinding<Unit>, ConnectionHandler, PubsubApi by api {
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
-        router.score.updateTopicParams(scoreParams)
+        router.currentTimeSupplier.updateTopicParams(scoreParams)
     }
 
     fun getGossipScore(peerId: PeerId): Double {
-        return router.score.getCachedScore(peerId)
+        return router.currentTimeSupplier.getCachedScore(peerId)
     }
 
     override val protocolDescriptor =

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -3,21 +3,50 @@ package io.libp2p.pubsub.gossip
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.core.pubsub.ValidationResult
-import io.libp2p.etc.types.anyComplete
-import io.libp2p.etc.types.completedExceptionally
-import io.libp2p.etc.types.copy
-import io.libp2p.etc.types.createLRUMap
-import io.libp2p.etc.types.median
-import io.libp2p.etc.types.seconds
-import io.libp2p.etc.types.toWBytes
-import io.libp2p.etc.types.whenTrue
+import io.libp2p.etc.types.*
 import io.libp2p.etc.util.P2PService
 import io.libp2p.pubsub.*
+import org.apache.logging.log4j.LogManager
 import pubsub.pb.Rpc
-import java.util.Optional
+import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.collections.Collection
+import kotlin.collections.List
+import kotlin.collections.MutableMap
+import kotlin.collections.MutableSet
+import kotlin.collections.any
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.count
+import kotlin.collections.distinct
+import kotlin.collections.drop
+import kotlin.collections.filter
+import kotlin.collections.filterNot
+import kotlin.collections.flatMap
+import kotlin.collections.flatten
+import kotlin.collections.forEach
+import kotlin.collections.getOrPut
+import kotlin.collections.isNotEmpty
+import kotlin.collections.linkedMapOf
+import kotlin.collections.map
+import kotlin.collections.mapNotNull
+import kotlin.collections.minus
+import kotlin.collections.minusAssign
+import kotlin.collections.mutableMapOf
+import kotlin.collections.mutableSetOf
+import kotlin.collections.none
+import kotlin.collections.plus
+import kotlin.collections.plusAssign
+import kotlin.collections.reversed
+import kotlin.collections.set
+import kotlin.collections.shuffled
+import kotlin.collections.sortedBy
+import kotlin.collections.sum
+import kotlin.collections.take
+import kotlin.collections.toMutableSet
 import kotlin.math.max
 import kotlin.math.min
 
@@ -25,6 +54,8 @@ const val MaxBackoffEntries = 10 * 1024
 const val MaxIAskedEntries = 256
 const val MaxPeerIHaveEntries = 256
 const val MaxIWantRequestsEntries = 10 * 1024
+
+typealias CurrentTimeSupplier = () -> Long
 
 fun P2PService.PeerHandler.isOutbound() = streamHandler.stream.connection.isInitiator
 
@@ -37,15 +68,29 @@ fun P2PService.PeerHandler.getPeerProtocol(): PubsubProtocol {
     return PubsubProtocol.fromProtocol(proto)
 }
 
+private val logger = LogManager.getLogger(GossipRouter::class.java)
+
 /**
  * Router implementing this protocol: https://github.com/libp2p/specs/tree/master/pubsub/gossipsub
  */
 open class GossipRouter @JvmOverloads constructor(
-    val params: GossipParams = GossipParams(),
-    val scoreParams: GossipScoreParams = GossipScoreParams(),
-    override val protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1,
-    subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()
-) : AbstractRouter(subscriptionTopicSubscriptionFilter, params.maxGossipMessageSize) {
+        val params: GossipParams = GossipParams(),
+        val scoreParams: GossipScoreParams = GossipScoreParams(),
+        val currentTimeSupplier: CurrentTimeSupplier = { System.currentTimeMillis() },
+        val random: Random = Random(),
+        val name: String = "GossipRouter",
+        val mCache: MCache = MCache(params.gossipSize, params.gossipHistoryLength),
+        val score: GossipScore,
+
+        subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
+        protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1,
+        executor: ScheduledExecutorService,
+        maxMsgSize: Int = DEFAULT_MAX_PUBSUB_MESSAGE_SIZE,
+        messageFactory: PubsubMessageFactory = { DefaultPubsubMessage(it) },
+        seenMessages: SeenCache<Optional<ValidationResult>> = LRUSeenCache(SimpleSeenCache(), DEFAULT_MAX_SEEN_MESSAGES_LIMIT),
+        messageValidator: PubsubRouterMessageValidator = NOP_ROUTER_VALIDATOR,
+
+        ) : AbstractRouter(executor, protocol, subscriptionTopicSubscriptionFilter, maxMsgSize, messageFactory, seenMessages, messageValidator) {
 
     // The idea behind choosing these specific default values for acceptRequestsWhitelist was
     // - from one side are pretty small and safe: peer unlikely be able to drop its score to `graylist`
@@ -56,17 +101,16 @@ open class GossipRouter @JvmOverloads constructor(
     val acceptRequestsWhitelistMaxMessages = 128
     val acceptRequestsWhitelistDuration = 1.seconds
 
-    val eventBroadcaster = GossipRouterEventBroadcaster()
-    open val score: GossipScore by lazy {
-        DefaultGossipScore(scoreParams, executor, curTimeMillis).also {
-            eventBroadcaster.listeners += it
-        }
-    }
-
+//    open val score: GossipScore by lazy {
+//        DefaultGossipScore(scoreParams, executor, curTimeMillis).also {
+//            eventBroadcaster.listeners += it
+//        }
+//    }
+//
     val fanout: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
     val mesh: MutableMap<Topic, MutableSet<PeerHandler>> = linkedMapOf()
+    val eventBroadcaster = GossipRouterEventBroadcaster()
 
-    private val mCache = MCache(params.gossipSize, params.gossipHistoryLength)
     private val lastPublished = linkedMapOf<Topic, Long>()
     private var heartbeatsCount = 0
     private val backoffExpireTimes = createLRUMap<Pair<PeerId, Topic>, Long>(MaxBackoffEntries)
@@ -84,21 +128,17 @@ open class GossipRouter @JvmOverloads constructor(
     private val acceptRequestsWhitelist = mutableMapOf<PeerHandler, AcceptRequestsWhitelistEntry>()
     override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
-    override val seenMessages: SeenCache<Optional<ValidationResult>> by lazy {
-        TTLSeenCache(SimpleSeenCache(), params.seenTTL, curTimeMillis)
-    }
-
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
-        backoffExpireTimes[peer.peerId to topic] = curTimeMillis() + delay
+        backoffExpireTimes[peer.peerId to topic] = currentTimeSupplier() + delay
     }
 
     private fun isBackOff(peer: PeerHandler, topic: Topic) =
-        curTimeMillis() < (backoffExpireTimes[peer.peerId to topic] ?: 0)
+        currentTimeSupplier() < (backoffExpireTimes[peer.peerId to topic] ?: 0)
 
     private fun isBackOffFlood(peer: PeerHandler, topic: Topic): Boolean {
         val expire = backoffExpireTimes[peer.peerId to topic] ?: return false
-        return curTimeMillis() < expire - (params.pruneBackoff + params.graftFloodThreshold).toMillis()
+        return currentTimeSupplier() < expire - (params.pruneBackoff + params.graftFloodThreshold).toMillis()
     }
 
     private fun getDirectPeers() = peers.filter(::isDirect)
@@ -183,7 +223,7 @@ open class GossipRouter @JvmOverloads constructor(
             return true
         }
 
-        val curTime = curTimeMillis()
+        val curTime = currentTimeSupplier()
         val whitelistEntry = acceptRequestsWhitelist[peer]
         if (whitelistEntry != null &&
             curTime <= whitelistEntry.whitelistedTill &&
@@ -332,7 +372,7 @@ open class GossipRouter @JvmOverloads constructor(
     }
 
     override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> {
-        msg.topics.forEach { lastPublished[it] = curTimeMillis() }
+        msg.topics.forEach { lastPublished[it] = currentTimeSupplier() }
 
         val peers =
             if (params.floodPublish) {
@@ -405,7 +445,7 @@ open class GossipRouter @JvmOverloads constructor(
         iAsked.clear()
         peerIHave.clear()
 
-        val staleIWantTime = this.curTimeMillis() - params.iWantFollowupTime.toMillis()
+        val staleIWantTime = this.currentTimeSupplier() - params.iWantFollowupTime.toMillis()
         iWantRequests.entries.removeIf { (key, time) ->
             (time < staleIWantTime)
                 .whenTrue { notifyIWantTimeout(key.first, key.second) }
@@ -478,7 +518,7 @@ open class GossipRouter @JvmOverloads constructor(
                 emitGossip(topic, peers)
             }
             lastPublished.entries.removeIf { (topic, lastPub) ->
-                (curTimeMillis() - lastPub > params.fanoutTTL.toMillis())
+                (currentTimeSupplier() - lastPub > params.fanoutTTL.toMillis())
                     .whenTrue { fanout.remove(topic) }
             }
 
@@ -520,7 +560,7 @@ open class GossipRouter @JvmOverloads constructor(
     private fun iWant(peer: PeerHandler, messageIds: List<MessageId>) {
         if (messageIds.isEmpty()) return
         messageIds[random.nextInt(messageIds.size)]
-            .also { iWantRequests[peer to it] = curTimeMillis() }
+            .also { iWantRequests[peer to it] = currentTimeSupplier() }
         enqueueIwant(peer, messageIds)
     }
 

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -73,7 +73,7 @@ private val logger = LogManager.getLogger(GossipRouter::class.java)
 /**
  * Router implementing this protocol: https://github.com/libp2p/specs/tree/master/pubsub/gossipsub
  */
-open class GossipRouter (
+open class GossipRouter(
     val params: GossipParams,
     val scoreParams: GossipScoreParams,
     val currentTimeSupplier: CurrentTimeSupplier,
@@ -97,7 +97,6 @@ open class GossipRouter (
     seenMessages,
     messageValidator
 ) {
-
 
     // The idea behind choosing these specific default values for acceptRequestsWhitelist was
     // - from one side are pretty small and safe: peer unlikely be able to drop its score to `graylist`
@@ -251,13 +250,13 @@ open class GossipRouter (
         val iHaveMessageIdCount = msg.control?.ihaveList?.map { w -> w.messageIDsCount }?.sum() ?: 0
 
         return params.maxPublishedMessages?.let { msg.publishCount <= it } ?: true &&
-                params.maxTopicsPerPublishedMessage?.let { msg.publishList.none { m -> m.topicIDsCount > it } } ?: true &&
-                params.maxSubscriptions?.let { msg.subscriptionsCount <= it } ?: true &&
-                params.maxIHaveLength.let { iHaveMessageIdCount <= it } &&
-                params.maxIWantMessageIds?.let { iWantMessageIdCount <= it } ?: true &&
-                params.maxGraftMessages?.let { (msg.control?.graftCount ?: 0) <= it } ?: true &&
-                params.maxPruneMessages?.let { (msg.control?.pruneCount ?: 0) <= it } ?: true &&
-                params.maxPeersPerPruneMessage?.let { msg.control?.pruneList?.none { p -> p.peersCount > it } } ?: true
+            params.maxTopicsPerPublishedMessage?.let { msg.publishList.none { m -> m.topicIDsCount > it } } ?: true &&
+            params.maxSubscriptions?.let { msg.subscriptionsCount <= it } ?: true &&
+            params.maxIHaveLength.let { iHaveMessageIdCount <= it } &&
+            params.maxIWantMessageIds?.let { iWantMessageIdCount <= it } ?: true &&
+            params.maxGraftMessages?.let { (msg.control?.graftCount ?: 0) <= it } ?: true &&
+            params.maxPruneMessages?.let { (msg.control?.pruneCount ?: 0) <= it } ?: true &&
+            params.maxPeersPerPruneMessage?.let { msg.control?.pruneList?.none { p -> p.peersCount > it } } ?: true
     }
 
     private fun processControlMessage(controlMsg: Any, receivedFrom: PeerHandler) {

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -1,0 +1,86 @@
+package io.libp2p.pubsub.gossip.builders
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import io.libp2p.core.pubsub.ValidationResult
+import io.libp2p.etc.types.lazyVar
+import io.libp2p.etc.types.lazyVarInit
+import io.libp2p.pubsub.*
+import io.libp2p.pubsub.gossip.*
+import java.util.*
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+
+typealias GossipRouterEventsSubscriber = (GossipRouterEventListener) -> Unit
+typealias GossipScoreFactory =
+    (GossipScoreParams, ScheduledExecutorService, CurrentTimeSupplier, GossipRouterEventsSubscriber) -> GossipScore
+
+open class GossipRouterBuilder {
+
+    var name: String = "GossipRouter"
+    var protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1
+
+    var scheduledAsyncExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+        ThreadFactoryBuilder().setDaemon(true).setNameFormat("GossipRouter-event-thread-%d").build()
+    )
+
+    var currentTimeSuppluer: CurrentTimeSupplier by lazyVarInit { { System.currentTimeMillis() } }
+    var random by lazyVarInit { Random() }
+
+    var params: GossipParams = GossipParams()
+    var scoreParams: GossipScoreParams = GossipScoreParams()
+
+    var maxMsgSize: Int = DEFAULT_MAX_PUBSUB_MESSAGE_SIZE
+    var messageFactory: PubsubMessageFactory = { DefaultPubsubMessage(it) }
+    var messageValidator: PubsubRouterMessageValidator = NOP_ROUTER_VALIDATOR
+    var maxSeenMessagesLimit = 10000
+    var seenCache: SeenCache<Optional<ValidationResult>> by lazyVar {
+        LRUSeenCache(SimpleSeenCache(), maxSeenMessagesLimit)
+    }
+    val mCache: MCache = MCache(params.gossipSize, params.gossipHistoryLength)
+
+    var subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()
+
+    var scoreFactory: GossipScoreFactory =
+        { scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer, eventsSubscriber ->
+            val gossipScore = DefaultGossipScore(scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer)
+            eventsSubscriber(gossipScore)
+            gossipScore
+        }
+    val gossipRouterEventListeners = mutableListOf<GossipRouterEventListener>()
+
+    protected fun createGossipRouter(): GossipRouter {
+        val gossipScore = scoreFactory(scoreParams, scheduledAsyncExecutor, currentTimeSuppluer, { gossipRouterEventListeners += it })
+
+
+        val router = GossipRouter(
+                params = params,
+                scoreParams = scoreParams,
+                currentTimeSupplier = currentTimeSuppluer,
+                random = random,
+                name = name,
+                mCache = mCache,
+                score = gossipScore,
+                subscriptionTopicSubscriptionFilter = subscriptionTopicSubscriptionFilter,
+                protocol = protocol,
+                executor = scheduledAsyncExecutor,
+                maxMsgSize = maxMsgSize,
+                messageFactory = messageFactory,
+                seenMessages = seenCache,
+                messageValidator = messageValidator
+        )
+
+        router.eventBroadcaster.listeners += gossipRouterEventListeners
+        return router
+    }
+
+    open fun build(): GossipRouter = createGossipRouter()
+
+
+    // TODO: does it make any sense ?
+    open fun build(messageHandlerInitializer: GossipRouter.() -> PubsubMessageHandler): GossipRouter {
+        val gossipRouter = createGossipRouter()
+        val messageHandler = messageHandlerInitializer(gossipRouter)
+        gossipRouter.initHandler(messageHandler)
+        return gossipRouter
+    }
+}

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -33,8 +33,8 @@ open class GossipRouterBuilder(
     var subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
 
     var scoreFactory: GossipScoreFactory =
-        { scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer, eventsSubscriber ->
-            val gossipScore = DefaultGossipScore(scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer)
+        { scoreParams1, scheduledAsyncRxecutor, currentTimeSuppluer1, eventsSubscriber ->
+            val gossipScore = DefaultGossipScore(scoreParams1, scheduledAsyncRxecutor, currentTimeSuppluer1)
             eventsSubscriber(gossipScore)
             gossipScore
         },

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -28,10 +28,8 @@ open class GossipRouterBuilder(
         var currentTimeSuppluer: CurrentTimeSupplier = { System.currentTimeMillis() },
         var random: Random = Random(),
 
-        var maxMsgSize: Int = DEFAULT_MAX_PUBSUB_MESSAGE_SIZE,
         var messageFactory: PubsubMessageFactory = { DefaultPubsubMessage(it) },
         var messageValidator: PubsubRouterMessageValidator = NOP_ROUTER_VALIDATOR,
-        var maxSeenMessagesLimit: Int = 10000,
 
         var subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
 
@@ -44,7 +42,7 @@ open class GossipRouterBuilder(
         val gossipRouterEventListeners: MutableList<GossipRouterEventListener> = mutableListOf()
 ) {
 
-    var seenCache: SeenCache<Optional<ValidationResult>> by lazyVar { LRUSeenCache(SimpleSeenCache(), maxSeenMessagesLimit) }
+    var seenCache: SeenCache<Optional<ValidationResult>> by lazyVar { TTLSeenCache(SimpleSeenCache(), params.seenTTL, currentTimeSuppluer) }
     var mCache: MCache by lazyVar { MCache(params.gossipSize, params.gossipHistoryLength) }
 
     private var disposed = false
@@ -63,7 +61,6 @@ open class GossipRouterBuilder(
                 subscriptionTopicSubscriptionFilter = subscriptionTopicSubscriptionFilter,
                 protocol = protocol,
                 executor = scheduledAsyncExecutor,
-                maxMsgSize = maxMsgSize,
                 messageFactory = messageFactory,
                 seenMessages = seenCache,
                 messageValidator = messageValidator

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -3,7 +3,6 @@ package io.libp2p.pubsub.gossip.builders
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.lazyVar
-import io.libp2p.etc.types.lazyVarInit
 import io.libp2p.pubsub.*
 import io.libp2p.pubsub.gossip.*
 import java.util.*
@@ -12,34 +11,34 @@ import java.util.concurrent.ScheduledExecutorService
 
 typealias GossipRouterEventsSubscriber = (GossipRouterEventListener) -> Unit
 typealias GossipScoreFactory =
-        (GossipScoreParams, ScheduledExecutorService, CurrentTimeSupplier, GossipRouterEventsSubscriber) -> GossipScore
+    (GossipScoreParams, ScheduledExecutorService, CurrentTimeSupplier, GossipRouterEventsSubscriber) -> GossipScore
 
 open class GossipRouterBuilder(
 
-        var name: String = "GossipRouter",
-        var protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1,
+    var name: String = "GossipRouter",
+    var protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1,
 
-        var params: GossipParams = GossipParams(),
-        var scoreParams: GossipScoreParams = GossipScoreParams(),
+    var params: GossipParams = GossipParams(),
+    var scoreParams: GossipScoreParams = GossipScoreParams(),
 
-        var scheduledAsyncExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
-                ThreadFactoryBuilder().setDaemon(true).setNameFormat("GossipRouter-event-thread-%d").build()
-        ),
-        var currentTimeSuppluer: CurrentTimeSupplier = { System.currentTimeMillis() },
-        var random: Random = Random(),
+    var scheduledAsyncExecutor: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+        ThreadFactoryBuilder().setDaemon(true).setNameFormat("GossipRouter-event-thread-%d").build()
+    ),
+    var currentTimeSuppluer: CurrentTimeSupplier = { System.currentTimeMillis() },
+    var random: Random = Random(),
 
-        var messageFactory: PubsubMessageFactory = { DefaultPubsubMessage(it) },
-        var messageValidator: PubsubRouterMessageValidator = NOP_ROUTER_VALIDATOR,
+    var messageFactory: PubsubMessageFactory = { DefaultPubsubMessage(it) },
+    var messageValidator: PubsubRouterMessageValidator = NOP_ROUTER_VALIDATOR,
 
-        var subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
+    var subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
 
-        var scoreFactory: GossipScoreFactory =
-                { scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer, eventsSubscriber ->
-                    val gossipScore = DefaultGossipScore(scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer)
-                    eventsSubscriber(gossipScore)
-                    gossipScore
-                },
-        val gossipRouterEventListeners: MutableList<GossipRouterEventListener> = mutableListOf()
+    var scoreFactory: GossipScoreFactory =
+        { scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer, eventsSubscriber ->
+            val gossipScore = DefaultGossipScore(scoreParams, scheduledAsyncRxecutor, currentTimeSuppluer)
+            eventsSubscriber(gossipScore)
+            gossipScore
+        },
+    val gossipRouterEventListeners: MutableList<GossipRouterEventListener> = mutableListOf()
 ) {
 
     var seenCache: SeenCache<Optional<ValidationResult>> by lazyVar { TTLSeenCache(SimpleSeenCache(), params.seenTTL, currentTimeSuppluer) }
@@ -51,19 +50,19 @@ open class GossipRouterBuilder(
         val gossipScore = scoreFactory(scoreParams, scheduledAsyncExecutor, currentTimeSuppluer, { gossipRouterEventListeners += it })
 
         val router = GossipRouter(
-                params = params,
-                scoreParams = scoreParams,
-                currentTimeSupplier = currentTimeSuppluer,
-                random = random,
-                name = name,
-                mCache = mCache,
-                score = gossipScore,
-                subscriptionTopicSubscriptionFilter = subscriptionTopicSubscriptionFilter,
-                protocol = protocol,
-                executor = scheduledAsyncExecutor,
-                messageFactory = messageFactory,
-                seenMessages = seenCache,
-                messageValidator = messageValidator
+            params = params,
+            scoreParams = scoreParams,
+            currentTimeSupplier = currentTimeSuppluer,
+            random = random,
+            name = name,
+            mCache = mCache,
+            score = gossipScore,
+            subscriptionTopicSubscriptionFilter = subscriptionTopicSubscriptionFilter,
+            protocol = protocol,
+            executor = scheduledAsyncExecutor,
+            messageFactory = messageFactory,
+            seenMessages = seenCache,
+            messageValidator = messageValidator
         )
 
         router.eventBroadcaster.listeners += gossipRouterEventListeners

--- a/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -74,12 +74,4 @@ open class GossipRouterBuilder(
         disposed = true
         return createGossipRouter()
     }
-
-    // TODO: does it make any sense ?
-    open fun build(messageHandlerInitializer: GossipRouter.() -> PubsubMessageHandler): GossipRouter {
-        val gossipRouter = createGossipRouter()
-        val messageHandler = messageHandlerInitializer(gossipRouter)
-        gossipRouter.initHandler(messageHandler)
-        return gossipRouter
-    }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
@@ -3,11 +3,16 @@ package io.libp2p.pubsub
 import io.libp2p.core.crypto.KEY_TYPE
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.etc.types.lazyVar
+import io.libp2p.pubsub.flood.FloodRouter
+import io.libp2p.pubsub.gossip.CurrentTimeSupplier
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.libp2p.tools.schedulers.ControlledExecutorServiceImpl
 import io.libp2p.tools.schedulers.TimeControllerImpl
 import java.security.SecureRandom
 import java.util.Random
 import java.util.concurrent.ScheduledExecutorService
+
+typealias DeterministicFuzzRouterFactory = (ScheduledExecutorService, CurrentTimeSupplier, Random) -> PubsubRouterDebug
 
 class DeterministicFuzz {
 
@@ -17,21 +22,61 @@ class DeterministicFuzz {
     val random by lazyVar { Random(randomSeed) }
 
     fun createControlledExecutor(): ScheduledExecutorService =
-        ControlledExecutorServiceImpl().also { it.setTimeController(timeController) }
+            ControlledExecutorServiceImpl().also { it.setTimeController(timeController) }
 
-    fun createTestRouter(
-        routerInstance: PubsubRouterDebug,
-        protocol: PubsubProtocol = routerInstance.protocol
-    ): TestRouter {
-        routerInstance.curTimeMillis = { timeController.time }
-        routerInstance.random = this.random
-        val testRouter = TestRouter("" + (cnt++), protocol.announceStr).also {
+    fun createTestGossipRouter(gossipRouterBuilder: () -> GossipRouterBuilder): TestRouter =
+        createTestRouter(createGossipFuzzRouterFactory(gossipRouterBuilder))
+
+    fun createMockRouter() = createTestRouter(createMockFuzzRouterFactory())
+    fun createFloodRouter() = createTestRouter(createFloodFuzzRouterFactory())
+
+
+    fun createTestRouter(routerCtor: DeterministicFuzzRouterFactory): TestRouter {
+        val deterministicExecutor = createControlledExecutor()
+        val router = routerCtor(deterministicExecutor, { timeController.time }, random)
+
+        return TestRouter("" + (cnt++), router).apply {
             val randomBytes = ByteArray(8)
             random.nextBytes(randomBytes)
-            it.keyPair = generateKeyPair(KEY_TYPE.ECDSA, random = SecureRandom(randomBytes))
+            keyPair = generateKeyPair(KEY_TYPE.ECDSA, random = SecureRandom(randomBytes))
+            testExecutor = deterministicExecutor
         }
-        testRouter.routerInstance = routerInstance
-        testRouter.testExecutor = createControlledExecutor()
-        return testRouter
+    }
+
+//    fun createTestRouter(
+//            routerInstance: PubsubRouterDebug,
+//            protocol: PubsubProtocol = routerInstance.protocol
+//    ): TestRouter {
+//        routerInstance.curTimeMillis = { timeController.time }
+//        routerInstance.random = this.random
+//        val testRouter = TestRouter("" + (cnt++), protocol.announceStr).also {
+//            val randomBytes = ByteArray(8)
+//            random.nextBytes(randomBytes)
+//            it.keyPair = generateKeyPair(KEY_TYPE.ECDSA, random = SecureRandom(randomBytes))
+//        }
+//        testRouter.routerInstance = routerInstance
+//        testRouter.testExecutor = createControlledExecutor()
+//        return testRouter
+//    }
+
+    companion object {
+        fun createGossipFuzzRouterFactory(routerBuilderFactory: () -> GossipRouterBuilder): DeterministicFuzzRouterFactory =
+                { executor, curTime, random ->
+                    routerBuilderFactory().also {
+                        it.scheduledAsyncExecutor = executor
+                        it.currentTimeSuppluer = curTime
+                        it.random = random
+                    }.build()
+                }
+
+        fun createMockFuzzRouterFactory(): DeterministicFuzzRouterFactory =
+                { executor, _, _ ->
+                    MockRouter(executor)
+                }
+
+        fun createFloodFuzzRouterFactory(): DeterministicFuzzRouterFactory =
+            { executor, _, _ ->
+                FloodRouter(executor)
+            }
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
@@ -22,14 +22,13 @@ class DeterministicFuzz {
     val random by lazyVar { Random(randomSeed) }
 
     fun createControlledExecutor(): ScheduledExecutorService =
-            ControlledExecutorServiceImpl().also { it.setTimeController(timeController) }
+        ControlledExecutorServiceImpl().also { it.setTimeController(timeController) }
 
     fun createTestGossipRouter(gossipRouterBuilder: () -> GossipRouterBuilder): TestRouter =
         createTestRouter(createGossipFuzzRouterFactory(gossipRouterBuilder))
 
     fun createMockRouter() = createTestRouter(createMockFuzzRouterFactory())
     fun createFloodRouter() = createTestRouter(createFloodFuzzRouterFactory())
-
 
     fun createTestRouter(routerCtor: DeterministicFuzzRouterFactory): TestRouter {
         val deterministicExecutor = createControlledExecutor()
@@ -61,18 +60,18 @@ class DeterministicFuzz {
 
     companion object {
         fun createGossipFuzzRouterFactory(routerBuilderFactory: () -> GossipRouterBuilder): DeterministicFuzzRouterFactory =
-                { executor, curTime, random ->
-                    routerBuilderFactory().also {
-                        it.scheduledAsyncExecutor = executor
-                        it.currentTimeSuppluer = curTime
-                        it.random = random
-                    }.build()
-                }
+            { executor, curTime, random ->
+                routerBuilderFactory().also {
+                    it.scheduledAsyncExecutor = executor
+                    it.currentTimeSuppluer = curTime
+                    it.random = random
+                }.build()
+            }
 
         fun createMockFuzzRouterFactory(): DeterministicFuzzRouterFactory =
-                { executor, _, _ ->
-                    MockRouter(executor)
-                }
+            { executor, _, _ ->
+                MockRouter(executor)
+            }
 
         fun createFloodFuzzRouterFactory(): DeterministicFuzzRouterFactory =
             { executor, _, _ ->

--- a/src/test/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
@@ -42,22 +42,6 @@ class DeterministicFuzz {
         }
     }
 
-//    fun createTestRouter(
-//            routerInstance: PubsubRouterDebug,
-//            protocol: PubsubProtocol = routerInstance.protocol
-//    ): TestRouter {
-//        routerInstance.curTimeMillis = { timeController.time }
-//        routerInstance.random = this.random
-//        val testRouter = TestRouter("" + (cnt++), protocol.announceStr).also {
-//            val randomBytes = ByteArray(8)
-//            random.nextBytes(randomBytes)
-//            it.keyPair = generateKeyPair(KEY_TYPE.ECDSA, random = SecureRandom(randomBytes))
-//        }
-//        testRouter.routerInstance = routerInstance
-//        testRouter.testExecutor = createControlledExecutor()
-//        return testRouter
-//    }
-
     companion object {
         fun createGossipFuzzRouterFactory(routerBuilderFactory: () -> GossipRouterBuilder): DeterministicFuzzRouterFactory =
             { executor, curTime, random ->

--- a/src/test/kotlin/io/libp2p/pubsub/GoInteropTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/GoInteropTest.kt
@@ -28,7 +28,7 @@ import io.libp2p.mux.mplex.MplexStreamMuxer
 import io.libp2p.protocol.Identify
 import io.libp2p.protocol.Ping
 import io.libp2p.pubsub.gossip.Gossip
-import io.libp2p.pubsub.gossip.GossipRouter
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.libp2p.security.secio.SecIoSecureChannel
 import io.libp2p.tools.P2pdRunner
 import io.libp2p.tools.TestChannel
@@ -117,15 +117,12 @@ class GoInteropTest {
 
             println("Local peerID: " + PeerId.fromPubKey(pubKey1).toBase58())
 
-            val gossipRouter = GossipRouter().also {
-                it.messageValidator = SIGNATURE_ROUTER_VALIDATOR
-            }
-            val pubsubApi = createPubsubApi(gossipRouter)
+            val gossipRouter1 = GossipRouterBuilder().build()
+            val pubsubApi = createPubsubApi(gossipRouter1)
             val publisher = pubsubApi.createPublisher(privKey1, 8888)
 
-            val gossip = GossipProtocol(gossipRouter).also {
+            val gossip = GossipProtocol(gossipRouter1).also {
                 it.debugGossipHandler = LoggingHandler("#4", LogLevel.INFO)
-                it.router.messageValidator = NOP_ROUTER_VALIDATOR
             }
 
             val applicationProtocols = listOf(ProtocolBinding.createSimple("/meshsub/1.0.0", gossip), Identify())

--- a/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -10,9 +10,14 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
 open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
-        executor,
-        PubsubProtocol.Gossip_V_1_1,
-        TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()) {
+    protocol = PubsubProtocol.Floodsub,
+    executor = executor,
+    subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
+    maxMsgSize = Int.MAX_VALUE,
+    messageFactory = { DefaultPubsubMessage(it) },
+    seenMessages = LRUSeenCache(SimpleSeenCache(), DEFAULT_MAX_SEEN_MESSAGES_LIMIT),
+    messageValidator = NOP_ROUTER_VALIDATOR
+) {
 
     val inboundMessages: BlockingQueue<Rpc.RPC> = LinkedBlockingQueue()
 

--- a/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -3,13 +3,16 @@ package io.libp2p.pubsub
 import pubsub.pb.Rpc
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
-open class MockRouter(
-    override val protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_1
-) : AbstractRouter(TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()) {
+open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
+        executor,
+        PubsubProtocol.Gossip_V_1_1,
+        TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter()) {
 
     val inboundMessages: BlockingQueue<Rpc.RPC> = LinkedBlockingQueue()
 
@@ -22,7 +25,7 @@ open class MockRouter(
         var cnt = 0
         while (true) {
             val msg = inboundMessages.poll(5, TimeUnit.SECONDS)
-                ?: throw TimeoutException("No matching message received among $cnt")
+                    ?: throw TimeoutException("No matching message received among $cnt")
             if (predicate(msg)) return msg
             cnt++
         }

--- a/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -3,7 +3,6 @@ package io.libp2p.pubsub
 import pubsub.pb.Rpc
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -15,7 +14,7 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
     subscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
     maxMsgSize = Int.MAX_VALUE,
     messageFactory = { DefaultPubsubMessage(it) },
-    seenMessages = LRUSeenCache(SimpleSeenCache(), DEFAULT_MAX_SEEN_MESSAGES_LIMIT),
+    seenMessages = LRUSeenCache(SimpleSeenCache(), 1000),
     messageValidator = NOP_ROUTER_VALIDATOR
 ) {
 
@@ -30,7 +29,7 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
         var cnt = 0
         while (true) {
             val msg = inboundMessages.poll(5, TimeUnit.SECONDS)
-                    ?: throw TimeoutException("No matching message received among $cnt")
+                ?: throw TimeoutException("No matching message received among $cnt")
             if (predicate(msg)) return msg
             cnt++
         }

--- a/src/test/kotlin/io/libp2p/pubsub/PubsubApiTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/PubsubApiTest.kt
@@ -7,7 +7,6 @@ import io.libp2p.core.pubsub.createPubsubApi
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
 import io.libp2p.etc.types.toLongBigEndian
-import io.libp2p.pubsub.flood.FloodRouter
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/src/test/kotlin/io/libp2p/pubsub/PubsubApiTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/PubsubApiTest.kt
@@ -23,9 +23,9 @@ class PubsubApiTest {
     @Test
     fun testNoFromOrSeqNoMessageField() {
         val fuzz = DeterministicFuzz()
-        val router1 = fuzz.createTestRouter(FloodRouter())
+        val router1 = fuzz.createFloodRouter()
         val api1 = createPubsubApi(router1.router)
-        val router2 = fuzz.createTestRouter(FloodRouter())
+        val router2 = fuzz.createFloodRouter()
         val api2 = createPubsubApi(router2.router)
 
         router1.connectSemiDuplex(router2)
@@ -56,9 +56,9 @@ class PubsubApiTest {
     @Test
     fun testNoSenderPrivateKey() {
         val fuzz = DeterministicFuzz()
-        val router1 = fuzz.createTestRouter(FloodRouter())
+        val router1 = fuzz.createFloodRouter()
         val api1 = createPubsubApi(router1.router)
-        val router2 = fuzz.createTestRouter(FloodRouter())
+        val router2 = fuzz.createFloodRouter()
 
         router1.connectSemiDuplex(router2)
 
@@ -83,9 +83,9 @@ class PubsubApiTest {
     @Test
     fun testPublishExt() {
         val fuzz = DeterministicFuzz()
-        val router1 = fuzz.createTestRouter(FloodRouter())
+        val router1 = fuzz.createFloodRouter()
         val api1 = createPubsubApi(router1.router)
-        val router2 = fuzz.createTestRouter(FloodRouter())
+        val router2 = fuzz.createFloodRouter()
 
         router1.connectSemiDuplex(router2)
 

--- a/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -1,6 +1,5 @@
 package io.libp2p.pubsub
 
-import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.MessageApi
 import io.libp2p.core.pubsub.RESULT_INVALID
 import io.libp2p.core.pubsub.RESULT_VALID
@@ -14,7 +13,6 @@ import io.libp2p.etc.types.toBytesBigEndian
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.pubsub.gossip.GossipRouter
 import io.libp2p.tools.TestChannel.TestConnection
-import io.libp2p.transport.implementation.P2PChannelOverNetty
 import io.netty.handler.logging.LogLevel
 import io.netty.util.ResourceLeakDetector
 import org.junit.jupiter.api.Assertions

--- a/src/test/kotlin/io/libp2p/pubsub/TestRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/TestRouter.kt
@@ -36,8 +36,8 @@ class SemiduplexConnection(val conn1: TestConnection, val conn2: TestConnection)
 }
 
 class TestRouter(
-        val name: String = "" + cnt.getAndIncrement(),
-        val router: PubsubRouterDebug
+    val name: String = "" + cnt.getAndIncrement(),
+    val router: PubsubRouterDebug
 ) {
 
     val inboundMessages = LinkedBlockingQueue<PubsubMessage>()

--- a/src/test/kotlin/io/libp2p/pubsub/TestRouter.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/TestRouter.kt
@@ -5,12 +5,10 @@ import io.libp2p.core.crypto.KEY_TYPE
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.pubsub.RESULT_VALID
 import io.libp2p.core.pubsub.ValidationResult
-import io.libp2p.core.pubsub.createPubsubApi
 import io.libp2p.core.security.SecureChannel
 import io.libp2p.etc.PROTOCOL
 import io.libp2p.etc.types.lazyVar
 import io.libp2p.etc.util.netty.nettyInitializer
-import io.libp2p.pubsub.flood.FloodRouter
 import io.libp2p.tools.NullTransport
 import io.libp2p.tools.TestChannel
 import io.libp2p.tools.TestChannel.TestConnection
@@ -48,9 +46,6 @@ class TestRouter(
     }
 
     var testExecutor: ScheduledExecutorService by lazyVar { Executors.newSingleThreadScheduledExecutor() }
-
-    var routerInstance: PubsubRouterDebug by lazyVar { FloodRouter() }
-    var api by lazyVar { createPubsubApi(router) }
 
     var keyPair = generateKeyPair(KEY_TYPE.ECDSA)
     val peerId by lazy { PeerId.fromPubKey(keyPair.second) }

--- a/src/test/kotlin/io/libp2p/pubsub/flood/FloodPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/flood/FloodPubsubRouterTest.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub.flood
 
+import io.libp2p.pubsub.DeterministicFuzz
 import io.libp2p.pubsub.PubsubRouterTest
 
-class FloodPubsubRouterTest : PubsubRouterTest(::FloodRouter)
+class FloodPubsubRouterTest : PubsubRouterTest(DeterministicFuzz.createFloodFuzzRouterFactory())

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipBackwardCompatibilityTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipBackwardCompatibilityTest.kt
@@ -1,12 +1,13 @@
 package io.libp2p.pubsub.gossip
 
 import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class GossipBackwardCompatibilityTest : TwoGossipHostTestBase() {
-    override val router1 = GossipRouter(protocol = PubsubProtocol.Gossip_V_1_0)
-    override val router2 = GossipRouter(protocol = PubsubProtocol.Gossip_V_1_1)
+    override val router1 = GossipRouterBuilder(protocol = PubsubProtocol.Gossip_V_1_0).build()
+    override val router2 = GossipRouterBuilder(protocol = PubsubProtocol.Gossip_V_1_1).build()
 
     @Test
     fun testConnect_1_0_to_1_1() {

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -121,7 +121,7 @@ class GossipPubsubRouterTest : PubsubRouterTest(
         val fuzz = DeterministicFuzz()
 
         val router1 = fuzz.createMockRouter()
-        val router2 = fuzz.createTestRouter(router)
+        val router2 = fuzz.createTestRouter(routerFactory)
         val mockRouter = router1.router as MockRouter
 
         router2.router.subscribe("topic1")
@@ -148,8 +148,8 @@ class GossipPubsubRouterTest : PubsubRouterTest(
         val fuzz = DeterministicFuzz()
 
         val router1 = fuzz.createMockRouter()
-        val router2 = fuzz.createTestRouter(router)
-        val router3 = fuzz.createTestRouter(router)
+        val router2 = fuzz.createTestRouter(routerFactory)
+        val router3 = fuzz.createTestRouter(routerFactory)
         val mockRouter = router1.router as MockRouter
 
         router2.router.subscribe("topic1")

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -21,9 +21,9 @@ import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 class GossipPubsubRouterTest : PubsubRouterTest(
-        createGossipFuzzRouterFactory {
-            GossipRouterBuilder(params = GossipParams(3, 3, 100, floodPublish = false))
-        }
+    createGossipFuzzRouterFactory {
+        GossipRouterBuilder(params = GossipParams(3, 3, 100, floodPublish = false))
+    }
 ) {
 
     @Test
@@ -31,11 +31,12 @@ class GossipPubsubRouterTest : PubsubRouterTest(
         for (d in 3..6) {
             for (seed in 0..10) {
                 print("D=$d, seed=$seed  ")
-                super.doTenNeighborsTopology(seed,
-                        createGossipFuzzRouterFactory {
-                            // small backoff timeout for faster meshes settling down
-                            GossipRouterBuilder(params = GossipParams(d, d, d, DLazy = 100, pruneBackoff = 1.seconds))
-                        }
+                super.doTenNeighborsTopology(
+                    seed,
+                    createGossipFuzzRouterFactory {
+                        // small backoff timeout for faster meshes settling down
+                        GossipRouterBuilder(params = GossipParams(d, d, d, DLazy = 100, pruneBackoff = 1.seconds))
+                    }
                 )
             }
         }
@@ -58,7 +59,7 @@ class GossipPubsubRouterTest : PubsubRouterTest(
         // this is to test ihave/iwant
         fuzz.timeController.addTime(Duration.ofMillis(1))
 
-        val r =  { GossipRouterBuilder(params = GossipParams(3, 3, 3, DOut = 0, DLazy = 1000, floodPublish = false)) }
+        val r = { GossipRouterBuilder(params = GossipParams(3, 3, 3, DOut = 0, DLazy = 1000, floodPublish = false)) }
         val routerCenter = fuzz.createTestGossipRouter(r)
         allRouters.add(0, routerCenter)
 
@@ -230,7 +231,7 @@ class GossipPubsubRouterTest : PubsubRouterTest(
 
         val allCount = 20
         val allRouters = (1..allCount).map {
-            val r =  { GossipRouterBuilder(params = Eth2DefaultGossipParams, scoreParams = gossipScoreParams) }
+            val r = { GossipRouterBuilder(params = Eth2DefaultGossipParams, scoreParams = gossipScoreParams) }
             fuzz.createTestRouter(createGossipFuzzRouterFactory(r))
         }
 

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -4,10 +4,12 @@ import io.libp2p.core.pubsub.RESULT_IGNORE
 import io.libp2p.etc.types.seconds
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.pubsub.DeterministicFuzz
+import io.libp2p.pubsub.DeterministicFuzz.Companion.createGossipFuzzRouterFactory
 import io.libp2p.pubsub.MockRouter
 import io.libp2p.pubsub.PubsubRouterTest
 import io.libp2p.pubsub.TestRouter
 import io.libp2p.pubsub.gossip.builders.GossipPeerScoreParamsBuilder
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.libp2p.pubsub.gossip.builders.GossipScoreParamsBuilder
 import io.libp2p.tools.TestLogAppender
 import io.netty.handler.logging.LogLevel
@@ -18,23 +20,23 @@ import pubsub.pb.Rpc
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
-class GossipPubsubRouterTest : PubsubRouterTest({
-    GossipRouter(
-        GossipParams(3, 3, 100, floodPublish = false)
-    )
-}) {
+class GossipPubsubRouterTest : PubsubRouterTest(
+        createGossipFuzzRouterFactory {
+            GossipRouterBuilder(params = GossipParams(3, 3, 100, floodPublish = false))
+        }
+) {
 
     @Test
     override fun TenNeighborsTopology() {
         for (d in 3..6) {
             for (seed in 0..10) {
                 print("D=$d, seed=$seed  ")
-                super.doTenNeighborsTopology(seed) {
-                    GossipRouter(
-                        // small backoff timeout for faster meshes settling down
-                        GossipParams(d, d, d, DLazy = 100, pruneBackoff = 1.seconds)
-                    )
-                }
+                super.doTenNeighborsTopology(seed,
+                        createGossipFuzzRouterFactory {
+                            // small backoff timeout for faster meshes settling down
+                            GossipRouterBuilder(params = GossipParams(d, d, d, DLazy = 100, pruneBackoff = 1.seconds))
+                        }
+                )
             }
         }
     }
@@ -47,8 +49,8 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
         val otherCount = 5
         for (i in 1..otherCount) {
-            val r = GossipRouter(GossipParams(1, 0))
-            val routerEnd = fuzz.createTestRouter(r)
+            val r = { GossipRouterBuilder(params = GossipParams(1, 0)) }
+            val routerEnd = fuzz.createTestGossipRouter(r)
             allRouters += routerEnd
         }
 
@@ -56,8 +58,8 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         // this is to test ihave/iwant
         fuzz.timeController.addTime(Duration.ofMillis(1))
 
-        val r = GossipRouter(GossipParams(3, 3, 3, DOut = 0, DLazy = 1000, floodPublish = false))
-        val routerCenter = fuzz.createTestRouter(r)
+        val r =  { GossipRouterBuilder(params = GossipParams(3, 3, 3, DOut = 0, DLazy = 1000, floodPublish = false)) }
+        val routerCenter = fuzz.createTestGossipRouter(r)
         allRouters.add(0, routerCenter)
 
         for (i in 1..otherCount) {
@@ -117,8 +119,8 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         // shouldn't be treated as internal error and no WARN logs should be printed
         val fuzz = DeterministicFuzz()
 
-        val router1 = fuzz.createTestRouter(MockRouter())
-        val router2 = fuzz.createTestRouter(router())
+        val router1 = fuzz.createMockRouter()
+        val router2 = fuzz.createTestRouter(router)
         val mockRouter = router1.router as MockRouter
 
         router2.router.subscribe("topic1")
@@ -144,9 +146,9 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         // of gossip peers is yet 'partially' connected
         val fuzz = DeterministicFuzz()
 
-        val router1 = fuzz.createTestRouter(MockRouter())
-        val router2 = fuzz.createTestRouter(router())
-        val router3 = fuzz.createTestRouter(router())
+        val router1 = fuzz.createMockRouter()
+        val router2 = fuzz.createTestRouter(router)
+        val router3 = fuzz.createTestRouter(router)
         val mockRouter = router1.router as MockRouter
 
         router2.router.subscribe("topic1")
@@ -188,13 +190,13 @@ class GossipPubsubRouterTest : PubsubRouterTest({
         // shouldn't be treated as internal error and no WARN logs should be printed
         val fuzz = DeterministicFuzz()
 
-        val router1 = fuzz.createTestRouter(MockRouter())
+        val router1 = fuzz.createMockRouter()
 
         // when isDirect the gossip router should reply with PRUNE to GRAFT
         // this would reproduce the case
         val gossipScoreParams = GossipScoreParams(GossipPeerScoreParams(isDirect = { true }))
 
-        val router2 = fuzz.createTestRouter(GossipRouter(scoreParams = gossipScoreParams))
+        val router2 = fuzz.createTestGossipRouter { GossipRouterBuilder(scoreParams = gossipScoreParams) }
         val mockRouter = router1.router as MockRouter
 
         router2.router.subscribe("topic1")
@@ -228,8 +230,8 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
         val allCount = 20
         val allRouters = (1..allCount).map {
-            val r = GossipRouter(Eth2DefaultGossipParams, gossipScoreParams)
-            fuzz.createTestRouter(r)
+            val r =  { GossipRouterBuilder(params = Eth2DefaultGossipParams, scoreParams = gossipScoreParams) }
+            fuzz.createTestRouter(createGossipFuzzRouterFactory(r))
         }
 
         val senderRouter = allRouters[0]
@@ -256,7 +258,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
         val gossipRouter = scoringRouter.router as GossipRouter
         gossipRouter.peers.forEach {
-            assertThat(gossipRouter.currentTimeSupplier.score(it.peerId)).isGreaterThanOrEqualTo(0.0)
+            assertThat(gossipRouter.score.score(it.peerId)).isGreaterThanOrEqualTo(0.0)
         }
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipPubsubRouterTest.kt
@@ -256,7 +256,7 @@ class GossipPubsubRouterTest : PubsubRouterTest({
 
         val gossipRouter = scoringRouter.router as GossipRouter
         gossipRouter.peers.forEach {
-            assertThat(gossipRouter.score.score(it.peerId)).isGreaterThanOrEqualTo(0.0)
+            assertThat(gossipRouter.currentTimeSupplier.score(it.peerId)).isGreaterThanOrEqualTo(0.0)
         }
     }
 }

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterListLimitsTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterListLimitsTest.kt
@@ -1,6 +1,7 @@
 package io.libp2p.pubsub.gossip
 
 import io.libp2p.pubsub.gossip.builders.GossipParamsBuilder
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.libp2p.tools.protobuf.RpcBuilder
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -31,260 +32,218 @@ class GossipRouterListLimitsTest {
         .maxIHaveLength(Int.MAX_VALUE)
         .build()
 
+    private val routerWithLimits = GossipRouterBuilder(params = gossipParamsWithLimits).build()
+    private val routerWithNoLimits = GossipRouterBuilder(params = gossipParamsNoLimits).build()
+
     @Test
     fun validateProtobufLists_validMessage() {
-        val router = GossipRouter(gossipParamsWithLimits)
         val msg = fullMsgBuilder().build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_validMessageWithLargeLists_noLimits() {
-        val router = GossipRouter(gossipParamsNoLimits)
         val msg = fullMsgBuilder(20).build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithNoLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_smallValidMessage_noLimits() {
-        val router = GossipRouter(gossipParamsNoLimits)
         val msg = fullMsgBuilder().build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithNoLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_multipleListsAtMaxSize() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addSubscriptions(maxSubscriptions - 1)
         builder.addPublishMessages(maxPublishedMessages - 1, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_tooManySubscriptions() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addSubscriptions(maxSubscriptions)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyPublishMessages() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPublishMessages(maxPublishedMessages, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyPublishMessageTopics() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPublishMessages(1, maxTopicsPerPublishedMessage + 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyIHaves() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIHaves(maxIHaveLength, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyIHaveMsgIds() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIHaves(1, maxIHaveLength)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyIWants() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIWants(maxIWantMessageIds, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyIWantMsgIds() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIWants(1, maxIWantMessageIds)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyGrafts() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addGrafts(maxGraftMessages)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyPrunes() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPrunes(maxPruneMessages, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_tooManyPrunePeers() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPrunes(1, maxPeersPerPruneMessage + 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isFalse()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isFalse()
     }
 
     @Test
     fun validateProtobufLists_maxSubscriptions() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addSubscriptions(maxSubscriptions - 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxPublishMessages() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPublishMessages(maxPublishedMessages - 1, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxPublishMessageTopics() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPublishMessages(1, maxTopicsPerPublishedMessage)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxIHaves() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIHaves(maxIHaveLength - 1, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxIHaveMsgIds() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIHaves(1, maxIHaveLength - 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxIWants() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIWants(maxIWantMessageIds - 1, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxIWantMsgIds() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addIWants(1, maxIWantMessageIds - 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxGrafts() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addGrafts(maxGraftMessages - 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxPrunes() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPrunes(maxPruneMessages - 1, 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     @Test
     fun validateProtobufLists_maxPrunePeers() {
-        val router = GossipRouter(gossipParamsWithLimits)
-
         val builder = fullMsgBuilder()
         builder.addPrunes(1, maxPeersPerPruneMessage - 1)
         val msg = builder.build()
 
-        Assertions.assertThat(router.validateMessageListLimits(msg)).isTrue()
+        Assertions.assertThat(routerWithLimits.validateMessageListLimits(msg)).isTrue()
     }
 
     private fun fullMsgBuilder(): RpcBuilder {

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.PeerId
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.etc.types.toWBytes
 import io.libp2p.pubsub.gossip.builders.GossipParamsBuilder
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -190,7 +191,7 @@ class GossipRpcPartsQueueTest {
         gossipParams: GossipParams,
         queue: TestGossipQueue
     ) {
-        val router = GossipRouter(gossipParams)
+        val router = GossipRouterBuilder(params = gossipParams).build()
 
         val monolithMsg = queue.mergedSingle()
         val merged = queue.takeMerged()
@@ -217,7 +218,7 @@ class GossipRpcPartsQueueTest {
 
     @Test
     fun `mergeMessageParts() test that split doesn't result in topic publish before subscribe`() {
-        val router = GossipRouter(gossipParamsWithLimits)
+        val router = GossipRouterBuilder(params = gossipParamsWithLimits).build()
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
         (0 until maxSubscriptions + 1).forEach {
             partsQueue.addSubscribe("topic-$it")
@@ -239,7 +240,7 @@ class GossipRpcPartsQueueTest {
 
     @Test
     fun `mergeMessageParts() test that even when all parts fit to 2 messages the result should be 3 messages`() {
-        val router = GossipRouter(gossipParamsWithLimits)
+        val router = GossipRouterBuilder(params = gossipParamsWithLimits).build()
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
         (0 until maxSubscriptions + 1).forEach {
             partsQueue.addSubscribe("topic-$it")

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -57,13 +57,13 @@ class GossipV1_1Tests {
     protected fun getMessageId(msg: Rpc.Message): MessageId = msg.from.toWBytes() + msg.seqno.toWBytes()
 
     class ManyRoutersTest(
-            val mockRouterCount: Int = 10,
-            val params: GossipParams = GossipParams(),
-            val scoreParams: GossipScoreParams = GossipScoreParams(),
+        val mockRouterCount: Int = 10,
+        val params: GossipParams = GossipParams(),
+        val scoreParams: GossipScoreParams = GossipScoreParams(),
 //            mockRouters: () -> List<MockRouter> = { (0 until mockRouterCount).map { MockRouter() } }
     ) {
         val fuzz = DeterministicFuzz()
-        val gossipRouterBuilderFactory = { GossipRouterBuilder(params = params, scoreParams =  scoreParams) }
+        val gossipRouterBuilderFactory = { GossipRouterBuilder(params = params, scoreParams = scoreParams) }
         val router0 = fuzz.createTestRouter(createGossipFuzzRouterFactory(gossipRouterBuilderFactory))
         val routers = (0 until mockRouterCount).map { fuzz.createTestRouter(createMockFuzzRouterFactory()) }
         val connections = mutableListOf<SemiduplexConnection>()
@@ -100,9 +100,9 @@ class GossipV1_1Tests {
         mockRouterFactory: DeterministicFuzzRouterFactory = createMockFuzzRouterFactory()
     ) {
         val fuzz = DeterministicFuzz()
-        val gossipRouterBuilderFactory = { GossipRouterBuilder(params = coreParams, scoreParams =  scoreParams) }
+        val gossipRouterBuilderFactory = { GossipRouterBuilder(params = coreParams, scoreParams = scoreParams) }
         val router1 = fuzz.createTestRouter(createGossipFuzzRouterFactory(gossipRouterBuilderFactory))
-        val router2 =  fuzz.createTestRouter(mockRouterFactory)
+        val router2 = fuzz.createTestRouter(mockRouterFactory)
         val gossipRouter = router1.router as GossipRouter
         val mockRouter = router2.router as MockRouter
 

--- a/src/test/kotlin/io/libp2p/pubsub/gossip/TwoGossipHostTestBase.kt
+++ b/src/test/kotlin/io/libp2p/pubsub/gossip/TwoGossipHostTestBase.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.dsl.host
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.mux.StreamMuxerProtocol
 import io.libp2p.etc.util.netty.LoggingHandlerShort
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.libp2p.security.noise.NoiseXXSecureChannel
 import io.libp2p.transport.tcp.TcpTransport
 import io.netty.handler.logging.LogLevel
@@ -16,8 +17,8 @@ abstract class TwoGossipHostTestBase {
 
     open val params = GossipParams()
 
-    open val router1 by lazy { GossipRouter(params) }
-    open val router2 by lazy { GossipRouter(params) }
+    open val router1 by lazy { GossipRouterBuilder(params = params).build() }
+    open val router2 by lazy { GossipRouterBuilder(params = params).build() }
 
     open val gossip1 by lazy {
         Gossip(router1, debugGossipHandler = LoggingHandlerShort("host-1", LogLevel.INFO))


### PR DESCRIPTION
This is follow up to #247 

In the very initial version I've made an attempt to invent a new Kotlin specific pattern which combines both builder and its resulting class entities. It should in theory make the code smaller and supporting efforts cheaper. 

But it finally failed to be both a builder pattern and any kind of sustainable code. With `GossipRouter` becoming more complex class that approach is turning into error-prone spaghetti code. 

This PR extracts `GossipRouterBuilder` with making `GossipRouter` properties final (where appropriate), which looks more like a traditional pattern for Teku code and should be less error-prone and more sustainable 

Also:
- Move property declarations right after primary constructor (which may also declare properties) in changed classes
- Refactor `AbstractRouter.addPeerWithDebugHandler()` workaround 
- Remove pubsub interface `var` properties 
- Adjust tests