### PR TITLE
Fix scenario where a call to `getPeerHandler` would always throw

### DIFF
--- a/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -166,8 +166,8 @@ abstract class P2PService(
     }
 
     protected open fun streamDisconnected(stream: StreamHandler) {
-        val peerHandler = stream.getPeerHandler()
         if (stream.aborted) return
+        val peerHandler = stream.getPeerHandler()
         activePeersMutable -= peerHandler
         if (peersMutable.remove(peerHandler)) {
             onPeerDisconnected(peerHandler)


### PR DESCRIPTION
Attempt to fix an issue where `stream.getPeerHandler` is called even when steam is closed on initialization, which would always throw due to `peerHandler` not being set, as documented in `P2PService.closeAbruptly`

![image](https://user-images.githubusercontent.com/742762/185508961-81b334d2-22e6-443a-9c8c-76459308b706.png)

Avoiding the `stream.getPeerHandler` call in the case where `stream.aborted == true` should prevent this error.

Issue raised in Teku:
https://github.com/ConsenSys/teku/issues/6088

ps. I'm not familiar with the code base at all - so my investigation and guess may well be incorrect. I'm looking for a way to test this - any suggestions / ideas on how to do this is appreciated!