### PR TITLE
Fix yamux handling of writes bigger than the window size

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -43,9 +43,10 @@ open class YamuxHandler(
                 val buf = buffered.first()
                 val readableBytes = buf.readableBytes()
                 if (readableBytes + written < sendWindow.get()) {
-                    buffered.removeFirst()
                     sendBlocks(ctx, buf, sendWindow, id)
                     written += readableBytes
+                    buf.release()
+                    buffered.removeFirst()
                 } else {
                     // partial write to fit within window
                     val toRead = sendWindow.get() - written

--- a/libp2p/src/main/kotlin/io/libp2p/protocol/Ping.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/protocol/Ping.kt
@@ -22,19 +22,22 @@ interface PingController {
     fun ping(): CompletableFuture<Long>
 }
 
-class Ping : PingBinding(PingProtocol())
+class Ping(pingSize: Int) : PingBinding(PingProtocol(pingSize)) {
+    constructor() : this(32)
+}
 
 open class PingBinding(ping: PingProtocol) :
     StrictProtocolBinding<PingController>("/ipfs/ping/1.0.0", ping)
 
 class PingTimeoutException : Libp2pException()
 
-open class PingProtocol : ProtocolHandler<PingController>(Long.MAX_VALUE, Long.MAX_VALUE) {
+open class PingProtocol(var pingSize: Int) : ProtocolHandler<PingController>(Long.MAX_VALUE, Long.MAX_VALUE) {
     var timeoutScheduler by lazyVar { Executors.newSingleThreadScheduledExecutor() }
     var curTime: () -> Long = { System.currentTimeMillis() }
     var random = Random()
-    var pingSize = 32
     var pingTimeout = Duration.ofSeconds(10)
+
+    constructor() : this(32)
 
     override fun onStartInitiator(stream: Stream): CompletableFuture<PingController> {
         val handler = PingInitiator()

--- a/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
@@ -94,6 +94,69 @@ public class HostTestJava {
     }
 
     @Test
+    void largePing() throws Exception {
+        int pingSize = 200 * 1024;
+        String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
+
+        Host clientHost = new HostBuilder()
+                .transport(TcpTransport::new)
+                .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
+                .muxer(StreamMuxerProtocol::getYamux)
+                .build();
+
+        Host serverHost = new HostBuilder()
+                .transport(TcpTransport::new)
+                .secureChannel(TlsSecureChannel::new)
+                .muxer(StreamMuxerProtocol::getYamux)
+                .protocol(new Ping(pingSize))
+                .listen(localListenAddress)
+                .build();
+
+        CompletableFuture<Void> clientStarted = clientHost.start();
+        CompletableFuture<Void> serverStarted = serverHost.start();
+        clientStarted.get(5, TimeUnit.SECONDS);
+        System.out.println("Client started");
+        serverStarted.get(5, TimeUnit.SECONDS);
+        System.out.println("Server started");
+
+        Assertions.assertEquals(0, clientHost.listenAddresses().size());
+        Assertions.assertEquals(1, serverHost.listenAddresses().size());
+        Assertions.assertEquals(
+                localListenAddress + "/p2p/" + serverHost.getPeerId(),
+                serverHost.listenAddresses().get(0).toString()
+        );
+
+        StreamPromise<PingController> ping =
+                clientHost.getNetwork().connect(
+                                serverHost.getPeerId(),
+                                new Multiaddr(localListenAddress)
+                        ).thenApply(
+                                it -> it.muxerSession().createStream(new Ping(pingSize))
+                        )
+                        .join();
+
+        Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+        System.out.println("Ping stream created");
+        PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
+        System.out.println("Ping controller created");
+
+        for (int i = 0; i < 10; i++) {
+            long latency = pingCtr.ping().join();//get(5, TimeUnit.SECONDS);
+            System.out.println("Ping is " + latency);
+        }
+        pingStream.close().get(5, TimeUnit.SECONDS);
+        System.out.println("Ping stream closed");
+
+        Assertions.assertThrows(ExecutionException.class, () ->
+                pingCtr.ping().get(5, TimeUnit.SECONDS));
+
+        clientHost.stop().get(5, TimeUnit.SECONDS);
+        System.out.println("Client stopped");
+        serverHost.stop().get(5, TimeUnit.SECONDS);
+        System.out.println("Server stopped");
+    }
+
+    @Test
     void keyPairGeneration() {
         Pair<PrivKey, PubKey> pair = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1);
         PeerId peerId = PeerId.fromPubKey(pair.component2());


### PR DESCRIPTION
Also fix inefficient window size handling.

I tried to test this with ping, but of course ping doesn't handle messages sent in multiple parts. But we have tested this downstream. 