### PR TITLE
Fix ecdsa cert usage in TLS which bouncycastle broke

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
@@ -145,7 +145,7 @@ fun buildTlsHandler(
                     mux.protocolDescriptor.protocolMatcher.matches(nextProtocol)
                 }
                 .map { mux ->
-                    NegotiatedStreamMuxer(mux, nextProtocol) 
+                    NegotiatedStreamMuxer(mux, nextProtocol)
                 }
                 .firstOrNull()
             handshakeComplete.complete(

--- a/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
@@ -71,6 +71,8 @@ class TlsSecureChannel(private val localKey: PrivKey, private val muxers: List<S
         init {
             Security.insertProviderAt(Libp2pCrypto.provider, 1)
             Security.insertProviderAt(BouncyCastleJsseProvider(), 2)
+            Security.setProperty("ssl.KeyManagerFactory.algorithm", "PKIX")
+            Security.setProperty("ssl.TrustManagerFactory.algorithm", "PKIX")
         }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
@@ -140,14 +140,14 @@ fun buildTlsHandler(
             handshakeComplete.completeExceptionally(cause)
         } else {
             val nextProtocol = handler.applicationProtocol()
-            val selectedMuxer = muxers.stream()
-                .flatMap { mux ->
-                    mux.protocolDescriptor.announceProtocols.stream()
-                        .filter({ it.equals(nextProtocol) })
-                        .map { NegotiatedStreamMuxer(mux, it) }
+            val selectedMuxer = muxers
+                .filter { mux ->
+                    mux.protocolDescriptor.protocolMatcher.matches(nextProtocol)
                 }
-                .findFirst()
-                .orElse(null)
+                .map { mux ->
+                    NegotiatedStreamMuxer(mux, nextProtocol) 
+                }
+                .firstOrNull()
             handshakeComplete.complete(
                 SecureChannel.Session(
                     PeerId.fromPubKey(localKey.publicKey()),

--- a/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
@@ -37,7 +37,7 @@ public class HostTestJava {
 
         Host clientHost = new HostBuilder()
                 .transport(TcpTransport::new)
-                .secureChannel(TlsSecureChannel::new)
+                .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
                 .muxer(StreamMuxerProtocol::getYamux)
                 .build();
 


### PR DESCRIPTION
Also update unit test to cover this

Edit: Including another fix for early muxer negotiation via ALPN which wasn't actually using the ALPN result. 

Added a helper method to construct ECDSA based instances of TLS. 