### PR TITLE
Finer grained netty dependencies

### DIFF
--- a/libp2p/build.gradle.kts
+++ b/libp2p/build.gradle.kts
@@ -5,7 +5,12 @@ plugins {
 }
 
 dependencies {
-    api("io.netty:netty-all")
+    api("io.netty:netty-common")
+    api("io.netty:netty-buffer")
+    api("io.netty:netty-transport")
+    implementation("io.netty:netty-handler")
+    implementation("io.netty:netty-codec-http")
+
     api("com.google.protobuf:protobuf-java")
 
     implementation("commons-codec:commons-codec")
@@ -15,6 +20,8 @@ dependencies {
     implementation("org.bouncycastle:bcpkix-jdk15on")
 
     testImplementation(project(":tools:schedulers"))
+
+    testFixturesImplementation("io.netty:netty-transport-classes-epoll")
 
     jmhImplementation(project(":tools:schedulers"))
     jmhImplementation("org.openjdk.jmh:jmh-core")

--- a/tools/simulator/build.gradle
+++ b/tools/simulator/build.gradle
@@ -5,6 +5,8 @@ dependencies {
   api project(':libp2p')
   api project(':tools:schedulers')
 
+  implementation("io.netty:netty-handler")
+
   implementation("org.jgrapht:jgrapht-core:1.3.1")
   api("org.apache.commons:commons-math3:3.6.1")
   implementation("org.jetbrains.kotlin:kotlin-reflect:1.3.0")

--- a/versions.gradle
+++ b/versions.gradle
@@ -27,7 +27,14 @@ dependencyManagement {
             entry 'protobuf-java'
             entry 'protoc'
         }
-        dependency "io.netty:netty-all:4.1.87.Final"
+        dependencySet(group: "io.netty", version: "4.1.87.Final") {
+            entry 'netty-common'
+            entry 'netty-handler'
+            entry 'netty-transport'
+            entry 'netty-buffer'
+            entry 'netty-codec-http'
+            entry 'netty-transport-classes-epoll'
+        }
         dependency "commons-codec:commons-codec:1.15"
         dependency "tech.pegasys:noise-java:22.1.0"
         dependencySet(group: "org.bouncycastle", version: "1.70") {


### PR DESCRIPTION
Follow up to https://github.com/libp2p/jvm-libp2p/issues/274#issuecomment-1549011067

'Umbrella' artifact `netty-all` transitively includes a lot of unneeded Netty dependencies. 
It's better to have finer grained Netty artifacts dependencies 