### PR TITLE
Expose eventloop on Stream

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/core/Stream.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/Stream.kt
@@ -2,6 +2,7 @@ package io.libp2p.core
 
 import io.libp2p.protocol.ProtocolMessageHandler
 import io.libp2p.protocol.ProtocolMessageHandlerAdapter
+import io.netty.channel.EventLoop
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -9,6 +10,11 @@ import java.util.concurrent.CompletableFuture
  */
 interface Stream : P2PChannel {
     val connection: Connection
+
+    /**
+     * Return the underlying EventLoop
+     */
+    fun eventLoop(): EventLoop
 
     /**
      * Returns the [PeerId] of the remote peer [Connection] which this

--- a/libp2p/src/main/kotlin/io/libp2p/transport/implementation/StreamOverNetty.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/implementation/StreamOverNetty.kt
@@ -6,6 +6,7 @@ import io.libp2p.core.Stream
 import io.libp2p.etc.PROTOCOL
 import io.libp2p.etc.types.toVoidCompletableFuture
 import io.netty.channel.Channel
+import io.netty.channel.EventLoop
 import java.util.concurrent.CompletableFuture
 
 class StreamOverNetty(
@@ -13,9 +14,14 @@ class StreamOverNetty(
     override val connection: Connection,
     initiator: Boolean
 ) : Stream, P2PChannelOverNetty(ch, initiator) {
+
+    val group: EventLoop
     init {
         nettyChannel.attr(PROTOCOL).set(CompletableFuture())
+        group = ch.eventLoop()
     }
+
+    override fun eventLoop() = group
 
     /**
      * Returns the [PeerId] of the remote peer [Connection] which this

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/NettyStream.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/NettyStream.java
@@ -3,7 +3,7 @@ package io.libp2p.tools.p2pd;
 import io.libp2p.tools.p2pd.libp2pj.Muxer;
 import io.libp2p.tools.p2pd.libp2pj.Stream;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
+import io.netty.channel.*;
 
 import java.nio.ByteBuffer;
 
@@ -28,6 +28,11 @@ public class NettyStream implements Stream<Muxer.MuxerAdress> {
 
     public NettyStream(Channel channel, boolean initiator) {
         this(channel, initiator, null, null);
+    }
+
+    @Override
+    public EventLoop eventLoop() {
+        return channel.eventLoop();
     }
 
     @Override

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Stream.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Stream.java
@@ -1,5 +1,7 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
+import io.netty.channel.*;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -8,6 +10,8 @@ import java.nio.ByteBuffer;
 public interface Stream<TEndpoint> {
 
     boolean isInitiator();
+
+    EventLoop eventLoop();
 
     void write(ByteBuffer data);
 

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/tools/Stubs.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/tools/Stubs.kt
@@ -6,6 +6,7 @@ import io.libp2p.core.Stream
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.etc.util.P2PService
 import io.netty.channel.ChannelHandler
+import io.netty.channel.EventLoop
 import java.util.concurrent.CompletableFuture
 
 class ConnectionStub : Connection {
@@ -25,6 +26,11 @@ class ConnectionStub : Connection {
 class StreamStub : Stream {
     private val remotePeerId = PeerId.random()
     override val connection = ConnectionStub()
+
+    override fun eventLoop(): EventLoop {
+        TODO("Not yet implemented")
+    }
+
     override fun remotePeerId() = remotePeerId
     override fun getProtocol() = CompletableFuture.completedFuture("nop")
     override fun pushHandler(handler: ChannelHandler) = TODO()

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TestStreamChannel.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TestStreamChannel.kt
@@ -15,6 +15,7 @@ import io.libp2p.etc.util.netty.nettyInitializer
 import io.libp2p.transport.implementation.P2PChannelOverNetty
 import io.netty.channel.Channel
 import io.netty.channel.ChannelHandler
+import io.netty.channel.EventLoop
 import io.netty.channel.embedded.EmbeddedChannel
 import java.util.concurrent.CompletableFuture
 
@@ -40,6 +41,10 @@ class TestStreamChannel<TController>(
 private class TestStream(ch: Channel, initiator: Boolean) : P2PChannelOverNetty(ch, initiator), Stream {
     init {
         nettyChannel.attr(PROTOCOL).set(CompletableFuture())
+    }
+
+    override fun eventLoop(): EventLoop {
+        TODO("Not yet implemented")
     }
 
     override fun remotePeerId(): PeerId {

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/Libp2pStreamImpl.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/Libp2pStreamImpl.kt
@@ -6,6 +6,7 @@ import io.libp2p.etc.PROTOCOL
 import io.libp2p.etc.types.toVoidCompletableFuture
 import io.libp2p.transport.implementation.P2PChannelOverNetty
 import io.netty.channel.Channel
+import io.netty.channel.EventLoop
 import java.util.concurrent.CompletableFuture
 
 class Libp2pStreamImpl(
@@ -28,4 +29,8 @@ class Libp2pStreamImpl(
 
     override fun closeWrite(): CompletableFuture<Unit> =
         nettyChannel.disconnect().toVoidCompletableFuture()
+
+    override fun eventLoop(): EventLoop {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
The use for the EventLoop is a p2p http proxy. It accepts incoming libp2p connections and proxies it to a fixed http endpoint or http handler. We needed access to the eventloop to add the new http handlers when receiving a new connection: https://github.com/Peergos/nabu/blob/master/src/main/java/org/peergos/protocol/http/HttpProtocol.java#L103

It is basically HTTP over libp2p. The entire implementation is in the single file linked above. We explain the use case a bit more in the "Decentralization" section of https://peergos.org/posts/dev-update