### PR TITLE
Switch lib version to 'develop' in the develop branch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 // ./gradlew publish -PcloudsmithUser=<user> -PcloudsmithApiKey=<api-key>
 
 group = "io.libp2p"
-version = "0.7.0-RELEASE"
+version = "develop"
 description = "a minimal implementation of libp2p for the jvm"
 
 plugins {


### PR DESCRIPTION
Set the lib version to `develop` in the develop branch. 
This is for better local develop build testing. I.e. when you make `publishToMavenLocal` of a develop branch and need to test it with Teku of other project you may just use the `develop` maven dependency version