### PR TITLE
Use spotless instead of kotlinter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
@@ -18,7 +19,7 @@ plugins {
     id("java")
     id("maven-publish")
     id("org.jetbrains.dokka").version("1.7.20")
-    id("org.jmailen.kotlinter").version("3.10.0")
+    id("com.diffplug.spotless").version("6.20.0")
     id("java-test-fixtures")
     id("io.spring.dependency-management").version("1.1.0")
 
@@ -45,7 +46,7 @@ configure(
     apply(plugin = "io.gitlab.arturbosch.detekt")
     apply(plugin = "maven-publish")
     apply(plugin = "org.jetbrains.dokka")
-    apply(plugin = "org.jmailen.kotlinter")
+    apply(plugin = "com.diffplug.spotless")
     apply(plugin = "java-test-fixtures")
     apply(plugin = "io.spring.dependency-management")
     apply(from = "$rootDir/versions.gradle")
@@ -108,8 +109,21 @@ configure(
 //    Runtime.getRuntime().availableProcessors().div(2))
     }
 
-    kotlinter {
-        disabledRules = arrayOf("no-wildcard-imports", "enum-entry-name-case")
+    configure<SpotlessExtension> {
+        kotlin {
+            ktlint().editorConfigOverride(
+                mapOf(
+                    "ktlint_standard_no-wildcard-imports" to "disabled",
+                    "ktlint_standard_enum-entry-name-case" to "disabled",
+                    "ktlint_standard_trailing-comma-on-call-site" to "disabled",
+                    "ktlint_standard_trailing-comma-on-declaration-site" to "disabled"
+                )
+            )
+        }
+        java {
+            targetExclude("**/generated/**/proto/**")
+            googleJavaFormat()
+        }
     }
 
     val sourcesJar by tasks.registering(Jar::class) {

--- a/examples/chatter/src/main/kotlin/io/libp2p/example/chat/ChatNode.kt
+++ b/examples/chatter/src/main/kotlin/io/libp2p/example/chat/ChatNode.kt
@@ -50,8 +50,9 @@ class ChatNode(private val printMsg: OnMessage) {
     fun send(message: String) {
         peers.values.forEach { it.controller.send(message) }
 
-        if (message.startsWith("alias "))
+        if (message.startsWith("alias ")) {
             currentAlias = message.substring(6).trim()
+        }
     } // send
 
     fun stop() {
@@ -83,8 +84,9 @@ class ChatNode(private val printMsg: OnMessage) {
         if (
             info.peerId == chatHost.peerId ||
             knownNodes.contains(info.peerId)
-        )
+        ) {
             return
+        }
 
         knownNodes.add(info.peerId)
 
@@ -126,10 +128,11 @@ class ChatNode(private val printMsg: OnMessage) {
                 .filterIsInstance<Inet4Address>()
                 .filter { it.isSiteLocalAddress }
                 .sortedBy { it.hostAddress }
-            return if (addresses.isNotEmpty())
+            return if (addresses.isNotEmpty()) {
                 addresses[0]
-            else
+            } else {
                 InetAddress.getLoopbackAddress()
+            }
         }
     }
 } // class ChatNode

--- a/examples/cli-chatter/src/main/kotlin/io/libp2p/example/chat/Chatter.kt
+++ b/examples/cli-chatter/src/main/kotlin/io/libp2p/example/chat/Chatter.kt
@@ -17,8 +17,9 @@ fun main() {
         print(">> ")
         message = readLine()?.trim()
 
-        if (message == null || message.isEmpty())
+        if (message == null || message.isEmpty()) {
             continue
+        }
 
         node.send(message)
     } while ("bye" != message)

--- a/examples/pinger/src/main/java/io/libp2p/example/ping/Pinger.java
+++ b/examples/pinger/src/main/java/io/libp2p/example/ping/Pinger.java
@@ -5,18 +5,13 @@ import io.libp2p.core.dsl.HostBuilder;
 import io.libp2p.core.multiformats.Multiaddr;
 import io.libp2p.protocol.Ping;
 import io.libp2p.protocol.PingController;
-
 import java.util.concurrent.ExecutionException;
 
 public class Pinger {
-  public static void main(String[] args)
-      throws ExecutionException, InterruptedException {
+  public static void main(String[] args) throws ExecutionException, InterruptedException {
     // Create a libp2p node and configure it
     // to accept TCP connections on a random port
-    Host node = new HostBuilder()
-        .protocol(new Ping())
-        .listen("/ip4/127.0.0.1/tcp/0")
-        .build();
+    Host node = new HostBuilder().protocol(new Ping()).listen("/ip4/127.0.0.1/tcp/0").build();
 
     // start listening
     node.start().get();
@@ -26,10 +21,7 @@ public class Pinger {
 
     if (args.length > 0) {
       Multiaddr address = Multiaddr.fromString(args[0]);
-      PingController pinger = new Ping().dial(
-          node,
-          address
-      ).getController().get();
+      PingController pinger = new Ping().dial(node, address).getController().get();
 
       System.out.println("Sending 5 ping messages to " + address.toString());
       for (int i = 1; i <= 5; ++i) {

--- a/libp2p/src/jmh/java/io/libp2p/pubsub/gossip/GossipScoreBenchmark.java
+++ b/libp2p/src/jmh/java/io/libp2p/pubsub/gossip/GossipScoreBenchmark.java
@@ -7,10 +7,6 @@ import io.libp2p.pubsub.DefaultPubsubMessage;
 import io.libp2p.tools.schedulers.ControlledExecutorServiceImpl;
 import io.libp2p.tools.schedulers.TimeController;
 import io.libp2p.tools.schedulers.TimeControllerImpl;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.Blackhole;
-import pubsub.pb.Rpc;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -18,6 +14,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import pubsub.pb.Rpc;
 
 @State(Scope.Thread)
 @Fork(5)
@@ -25,92 +24,95 @@ import java.util.stream.Stream;
 @Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 public class GossipScoreBenchmark {
 
-    private final int peerCount = 5000;
-    private final int connectedCount = 2000;
-    private final int topicCount = 128;
+  private final int peerCount = 5000;
+  private final int connectedCount = 2000;
+  private final int topicCount = 128;
 
-    private final List<String> topics = IntStream
-            .range(0, topicCount)
-            .mapToObj(i -> "Topic-" + i)
-            .collect(Collectors.toList());
+  private final List<String> topics =
+      IntStream.range(0, topicCount).mapToObj(i -> "Topic-" + i).collect(Collectors.toList());
 
-    private final List<PeerId> peerIds = Stream.generate(PeerId::random).limit(peerCount).collect(Collectors.toList());
-    private final List<Multiaddr> peerAddresses = IntStream
-            .range(0, peerCount)
-            .mapToObj(idx ->
-                    Multiaddr.empty()
-                            .withComponent(Protocol.IP4, new byte[]{(byte) (idx >>> 8 & 0xFF), (byte) (idx & 0xFF), 0, 0})
-                            .withComponent(Protocol.TCP, new byte[]{0x23, 0x28}))
-            .collect(Collectors.toList());
+  private final List<PeerId> peerIds =
+      Stream.generate(PeerId::random).limit(peerCount).collect(Collectors.toList());
+  private final List<Multiaddr> peerAddresses =
+      IntStream.range(0, peerCount)
+          .mapToObj(
+              idx ->
+                  Multiaddr.empty()
+                      .withComponent(
+                          Protocol.IP4,
+                          new byte[] {(byte) (idx >>> 8 & 0xFF), (byte) (idx & 0xFF), 0, 0})
+                      .withComponent(Protocol.TCP, new byte[] {0x23, 0x28}))
+          .collect(Collectors.toList());
 
-    private final TimeController timeController = new TimeControllerImpl();
-    private final ControlledExecutorServiceImpl controlledExecutor = new ControlledExecutorServiceImpl();
-    private final GossipScoreParams gossipScoreParams;
-    private final DefaultGossipScore score;
+  private final TimeController timeController = new TimeControllerImpl();
+  private final ControlledExecutorServiceImpl controlledExecutor =
+      new ControlledExecutorServiceImpl();
+  private final GossipScoreParams gossipScoreParams;
+  private final DefaultGossipScore score;
 
-    public GossipScoreBenchmark() {
-        Map<String, GossipTopicScoreParams> topicParamMap = topics.stream()
-                .collect(Collectors.toMap(Function.identity(), __ -> new GossipTopicScoreParams()));
-        GossipTopicsScoreParams gossipTopicsScoreParams = new GossipTopicsScoreParams(new GossipTopicScoreParams(), topicParamMap);
+  public GossipScoreBenchmark() {
+    Map<String, GossipTopicScoreParams> topicParamMap =
+        topics.stream()
+            .collect(Collectors.toMap(Function.identity(), __ -> new GossipTopicScoreParams()));
+    GossipTopicsScoreParams gossipTopicsScoreParams =
+        new GossipTopicsScoreParams(new GossipTopicScoreParams(), topicParamMap);
 
-        gossipScoreParams = new GossipScoreParams(new GossipPeerScoreParams(), gossipTopicsScoreParams, 0, 0, 0, 0, 0);
-        controlledExecutor.setTimeController(timeController);
-        score = new DefaultGossipScore(gossipScoreParams, controlledExecutor, timeController::getTime);
+    gossipScoreParams =
+        new GossipScoreParams(new GossipPeerScoreParams(), gossipTopicsScoreParams, 0, 0, 0, 0, 0);
+    controlledExecutor.setTimeController(timeController);
+    score = new DefaultGossipScore(gossipScoreParams, controlledExecutor, timeController::getTime);
 
-        for (int i = 0; i < peerCount; i++) {
-            PeerId peerId = peerIds.get(i);
-            score.notifyConnected(peerId, peerAddresses.get(i));
-            for (String topic : topics) {
-                notifyUnseenMessage(peerId, topic);
-            }
-        }
-
-        for (int i = connectedCount; i < peerCount; i++) {
-            score.notifyDisconnected(peerIds.get(i));
-        }
+    for (int i = 0; i < peerCount; i++) {
+      PeerId peerId = peerIds.get(i);
+      score.notifyConnected(peerId, peerAddresses.get(i));
+      for (String topic : topics) {
+        notifyUnseenMessage(peerId, topic);
+      }
     }
 
-    private void notifyUnseenMessage(PeerId peerId, String topic) {
-        Rpc.Message message = Rpc.Message.newBuilder()
-                .addTopicIDs(topic)
-                .build();
-        score.notifyUnseenValidMessage(peerId, new DefaultPubsubMessage(message));
+    for (int i = connectedCount; i < peerCount; i++) {
+      score.notifyDisconnected(peerIds.get(i));
     }
+  }
 
-    @Benchmark
-    public void scoresDelay0(Blackhole bh) {
-        for (int i = 0; i < connectedCount; i++) {
-            double s = score.score(peerIds.get(i));
-            bh.consume(s);
-        }
+  private void notifyUnseenMessage(PeerId peerId, String topic) {
+    Rpc.Message message = Rpc.Message.newBuilder().addTopicIDs(topic).build();
+    score.notifyUnseenValidMessage(peerId, new DefaultPubsubMessage(message));
+  }
+
+  @Benchmark
+  public void scoresDelay0(Blackhole bh) {
+    for (int i = 0; i < connectedCount; i++) {
+      double s = score.score(peerIds.get(i));
+      bh.consume(s);
     }
+  }
 
-    @Benchmark
-    public void scoresDelay100(Blackhole bh) {
-        timeController.addTime(100);
+  @Benchmark
+  public void scoresDelay100(Blackhole bh) {
+    timeController.addTime(100);
 
-        for (int i = 0; i < connectedCount; i++) {
-            double s = score.score(peerIds.get(i));
-            bh.consume(s);
-        }
+    for (int i = 0; i < connectedCount; i++) {
+      double s = score.score(peerIds.get(i));
+      bh.consume(s);
     }
+  }
 
-    @Benchmark
-    public void scoresDelay10000(Blackhole bh) {
-        timeController.addTime(10000);
+  @Benchmark
+  public void scoresDelay10000(Blackhole bh) {
+    timeController.addTime(10000);
 
-        for (int i = 0; i < connectedCount; i++) {
-            double s = score.score(peerIds.get(i));
-            bh.consume(s);
-        }
+    for (int i = 0; i < connectedCount; i++) {
+      double s = score.score(peerIds.get(i));
+      bh.consume(s);
     }
+  }
 
-    /**
-     * Uncomment for debugging
-     */
-//    public static void main(String[] args) {
-//        GossipScoreBenchmark benchmark = new GossipScoreBenchmark();
-//        Blackhole blackhole = new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
-//        benchmark.scoresDelay0(blackhole);
-//    }
+  /** Uncomment for debugging */
+  //    public static void main(String[] args) {
+  //        GossipScoreBenchmark benchmark = new GossipScoreBenchmark();
+  //        Blackhole blackhole = new Blackhole("Today's password is swordfish. I understand
+  // instantiating Blackholes directly is dangerous.");
+  //        benchmark.scoresDelay0(blackhole);
+  //    }
 }

--- a/libp2p/src/main/java/io/libp2p/core/dsl/HostBuilder.java
+++ b/libp2p/src/main/java/io/libp2p/core/dsl/HostBuilder.java
@@ -7,91 +7,81 @@ import io.libp2p.core.mux.*;
 import io.libp2p.core.security.SecureChannel;
 import io.libp2p.core.transport.Transport;
 import io.libp2p.transport.ConnectionUpgrader;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 
 public class HostBuilder {
-    public HostBuilder() { this(DefaultMode.Standard); }
-    public HostBuilder(DefaultMode defaultMode) {
-        defaultMode_ = defaultMode;
+  public HostBuilder() {
+    this(DefaultMode.Standard);
+  }
+
+  public HostBuilder(DefaultMode defaultMode) {
+    defaultMode_ = defaultMode;
+  }
+
+  public enum DefaultMode {
+    None,
+    Standard;
+
+    private Builder.Defaults asBuilderDefault() {
+      if (this.equals(None)) {
+        return Builder.Defaults.None;
+      }
+      return Builder.Defaults.Standard;
     }
+  };
 
-    public enum DefaultMode {
-        None,
-        Standard;
+  @SafeVarargs
+  public final HostBuilder transport(Function<ConnectionUpgrader, Transport>... transports) {
+    transports_.addAll(Arrays.asList(transports));
+    return this;
+  }
 
-        private Builder.Defaults asBuilderDefault() {
-            if (this.equals(None)) {
-                return Builder.Defaults.None;
-            }
-            return Builder.Defaults.Standard;
-        }
-    };
+  @SafeVarargs
+  public final HostBuilder secureChannel(
+      BiFunction<PrivKey, List<StreamMuxer>, SecureChannel>... secureChannels) {
+    secureChannels_.addAll(Arrays.asList(secureChannels));
+    return this;
+  }
 
-    @SafeVarargs
-    public final HostBuilder transport(
-            Function<ConnectionUpgrader, Transport>... transports) {
-        transports_.addAll(Arrays.asList(transports));
-        return this;
-    }
+  @SafeVarargs
+  public final HostBuilder muxer(Supplier<StreamMuxerProtocol>... muxers) {
+    muxers_.addAll(Arrays.asList(muxers));
+    return this;
+  }
 
-    @SafeVarargs
-    public final HostBuilder secureChannel(
-            BiFunction<PrivKey, List<StreamMuxer>, SecureChannel>... secureChannels) {
-        secureChannels_.addAll(Arrays.asList(secureChannels));
-        return this;
-    }
+  public final HostBuilder protocol(ProtocolBinding<?>... protocols) {
+    protocols_.addAll(Arrays.asList(protocols));
+    return this;
+  }
 
-    @SafeVarargs
-    public final HostBuilder muxer(
-            Supplier<StreamMuxerProtocol>... muxers) {
-        muxers_.addAll(Arrays.asList(muxers));
-        return this;
-    }
+  public final HostBuilder listen(String... addresses) {
+    listenAddresses_.addAll(Arrays.asList(addresses));
+    return this;
+  }
 
-    public final HostBuilder protocol(
-            ProtocolBinding<?>... protocols) {
-        protocols_.addAll(Arrays.asList(protocols));
-        return this;
-    }
+  public Host build() {
+    return BuilderJKt.hostJ(
+        defaultMode_.asBuilderDefault(),
+        b -> {
+          b.getIdentity().random();
 
-    public final HostBuilder listen(
-            String... addresses) {
-        listenAddresses_.addAll(Arrays.asList(addresses));
-        return this;
-    }
+          transports_.forEach(t -> b.getTransports().add(t::apply));
+          secureChannels_.forEach(
+              sc -> b.getSecureChannels().add((k, m) -> sc.apply(k, (List<StreamMuxer>) m)));
+          muxers_.forEach(m -> b.getMuxers().add(m.get()));
+          b.getProtocols().addAll(protocols_);
+          listenAddresses_.forEach(a -> b.getNetwork().listen(a));
+        });
+  } // build
 
-
-    public Host build() {
-        return BuilderJKt.hostJ(
-            defaultMode_.asBuilderDefault(),
-            b -> {
-                b.getIdentity().random();
-
-                transports_.forEach(t ->
-                    b.getTransports().add(t::apply)
-                );
-                secureChannels_.forEach(sc ->
-                    b.getSecureChannels().add((k, m) -> sc.apply(k, (List<StreamMuxer>)m))
-                );
-                muxers_.forEach(m ->
-                    b.getMuxers().add(m.get())
-                );
-                b.getProtocols().addAll(protocols_);
-                listenAddresses_.forEach(a ->
-                    b.getNetwork().listen(a)
-                );
-            }
-        );
-    } // build
-
-    private DefaultMode defaultMode_;
-    private List<Function<ConnectionUpgrader, Transport>> transports_ = new ArrayList<>();
-    private List<BiFunction<PrivKey, List<StreamMuxer>, SecureChannel>> secureChannels_ = new ArrayList<>();
-    private List<Supplier<StreamMuxerProtocol>> muxers_ = new ArrayList<>();
-    private List<ProtocolBinding<?>> protocols_ = new ArrayList<>();
-    private List<String> listenAddresses_ = new ArrayList<>();
+  private DefaultMode defaultMode_;
+  private List<Function<ConnectionUpgrader, Transport>> transports_ = new ArrayList<>();
+  private List<BiFunction<PrivKey, List<StreamMuxer>, SecureChannel>> secureChannels_ =
+      new ArrayList<>();
+  private List<Supplier<StreamMuxerProtocol>> muxers_ = new ArrayList<>();
+  private List<ProtocolBinding<?>> protocols_ = new ArrayList<>();
+  private List<String> listenAddresses_ = new ArrayList<>();
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/AnswerListener.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/AnswerListener.java
@@ -1,10 +1,9 @@
 package io.libp2p.discovery.mdns;
 
 import io.libp2p.discovery.mdns.impl.DNSRecord;
-
 import java.util.EventListener;
 import java.util.List;
 
 public interface AnswerListener extends EventListener {
-    void answersReceived(List<DNSRecord> answers);
+  void answersReceived(List<DNSRecord> answers);
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/JmDNS.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/JmDNS.java
@@ -5,73 +5,75 @@
 package io.libp2p.discovery.mdns;
 
 import io.libp2p.discovery.mdns.impl.JmDNSImpl;
-
 import java.io.IOException;
 import java.net.InetAddress;
 
 /**
- * Based on code by Arthur van Hoff, Rick Blair, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Scott Lewis, Scott Cytacki
+ * Based on code by Arthur van Hoff, Rick Blair, Jeff Sonstein, Werner Randelshofer, Pierre Frisch,
+ * Scott Lewis, Scott Cytacki
  */
 public abstract class JmDNS {
-    /**
-     * <p>
-     * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
-     * </p>
-     * <p>
-     * <b>Note:</b> This is a convenience method. The preferred constructor is {@link #create(InetAddress, String)}.<br/>
-     * Check that your platform correctly handle the default localhost IP address and the local hostname. In doubt use the explicit constructor.<br/>
-     * This call is equivalent to <code>create(addr, null)</code>.
-     * </p>
-     *
-     * @see #create(InetAddress, String)
-     * @param addr
-     *            IP address to bind to.
-     * @return jmDNS instance
-     */
-    public static JmDNS create(final InetAddress addr) {
-        return new JmDNSImpl(addr, null);
-    }
+  /**
+   * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
+   *
+   * <p><b>Note:</b> This is a convenience method. The preferred constructor is {@link
+   * #create(InetAddress, String)}.<br>
+   * Check that your platform correctly handle the default localhost IP address and the local
+   * hostname. In doubt use the explicit constructor.<br>
+   * This call is equivalent to <code>create(addr, null)</code>.
+   *
+   * @see #create(InetAddress, String)
+   * @param addr IP address to bind to.
+   * @return jmDNS instance
+   */
+  public static JmDNS create(final InetAddress addr) {
+    return new JmDNSImpl(addr, null);
+  }
 
-    /**
-     * <p>
-     * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
-     * </p>
-     * If <code>addr</code> parameter is null this method will try to resolve to a local IP address of the machine using a network discovery:
-     * <ol>
-     * <li>Check the system property <code>net.mdns.interface</code></li>
-     * <li>Check the JVM local host</li>
-     * <li>In the last resort bind to the loopback address. This is non functional in most cases.</li>
-     * </ol>
-     * If <code>name</code> parameter is null will use the hostname. The hostname is determined by the following algorithm:
-     * <ol>
-     * <li>Get the hostname from the InetAdress obtained before.</li>
-     * <li>If the hostname is a reverse lookup default to <code>JmDNS name</code> or <code>computer</code> if null.</li>
-     * <li>If the name contains <code>'.'</code> replace them by <code>'-'</code></li>
-     * <li>Add <code>.local.</code> at the end of the name.</li>
-     * </ol>
-     *
-     * @param addr
-     *            IP address to bind to.
-     * @param name
-     *            name of the newly created JmDNS
-     * @return jmDNS instance
-     * @exception IOException
-     *                if an exception occurs during the socket creation
-     */
-    public static JmDNS create(final InetAddress addr, final String name) {
-        return new JmDNSImpl(addr, name);
-    }
+  /**
+   * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
+   * If <code>addr</code> parameter is null this method will try to resolve to a local IP address of
+   * the machine using a network discovery:
+   *
+   * <ol>
+   *   <li>Check the system property <code>net.mdns.interface</code>
+   *   <li>Check the JVM local host
+   *   <li>In the last resort bind to the loopback address. This is non functional in most cases.
+   * </ol>
+   *
+   * If <code>name</code> parameter is null will use the hostname. The hostname is determined by the
+   * following algorithm:
+   *
+   * <ol>
+   *   <li>Get the hostname from the InetAdress obtained before.
+   *   <li>If the hostname is a reverse lookup default to <code>JmDNS name</code> or <code>computer
+   *       </code> if null.
+   *   <li>If the name contains <code>'.'</code> replace them by <code>'-'</code>
+   *   <li>Add <code>.local.</code> at the end of the name.
+   * </ol>
+   *
+   * @param addr IP address to bind to.
+   * @param name name of the newly created JmDNS
+   * @return jmDNS instance
+   * @exception IOException if an exception occurs during the socket creation
+   */
+  public static JmDNS create(final InetAddress addr, final String name) {
+    return new JmDNSImpl(addr, name);
+  }
 
-    public abstract void start() throws IOException;
-    public abstract void stop();
+  public abstract void start() throws IOException;
 
-    /**
-     * Return the name of the JmDNS instance. This is an arbitrary string that is useful for distinguishing instances.
-     *
-     * @return name of the JmDNS
-     */
-    public abstract String getName();
+  public abstract void stop();
 
-    public abstract void addAnswerListener(String type, int queryInterval, AnswerListener listener);
-    public abstract void registerService(ServiceInfo info) throws IOException;
+  /**
+   * Return the name of the JmDNS instance. This is an arbitrary string that is useful for
+   * distinguishing instances.
+   *
+   * @return name of the JmDNS
+   */
+  public abstract String getName();
+
+  public abstract void addAnswerListener(String type, int queryInterval, AnswerListener listener);
+
+  public abstract void registerService(ServiceInfo info) throws IOException;
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/ServiceInfo.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/ServiceInfo.java
@@ -4,226 +4,207 @@
 package io.libp2p.discovery.mdns;
 
 import io.libp2p.discovery.mdns.impl.ServiceInfoImpl;
-
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.util.List;
 import java.util.Map;
 
 /**
- * <p>
  * The fully qualified service name is build using up to 5 components with the following structure:
- * 
+ *
  * <pre>
  *            &lt;app&gt;.&lt;protocol&gt;.&lt;servicedomain&gt;.&lt;parentdomain&gt;.<br/>
  * &lt;Instance&gt;.&lt;app&gt;.&lt;protocol&gt;.&lt;servicedomain&gt;.&lt;parentdomain&gt;.<br/>
  * &lt;sub&gt;._sub.&lt;app&gt;.&lt;protocol&gt;.&lt;servicedomain&gt;.&lt;parentdomain&gt;.
  * </pre>
- * 
+ *
  * <ol>
- * <li>&lt;servicedomain&gt;.&lt;parentdomain&gt;: This is the domain scope of the service typically "local.", but this can also be something similar to "in-addr.arpa." or "ip6.arpa."</li>
- * <li>&lt;protocol&gt;: This is either "_tcp" or "_udp"</li>
- * <li>&lt;app&gt;: This define the application protocol. Typical example are "_http", "_ftp", etc.</li>
- * <li>&lt;Instance&gt;: This is the service name</li>
- * <li>&lt;sub&gt;: This is the subtype for the application protocol</li>
+ *   <li>&lt;servicedomain&gt;.&lt;parentdomain&gt;: This is the domain scope of the service
+ *       typically "local.", but this can also be something similar to "in-addr.arpa." or
+ *       "ip6.arpa."
+ *   <li>&lt;protocol&gt;: This is either "_tcp" or "_udp"
+ *   <li>&lt;app&gt;: This define the application protocol. Typical example are "_http", "_ftp",
+ *       etc.
+ *   <li>&lt;Instance&gt;: This is the service name
+ *   <li>&lt;sub&gt;: This is the subtype for the application protocol
  * </ol>
- * </p>
  */
 public abstract class ServiceInfo implements Cloneable {
 
-    /**
-     * Fields for the fully qualified map.
-     */
-    public enum Fields {
-        /**
-         * Domain Field.
-         */
-        Domain,
-        /**
-         * Protocol Field.
-         */
-        Protocol,
-        /**
-         * Application Field.
-         */
-        Application,
-        /**
-         * Instance Field.
-         */
-        Instance,
-        /**
-         * Subtype Field.
-         */
-        Subtype
-    }
+  /** Fields for the fully qualified map. */
+  public enum Fields {
+    /** Domain Field. */
+    Domain,
+    /** Protocol Field. */
+    Protocol,
+    /** Application Field. */
+    Application,
+    /** Instance Field. */
+    Instance,
+    /** Subtype Field. */
+    Subtype
+  }
 
-    /**
-     * Construct a service description for registering with JmDNS.
-     * 
-     * @param type
-     *            fully qualified service type name, such as <code>_http._tcp.local.</code>.
-     * @param name
-     *            unqualified service instance name, such as <code>foobar</code>
-     * @param port
-     *            the local port on which the service runs
-     * @param text
-     *            string describing the service
-     * @return new service info
-     */
-    public static ServiceInfo create(
-            final String type,
-            final String name,
-            final int port,
-            final String text,
-            final List<Inet4Address> ip4Addresses,
-            final List<Inet6Address> ip6Addresses) {
-        ServiceInfoImpl si = new ServiceInfoImpl(type, name, "", port, 0, 0, text);
-        for (Inet4Address a : ip4Addresses)
-            si.addAddress(a);
-        for (Inet6Address a : ip6Addresses)
-            si.addAddress(a);
-        return si;
-    }
+  /**
+   * Construct a service description for registering with JmDNS.
+   *
+   * @param type fully qualified service type name, such as <code>_http._tcp.local.</code>.
+   * @param name unqualified service instance name, such as <code>foobar</code>
+   * @param port the local port on which the service runs
+   * @param text string describing the service
+   * @return new service info
+   */
+  public static ServiceInfo create(
+      final String type,
+      final String name,
+      final int port,
+      final String text,
+      final List<Inet4Address> ip4Addresses,
+      final List<Inet6Address> ip6Addresses) {
+    ServiceInfoImpl si = new ServiceInfoImpl(type, name, "", port, 0, 0, text);
+    for (Inet4Address a : ip4Addresses) si.addAddress(a);
+    for (Inet6Address a : ip6Addresses) si.addAddress(a);
+    return si;
+  }
 
-    /**
-     * Returns true if the service info is filled with data.
-     * 
-     * @return <code>true</code> if the service info has data, <code>false</code> otherwise.
-     */
-    public abstract boolean hasData();
+  /**
+   * Returns true if the service info is filled with data.
+   *
+   * @return <code>true</code> if the service info has data, <code>false</code> otherwise.
+   */
+  public abstract boolean hasData();
 
-    /**
-     * Fully qualified service type name, such as <code>_http._tcp.local.</code>
-     * 
-     * @return service type name
-     */
-    public abstract String getType();
+  /**
+   * Fully qualified service type name, such as <code>_http._tcp.local.</code>
+   *
+   * @return service type name
+   */
+  public abstract String getType();
 
-    /**
-     * Fully qualified service type name with the subtype if appropriate, such as <code>_printer._sub._http._tcp.local.</code>
-     * 
-     * @return service type name
-     */
-    public abstract String getTypeWithSubtype();
+  /**
+   * Fully qualified service type name with the subtype if appropriate, such as <code>
+   * _printer._sub._http._tcp.local.</code>
+   *
+   * @return service type name
+   */
+  public abstract String getTypeWithSubtype();
 
-    /**
-     * Unqualified service instance name, such as <code>foobar</code> .
-     * 
-     * @return service name
-     */
-    public abstract String getName();
+  /**
+   * Unqualified service instance name, such as <code>foobar</code> .
+   *
+   * @return service name
+   */
+  public abstract String getName();
 
-    /**
-     * The key is used to retrieve service info in hash tables.<br/>
-     * The key is the lower case qualified name.
-     * 
-     * @return the key
-     */
-    public abstract String getKey();
+  /**
+   * The key is used to retrieve service info in hash tables.<br>
+   * The key is the lower case qualified name.
+   *
+   * @return the key
+   */
+  public abstract String getKey();
 
-    /**
-     * Fully qualified service name, such as <code>foobar._http._tcp.local.</code> .
-     * 
-     * @return qualified service name
-     */
-    public abstract String getQualifiedName();
+  /**
+   * Fully qualified service name, such as <code>foobar._http._tcp.local.</code> .
+   *
+   * @return qualified service name
+   */
+  public abstract String getQualifiedName();
 
-    /**
-     * Get the name of the server.
-     * 
-     * @return server name
-     */
-    public abstract String getServer();
+  /**
+   * Get the name of the server.
+   *
+   * @return server name
+   */
+  public abstract String getServer();
 
-    /**
-     * Returns a list of all IPv4 InetAddresses that can be used for this service.
-     * <p>
-     * In a multi-homed environment service info can be associated with more than one address.
-     * </p>
-     * 
-     * @return list of InetAddress objects
-     */
-    public abstract Inet4Address[] getInet4Addresses();
+  /**
+   * Returns a list of all IPv4 InetAddresses that can be used for this service.
+   *
+   * <p>In a multi-homed environment service info can be associated with more than one address.
+   *
+   * @return list of InetAddress objects
+   */
+  public abstract Inet4Address[] getInet4Addresses();
 
-    /**
-     * Returns a list of all IPv6 InetAddresses that can be used for this service.
-     * <p>
-     * In a multi-homed environment service info can be associated with more than one address.
-     * </p>
-     * 
-     * @return list of InetAddress objects
-     */
-    public abstract Inet6Address[] getInet6Addresses();
+  /**
+   * Returns a list of all IPv6 InetAddresses that can be used for this service.
+   *
+   * <p>In a multi-homed environment service info can be associated with more than one address.
+   *
+   * @return list of InetAddress objects
+   */
+  public abstract Inet6Address[] getInet6Addresses();
 
-    /**
-     * Get the port for the service.
-     * 
-     * @return service port
-     */
-    public abstract int getPort();
+  /**
+   * Get the port for the service.
+   *
+   * @return service port
+   */
+  public abstract int getPort();
 
-    /**
-     * Get the priority of the service.
-     * 
-     * @return service priority
-     */
-    public abstract int getPriority();
+  /**
+   * Get the priority of the service.
+   *
+   * @return service priority
+   */
+  public abstract int getPriority();
 
-    /**
-     * Get the weight of the service.
-     * 
-     * @return service weight
-     */
-    public abstract int getWeight();
+  /**
+   * Get the weight of the service.
+   *
+   * @return service weight
+   */
+  public abstract int getWeight();
 
-    /**
-     * Get the text for the service as raw bytes.
-     * 
-     * @return raw service text
-     */
-    public abstract byte[] getTextBytes();
+  /**
+   * Get the text for the service as raw bytes.
+   *
+   * @return raw service text
+   */
+  public abstract byte[] getTextBytes();
 
-    /**
-     * Returns the domain of the service info suitable for printing.
-     * 
-     * @return service domain
-     */
-    public abstract String getDomain();
+  /**
+   * Returns the domain of the service info suitable for printing.
+   *
+   * @return service domain
+   */
+  public abstract String getDomain();
 
-    /**
-     * Returns the protocol of the service info suitable for printing.
-     * 
-     * @return service protocol
-     */
-    public abstract String getProtocol();
+  /**
+   * Returns the protocol of the service info suitable for printing.
+   *
+   * @return service protocol
+   */
+  public abstract String getProtocol();
 
-    /**
-     * Returns the application of the service info suitable for printing.
-     * 
-     * @return service application
-     */
-    public abstract String getApplication();
+  /**
+   * Returns the application of the service info suitable for printing.
+   *
+   * @return service application
+   */
+  public abstract String getApplication();
 
-    /**
-     * Returns the sub type of the service info suitable for printing.
-     * 
-     * @return service sub type
-     */
-    public abstract String getSubtype();
+  /**
+   * Returns the sub type of the service info suitable for printing.
+   *
+   * @return service sub type
+   */
+  public abstract String getSubtype();
 
-    /**
-     * Returns a dictionary of the fully qualified name component of this service.
-     * 
-     * @return dictionary of the fully qualified name components
-     */
-    public abstract Map<Fields, String> getQualifiedNameMap();
+  /**
+   * Returns a dictionary of the fully qualified name component of this service.
+   *
+   * @return dictionary of the fully qualified name components
+   */
+  public abstract Map<Fields, String> getQualifiedNameMap();
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#clone()
-     */
-    @Override
-    public ServiceInfo clone() throws CloneNotSupportedException {
-        return (ServiceInfo) super.clone();
-    }
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#clone()
+   */
+  @Override
+  public ServiceInfo clone() throws CloneNotSupportedException {
+    return (ServiceInfo) super.clone();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSEntry.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSEntry.java
@@ -4,16 +4,14 @@
 
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.ServiceInfo.Fields;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
-
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-
-import io.libp2p.discovery.mdns.ServiceInfo.Fields;
 
 /**
  * DNS entry with a name, type, and class. This is the base class for questions and records.
@@ -21,197 +19,211 @@ import io.libp2p.discovery.mdns.ServiceInfo.Fields;
  * @author Arthur van Hoff, Pierre Frisch, Rick Blair
  */
 public abstract class DNSEntry {
-    // private static Logger logger = LoggerFactory.getLogger(DNSEntry.class.getName());
-    private final String         _key;
+  // private static Logger logger = LoggerFactory.getLogger(DNSEntry.class.getName());
+  private final String _key;
 
-    private final String         _name;
+  private final String _name;
 
-    private final String         _type;
+  private final String _type;
 
-    private final DNSRecordType _recordType;
+  private final DNSRecordType _recordType;
 
-    private final DNSRecordClass _dnsClass;
+  private final DNSRecordClass _dnsClass;
 
-    private final boolean        _unique;
+  private final boolean _unique;
 
-    final Map<Fields, String>    _qualifiedNameMap;
+  final Map<Fields, String> _qualifiedNameMap;
 
-    /**
-     * Create an entry.
-     */
-    DNSEntry(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
-        _name = name;
-        // _key = (name != null ? name.trim().toLowerCase() : null);
-        _recordType = type;
-        _dnsClass = recordClass;
-        _unique = unique;
-        _qualifiedNameMap = ServiceInfoImpl.decodeQualifiedNameMapForType(this.getName());
-        String domain = _qualifiedNameMap.get(Fields.Domain);
-        String protocol = _qualifiedNameMap.get(Fields.Protocol);
-        String application = _qualifiedNameMap.get(Fields.Application);
-        String instance = _qualifiedNameMap.get(Fields.Instance).toLowerCase();
-        _type = (application.length() > 0 ? "_" + application + "." : "") + (protocol.length() > 0 ? "_" + protocol + "." : "") + domain + ".";
-        _key = ((instance.length() > 0 ? instance + "." : "") + _type).toLowerCase();
+  /** Create an entry. */
+  DNSEntry(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
+    _name = name;
+    // _key = (name != null ? name.trim().toLowerCase() : null);
+    _recordType = type;
+    _dnsClass = recordClass;
+    _unique = unique;
+    _qualifiedNameMap = ServiceInfoImpl.decodeQualifiedNameMapForType(this.getName());
+    String domain = _qualifiedNameMap.get(Fields.Domain);
+    String protocol = _qualifiedNameMap.get(Fields.Protocol);
+    String application = _qualifiedNameMap.get(Fields.Application);
+    String instance = _qualifiedNameMap.get(Fields.Instance).toLowerCase();
+    _type =
+        (application.length() > 0 ? "_" + application + "." : "")
+            + (protocol.length() > 0 ? "_" + protocol + "." : "")
+            + domain
+            + ".";
+    _key = ((instance.length() > 0 ? instance + "." : "") + _type).toLowerCase();
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object obj) {
+    boolean result = false;
+    if (obj instanceof DNSEntry) {
+      DNSEntry other = (DNSEntry) obj;
+      result =
+          this.getKey().equals(other.getKey())
+              && this.getRecordType().equals(other.getRecordType())
+              && this.getRecordClass() == other.getRecordClass();
     }
+    return result;
+  }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
-    @Override
-    public boolean equals(Object obj) {
-        boolean result = false;
-        if (obj instanceof DNSEntry) {
-            DNSEntry other = (DNSEntry) obj;
-            result = this.getKey().equals(other.getKey()) && this.getRecordType().equals(other.getRecordType()) && this.getRecordClass() == other.getRecordClass();
-        }
-        return result;
+  /**
+   * Check if two entries have exactly the same name, type, and class.
+   *
+   * @param entry
+   * @return <code>true</code> if the two entries have are for the same record, <code>false</code>
+   *     otherwise
+   */
+  public boolean isSameEntry(DNSEntry entry) {
+    return this.getKey().equals(entry.getKey())
+        && this.matchRecordType(entry.getRecordType())
+        && this.matchRecordClass(entry.getRecordClass());
+  }
+
+  /**
+   * Check if the requested record class match the current record class
+   *
+   * @param recordClass
+   * @return <code>true</code> if the two entries have compatible class, <code>false</code>
+   *     otherwise
+   */
+  public boolean matchRecordClass(DNSRecordClass recordClass) {
+    return (DNSRecordClass.CLASS_ANY == recordClass)
+        || (DNSRecordClass.CLASS_ANY == this.getRecordClass())
+        || this.getRecordClass().equals(recordClass);
+  }
+
+  /**
+   * Check if the requested record tyep match the current record type
+   *
+   * @param recordType
+   * @return <code>true</code> if the two entries have compatible type, <code>false</code> otherwise
+   */
+  public boolean matchRecordType(DNSRecordType recordType) {
+    return this.getRecordType().equals(recordType);
+  }
+
+  /**
+   * Returns the subtype of this entry
+   *
+   * @return subtype of this entry
+   */
+  public String getSubtype() {
+    String subtype = this.getQualifiedNameMap().get(Fields.Subtype);
+    return (subtype != null ? subtype : "");
+  }
+
+  /**
+   * Returns the name of this entry
+   *
+   * @return name of this entry
+   */
+  public String getName() {
+    return (_name != null ? _name : "");
+  }
+
+  /**
+   * @return the type
+   */
+  public String getType() {
+    return (_type != null ? _type : "");
+  }
+
+  /**
+   * Returns the key for this entry. The key is the lower case name.
+   *
+   * @return key for this entry
+   */
+  public String getKey() {
+    return (_key != null ? _key : "");
+  }
+
+  /**
+   * @return record type
+   */
+  public DNSRecordType getRecordType() {
+    return (_recordType != null ? _recordType : DNSRecordType.TYPE_IGNORE);
+  }
+
+  /**
+   * @return record class
+   */
+  public DNSRecordClass getRecordClass() {
+    return (_dnsClass != null ? _dnsClass : DNSRecordClass.CLASS_UNKNOWN);
+  }
+
+  /**
+   * @return true if unique
+   */
+  public boolean isUnique() {
+    return _unique;
+  }
+
+  public Map<Fields, String> getQualifiedNameMap() {
+    return Collections.unmodifiableMap(_qualifiedNameMap);
+  }
+
+  /**
+   * Check if the record is expired.
+   *
+   * @param now update date
+   * @return <code>true</code> is the record is expired, <code>false</code> otherwise.
+   */
+  public abstract boolean isExpired(long now);
+
+  /**
+   * @param dout
+   * @exception IOException
+   */
+  protected void toByteArray(DataOutputStream dout) throws IOException {
+    dout.write(this.getName().getBytes("UTF8"));
+    dout.writeShort(this.getRecordType().indexValue());
+    dout.writeShort(this.getRecordClass().indexValue());
+  }
+
+  /**
+   * Creates a byte array representation of this record. This is needed for tie-break tests
+   * according to draft-cheshire-dnsext-multicastdns-04.txt chapter 9.2.
+   *
+   * @return byte array representation
+   */
+  protected byte[] toByteArray() {
+    try {
+      ByteArrayOutputStream bout = new ByteArrayOutputStream();
+      DataOutputStream dout = new DataOutputStream(bout);
+      this.toByteArray(dout);
+      dout.close();
+      return bout.toByteArray();
+    } catch (IOException e) {
+      throw new InternalError();
     }
+  }
 
-    /**
-     * Check if two entries have exactly the same name, type, and class.
-     *
-     * @param entry
-     * @return <code>true</code> if the two entries have are for the same record, <code>false</code> otherwise
-     */
-    public boolean isSameEntry(DNSEntry entry) {
-        return this.getKey().equals(entry.getKey()) && this.matchRecordType(entry.getRecordType()) && this.matchRecordClass(entry.getRecordClass());
-    }
+  /** Overriden, to return a value which is consistent with the value returned by equals(Object). */
+  @Override
+  public int hashCode() {
+    return this.getKey().hashCode()
+        + this.getRecordType().indexValue()
+        + this.getRecordClass().indexValue();
+  }
 
-    /**
-     * Check if the requested record class match the current record class
-     *
-     * @param recordClass
-     * @return <code>true</code> if the two entries have compatible class, <code>false</code> otherwise
-     */
-    public boolean matchRecordClass(DNSRecordClass recordClass) {
-        return (DNSRecordClass.CLASS_ANY == recordClass) || (DNSRecordClass.CLASS_ANY == this.getRecordClass()) || this.getRecordClass().equals(recordClass);
-    }
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(200);
+    sb.append('[')
+        .append(this.getClass().getSimpleName())
+        .append('@')
+        .append(System.identityHashCode(this));
+    sb.append(" type: ").append(this.getRecordType());
+    sb.append(", class: ").append(this.getRecordClass());
+    sb.append((_unique ? "-unique," : ","));
+    sb.append(" name: ").append(_name);
+    sb.append(']');
 
-    /**
-     * Check if the requested record tyep match the current record type
-     *
-     * @param recordType
-     * @return <code>true</code> if the two entries have compatible type, <code>false</code> otherwise
-     */
-    public boolean matchRecordType(DNSRecordType recordType) {
-        return this.getRecordType().equals(recordType);
-    }
-
-    /**
-     * Returns the subtype of this entry
-     *
-     * @return subtype of this entry
-     */
-    public String getSubtype() {
-        String subtype = this.getQualifiedNameMap().get(Fields.Subtype);
-        return (subtype != null ? subtype : "");
-    }
-
-    /**
-     * Returns the name of this entry
-     *
-     * @return name of this entry
-     */
-    public String getName() {
-        return (_name != null ? _name : "");
-    }
-
-    /**
-     * @return the type
-     */
-    public String getType() {
-        return (_type != null ? _type : "");
-    }
-
-    /**
-     * Returns the key for this entry. The key is the lower case name.
-     *
-     * @return key for this entry
-     */
-    public String getKey() {
-        return (_key != null ? _key : "");
-    }
-
-    /**
-     * @return record type
-     */
-    public DNSRecordType getRecordType() {
-        return (_recordType != null ? _recordType : DNSRecordType.TYPE_IGNORE);
-    }
-
-    /**
-     * @return record class
-     */
-    public DNSRecordClass getRecordClass() {
-        return (_dnsClass != null ? _dnsClass : DNSRecordClass.CLASS_UNKNOWN);
-    }
-
-    /**
-     * @return true if unique
-     */
-    public boolean isUnique() {
-        return _unique;
-    }
-
-    public Map<Fields, String> getQualifiedNameMap() {
-        return Collections.unmodifiableMap(_qualifiedNameMap);
-    }
-
-    /**
-     * Check if the record is expired.
-     *
-     * @param now
-     *            update date
-     * @return <code>true</code> is the record is expired, <code>false</code> otherwise.
-     */
-    public abstract boolean isExpired(long now);
-
-    /**
-     * @param dout
-     * @exception IOException
-     */
-    protected void toByteArray(DataOutputStream dout) throws IOException {
-        dout.write(this.getName().getBytes("UTF8"));
-        dout.writeShort(this.getRecordType().indexValue());
-        dout.writeShort(this.getRecordClass().indexValue());
-    }
-
-    /**
-     * Creates a byte array representation of this record. This is needed for tie-break tests according to draft-cheshire-dnsext-multicastdns-04.txt chapter 9.2.
-     *
-     * @return byte array representation
-     */
-    protected byte[] toByteArray() {
-        try {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            DataOutputStream dout = new DataOutputStream(bout);
-            this.toByteArray(dout);
-            dout.close();
-            return bout.toByteArray();
-        } catch (IOException e) {
-            throw new InternalError();
-        }
-    }
-
-    /**
-     * Overriden, to return a value which is consistent with the value returned by equals(Object).
-     */
-    @Override
-    public int hashCode() {
-        return this.getKey().hashCode() + this.getRecordType().indexValue() + this.getRecordClass().indexValue();
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder(200);
-        sb.append('[').append(this.getClass().getSimpleName()).append('@').append(System.identityHashCode(this));
-        sb.append(" type: ").append(this.getRecordType());
-        sb.append(", class: ").append(this.getRecordClass());
-        sb.append((_unique ? "-unique," : ","));
-        sb.append(" name: ").append( _name);
-        sb.append(']');
-
-        return sb.toString();
-    }
+    return sb.toString();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSIncoming.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSIncoming.java
@@ -4,22 +4,20 @@
 
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
+import io.libp2p.discovery.mdns.impl.constants.DNSLabel;
+import io.libp2p.discovery.mdns.impl.constants.DNSOptionCode;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
+import io.libp2p.discovery.mdns.impl.constants.DNSResultCode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
-import io.libp2p.discovery.mdns.impl.constants.DNSResultCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
-import io.libp2p.discovery.mdns.impl.constants.DNSLabel;
-import io.libp2p.discovery.mdns.impl.constants.DNSOptionCode;
 
 /**
  * Parse an incoming DNS message into its components.
@@ -27,571 +25,645 @@ import io.libp2p.discovery.mdns.impl.constants.DNSOptionCode;
  * @author Arthur van Hoff, Werner Randelshofer, Pierre Frisch, Daniel Bobbert
  */
 public final class DNSIncoming extends DNSMessage {
-    private static Logger logger                                = LoggerFactory.getLogger(DNSIncoming.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(DNSIncoming.class.getName());
 
-    // This is a hack to handle a bug in the BonjourConformanceTest
-    // It is sending out target strings that don't follow the "domain name" format.
-    public static boolean USE_DOMAIN_NAME_FORMAT_FOR_SRV_TARGET = true;
+  // This is a hack to handle a bug in the BonjourConformanceTest
+  // It is sending out target strings that don't follow the "domain name" format.
+  public static boolean USE_DOMAIN_NAME_FORMAT_FOR_SRV_TARGET = true;
 
-    public static class MessageInputStream extends ByteArrayInputStream {
-        private static Logger      logger1 = LoggerFactory.getLogger(MessageInputStream.class.getName());
+  public static class MessageInputStream extends ByteArrayInputStream {
+    private static Logger logger1 = LoggerFactory.getLogger(MessageInputStream.class.getName());
 
-        final Map<Integer, String> _names;
+    final Map<Integer, String> _names;
 
-        public MessageInputStream(byte[] buffer, int length) {
-            this(buffer, 0, length);
-        }
-
-        /**
-         * @param buffer
-         * @param offset
-         * @param length
-         */
-        public MessageInputStream(byte[] buffer, int offset, int length) {
-            super(buffer, offset, length);
-            _names = new HashMap<Integer, String>();
-        }
-
-        public int readByte() {
-            return this.read();
-        }
-
-        public int readUnsignedByte() {
-            return (this.read() & 0xFF);
-        }
-
-        public int readUnsignedShort() {
-            return (this.readUnsignedByte() << 8) | this.readUnsignedByte();
-        }
-
-        public int readInt() {
-            return (this.readUnsignedShort() << 16) | this.readUnsignedShort();
-        }
-
-        public byte[] readBytes(int len) {
-            byte bytes[] = new byte[len];
-            this.read(bytes, 0, len);
-            return bytes;
-        }
-
-        public String readUTF(int len) {
-            final StringBuilder sb = new StringBuilder(len);
-            for (int index = 0; index < len; index++) {
-                int ch = this.readUnsignedByte();
-                switch (ch >> 4) {
-                    case 0:
-                    case 1:
-                    case 2:
-                    case 3:
-                    case 4:
-                    case 5:
-                    case 6:
-                    case 7:
-                        // 0xxxxxxx
-                        break;
-                    case 12:
-                    case 13:
-                        // 110x xxxx 10xx xxxx
-                        ch = ((ch & 0x1F) << 6) | (this.readUnsignedByte() & 0x3F);
-                        index++;
-                        break;
-                    case 14:
-                        // 1110 xxxx 10xx xxxx 10xx xxxx
-                        ch = ((ch & 0x0f) << 12) | ((this.readUnsignedByte() & 0x3F) << 6) | (this.readUnsignedByte() & 0x3F);
-                        index++;
-                        index++;
-                        break;
-                    default:
-                        // 10xx xxxx, 1111 xxxx
-                        ch = ((ch & 0x3F) << 4) | (this.readUnsignedByte() & 0x0f);
-                        index++;
-                        break;
-                }
-                sb.append((char) ch);
-            }
-            return sb.toString();
-        }
-
-        protected synchronized int peek() {
-            return (pos < count) ? (buf[pos] & 0xff) : -1;
-        }
-
-        public String readName() {
-            Map<Integer, StringBuilder> names = new HashMap<Integer, StringBuilder>();
-            final StringBuilder sb = new StringBuilder();
-            boolean finished = false;
-            while (!finished) {
-                int len = this.readUnsignedByte();
-                if (len == 0) {
-                    finished = true;
-                    break;
-                }
-                switch (DNSLabel.labelForByte(len)) {
-                    case Standard:
-                        int offset = pos - 1;
-                        String label = this.readUTF(len) + ".";
-                        sb.append(label);
-                        for (StringBuilder previousLabel : names.values()) {
-                            previousLabel.append(label);
-                        }
-                        names.put(Integer.valueOf(offset), new StringBuilder(label));
-                        break;
-                    case Compressed:
-                        int index = (DNSLabel.labelValue(len) << 8) | this.readUnsignedByte();
-                        String compressedLabel = _names.get(Integer.valueOf(index));
-                        if (compressedLabel == null) {
-                            logger1.warn("Bad domain name: possible circular name detected. Bad offset: 0x{} at 0x{}",
-                                    Integer.toHexString(index),
-                                    Integer.toHexString(pos - 2)
-                                    );
-                            compressedLabel = "";
-                        }
-                        sb.append(compressedLabel);
-                        for (StringBuilder previousLabel : names.values()) {
-                            previousLabel.append(compressedLabel);
-                        }
-                        finished = true;
-                        break;
-                    case Extended:
-                        // int extendedLabelClass = DNSLabel.labelValue(len);
-                        logger1.debug("Extended label are not currently supported.");
-                        break;
-                    case Unknown:
-                    default:
-                        logger1.warn("Unsupported DNS label type: '{}'", Integer.toHexString(len & 0xC0) );
-                }
-            }
-            for (final Map.Entry<Integer, StringBuilder> entry : names.entrySet()) {
-                final Integer index = entry.getKey();
-                _names.put(index, entry.getValue().toString());
-            }
-            return sb.toString();
-        }
-
-        public String readNonNameString() {
-            int len = this.readUnsignedByte();
-            return this.readUTF(len);
-        }
-
-    }
-
-    private final DatagramPacket     _packet;
-
-    private final long               _receivedTime;
-
-    private final MessageInputStream _messageInputStream;
-
-    private int                      _senderUDPPayload;
-
-    /**
-     * Parse a message from a datagram packet.
-     *
-     * @param packet
-     * @exception IOException
-     */
-    public DNSIncoming(DatagramPacket packet) throws IOException {
-        super(0, 0, packet.getPort() == DNSConstants.MDNS_PORT);
-        this._packet = packet;
-        InetAddress source = packet.getAddress();
-        this._messageInputStream = new MessageInputStream(packet.getData(), packet.getLength());
-        this._receivedTime = System.currentTimeMillis();
-        this._senderUDPPayload = DNSConstants.MAX_MSG_TYPICAL;
-
-        try {
-            this.setId(_messageInputStream.readUnsignedShort());
-            this.setFlags(_messageInputStream.readUnsignedShort());
-            if (this.getOperationCode() > 0) {
-                throw new IOException("Received a message with a non standard operation code. Currently unsupported in the specification.");
-            }
-            int numQuestions = _messageInputStream.readUnsignedShort();
-            int numAnswers = _messageInputStream.readUnsignedShort();
-            int numAuthorities = _messageInputStream.readUnsignedShort();
-            int numAdditionals = _messageInputStream.readUnsignedShort();
-
-            logger.debug("DNSIncoming() questions:{} answers:{} authorities:{} additionals:{}",
-                    numQuestions,
-                    numAnswers,
-                    numAuthorities,
-                    numAdditionals
-            );
-
-            // We need some sanity checks
-            // A question is at least 5 bytes and answer 11 so check what we have
-
-            if ((numQuestions * 5 + (numAnswers + numAuthorities + numAdditionals) * 11) > packet.getLength()) {
-                throw new IOException("questions:" + numQuestions + " answers:" + numAnswers + " authorities:" + numAuthorities + " additionals:" + numAdditionals);
-            }
-
-            // parse questions
-            for (int i = 0; i < numQuestions; i++) {
-                DNSQuestion question = this.readQuestion();
-                if (question != null)
-                    _questions.add(question);
-            }
-
-            // parse answers
-            for (int i = 0; i < numAnswers; i++) {
-                DNSRecord rec = this.readAnswer();
-                if (rec != null) {
-                    // Add a record, if we were able to create one.
-                    _answers.add(rec);
-                }
-            }
-
-            for (int i = 0; i < numAuthorities; i++) {
-                DNSRecord rec = this.readAnswer();
-                if (rec != null) {
-                    // Add a record, if we were able to create one.
-                    _authoritativeAnswers.add(rec);
-                }
-            }
-
-            for (int i = 0; i < numAdditionals; i++) {
-                DNSRecord rec = this.readAnswer();
-                if (rec != null) {
-                    // Add a record, if we were able to create one.
-                    _additionals.add(rec);
-                }
-            }
-
-            // We should have drained the entire stream by now
-            if (_messageInputStream.available() > 0) {
-                throw new IOException("Received a message with the wrong length.");
-            }
-        } catch (Exception e) {
-            logger.warn("DNSIncoming() dump " + print(true) + "\n exception ", e);
-            // This ugly but some JVM don't implement the cause on IOException
-            IOException ioe = new IOException("DNSIncoming corrupted message");
-            ioe.initCause(e);
-            throw ioe;
-        } finally {
-            try {
-                _messageInputStream.close();
-            } catch (Exception e) { 
-            	logger.warn("MessageInputStream close error");
-            }
-        }
-    }
-
-    private DNSIncoming(int flags, int id, boolean multicast, DatagramPacket packet, long receivedTime) {
-        super(flags, id, multicast);
-        this._packet = packet;
-        this._messageInputStream = new MessageInputStream(packet.getData(), packet.getLength());
-        this._receivedTime = receivedTime;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#clone()
-     */
-    @Override
-    public DNSIncoming clone() {
-        DNSIncoming in = new DNSIncoming(this.getFlags(), this.getId(), this.isMulticast(), this._packet, this._receivedTime);
-        in._senderUDPPayload = this._senderUDPPayload;
-        in._questions.addAll(this._questions);
-        in._answers.addAll(this._answers);
-        in._authoritativeAnswers.addAll(this._authoritativeAnswers);
-        in._additionals.addAll(this._additionals);
-        return in;
-    }
-
-    private DNSQuestion readQuestion() {
-        String domain = _messageInputStream.readName();
-        DNSRecordType type = DNSRecordType.typeForIndex(_messageInputStream.readUnsignedShort());
-        if (type == DNSRecordType.TYPE_IGNORE) {
-            logger.warn("Could not find record type: {}", this.print(true));
-        }
-        int recordClassIndex = _messageInputStream.readUnsignedShort();
-        DNSRecordClass recordClass = DNSRecordClass.classForIndex(recordClassIndex);
-        boolean unique = recordClass.isUnique(recordClassIndex);
-        return DNSQuestion.newQuestion(domain, type, recordClass, unique);
-    }
-
-    private DNSRecord readAnswer() {
-        String domain = _messageInputStream.readName();
-        DNSRecordType type = DNSRecordType.typeForIndex(_messageInputStream.readUnsignedShort());
-        if (type == DNSRecordType.TYPE_IGNORE) {
-            logger.warn("Could not find record type. domain: {}\n{}", domain, this.print(true));
-        }
-        int recordClassIndex = _messageInputStream.readUnsignedShort();
-        DNSRecordClass recordClass = (type == DNSRecordType.TYPE_OPT ? DNSRecordClass.CLASS_UNKNOWN : DNSRecordClass.classForIndex(recordClassIndex));
-        if ((recordClass == DNSRecordClass.CLASS_UNKNOWN) && (type != DNSRecordType.TYPE_OPT)) {
-            logger.warn("Could not find record class. domain: {} type: {}\n{}", domain, type, this.print(true));
-        }
-        boolean unique = recordClass.isUnique(recordClassIndex);
-        int ttl = _messageInputStream.readInt();
-        int len = _messageInputStream.readUnsignedShort();
-        DNSRecord rec = null;
-
-        switch (type) {
-            case TYPE_A: // IPv4
-                rec = new DNSRecord.IPv4Address(domain, recordClass, unique, ttl, _messageInputStream.readBytes(len));
-                break;
-            case TYPE_AAAA: // IPv6
-                rec = new DNSRecord.IPv6Address(domain, recordClass, unique, ttl, _messageInputStream.readBytes(len));
-                break;
-            case TYPE_CNAME:
-            case TYPE_PTR:
-                String service = "";
-                service = _messageInputStream.readName();
-                if (service.length() > 0) {
-                    rec = new DNSRecord.Pointer(domain, recordClass, unique, ttl, service);
-                } else {
-                    logger.warn("PTR record of class: {}, there was a problem reading the service name of the answer for domain: {}", recordClass, domain);
-                }
-                break;
-            case TYPE_TXT:
-                rec = new DNSRecord.Text(domain, recordClass, unique, ttl, _messageInputStream.readBytes(len));
-                break;
-            case TYPE_SRV:
-                int priority = _messageInputStream.readUnsignedShort();
-                int weight = _messageInputStream.readUnsignedShort();
-                int port = _messageInputStream.readUnsignedShort();
-                String target = "";
-                // This is a hack to handle a bug in the BonjourConformanceTest
-                // It is sending out target strings that don't follow the "domain name" format.
-                if (USE_DOMAIN_NAME_FORMAT_FOR_SRV_TARGET) {
-                    target = _messageInputStream.readName();
-                } else {
-                    // [PJYF Nov 13 2010] Do we still need this? This looks really bad. All label are supposed to start by a length.
-                    target = _messageInputStream.readNonNameString();
-                }
-                rec = new DNSRecord.Service(domain, recordClass, unique, ttl, priority, weight, port, target);
-                break;
-            case TYPE_HINFO:
-                final StringBuilder sb = new StringBuilder();
-                sb.append(_messageInputStream.readUTF(len));
-                int index = sb.indexOf(" ");
-                String cpu = (index > 0 ? sb.substring(0, index) : sb.toString()).trim();
-                String os = (index > 0 ? sb.substring(index + 1) : "").trim();
-                rec = new DNSRecord.HostInformation(domain, recordClass, unique, ttl, cpu, os);
-                break;
-            case TYPE_OPT:
-                DNSResultCode extendedResultCode = DNSResultCode.resultCodeForFlags(this.getFlags(), ttl);
-                int version = (ttl & 0x00ff0000) >> 16;
-                if (version == 0) {
-                    _senderUDPPayload = recordClassIndex;
-                    while (_messageInputStream.available() > 0) {
-                        // Read RDData
-                        int optionCodeInt = 0;
-                        DNSOptionCode optionCode = null;
-                        if (_messageInputStream.available() >= 2) {
-                            optionCodeInt = _messageInputStream.readUnsignedShort();
-                            optionCode = DNSOptionCode.resultCodeForFlags(optionCodeInt);
-                        } else {
-                            logger.warn("There was a problem reading the OPT record. Ignoring.");
-                            break;
-                        }
-                        int optionLength = 0;
-                        if (_messageInputStream.available() >= 2) {
-                            optionLength = _messageInputStream.readUnsignedShort();
-                        } else {
-                            logger.warn("There was a problem reading the OPT record. Ignoring.");
-                            break;
-                        }
-                        byte[] optiondata = new byte[0];
-                        if (_messageInputStream.available() >= optionLength) {
-                            optiondata = _messageInputStream.readBytes(optionLength);
-                        }
-                        //
-                        // We should really do something with those options.
-                        switch (optionCode) {
-                            case Owner:
-                                // Valid length values are 8, 14, 18 and 20
-                                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-                                // |Opt|Len|V|S|Primary MAC|Wakeup MAC | Password |
-                                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-                                //
-                                int ownerVersion = 0;
-                                int ownerSequence = 0;
-                                byte[] ownerPrimaryMacAddress = null;
-                                byte[] ownerWakeupMacAddress = null;
-                                byte[] ownerPassword = null;
-                                try {
-                                    ownerVersion = optiondata[0];
-                                    ownerSequence = optiondata[1];
-                                    ownerPrimaryMacAddress = new byte[] { optiondata[2], optiondata[3], optiondata[4], optiondata[5], optiondata[6], optiondata[7] };
-                                    ownerWakeupMacAddress = ownerPrimaryMacAddress;
-                                    if (optiondata.length > 8) {
-                                        // We have a wakeupMacAddress.
-                                        ownerWakeupMacAddress = new byte[] { optiondata[8], optiondata[9], optiondata[10], optiondata[11], optiondata[12], optiondata[13] };
-                                    }
-                                    if (optiondata.length == 18) {
-                                        // We have a short password.
-                                        ownerPassword = new byte[] { optiondata[14], optiondata[15], optiondata[16], optiondata[17] };
-                                    }
-                                    if (optiondata.length == 22) {
-                                        // We have a long password.
-                                        ownerPassword = new byte[] { optiondata[14], optiondata[15], optiondata[16], optiondata[17], optiondata[18], optiondata[19], optiondata[20], optiondata[21] };
-                                    }
-                                } catch (Exception exception) {
-                                    logger.warn("Malformed OPT answer. Option code: Owner data: {}", this._hexString(optiondata));
-                                }
-                                if (logger.isDebugEnabled()) {
-                                    logger.debug("Unhandled Owner OPT version: {} sequence: {} MAC address: {} {}{} {}{}",
-                                            ownerVersion,
-                                            ownerSequence,
-                                            this._hexString(ownerPrimaryMacAddress),
-                                            (ownerWakeupMacAddress != ownerPrimaryMacAddress ? " wakeup MAC address: " : ""),
-                                            (ownerWakeupMacAddress != ownerPrimaryMacAddress ? this._hexString(ownerWakeupMacAddress) : ""),
-                                            (ownerPassword != null ? " password: ": ""),
-                                            (ownerPassword != null ? this._hexString(ownerPassword) : "")
-                                    );
-                                }
-                                break;
-                            case LLQ:
-                            case NSID:
-                            case UL:
-                                if (logger.isDebugEnabled()) {
-                                    logger.debug("There was an OPT answer. Option code: {} data: {}", optionCode, this._hexString(optiondata));
-                                }
-                                break;
-                            case Unknown:
-                                if (optionCodeInt >= 65001 && optionCodeInt <= 65534) {
-                                     // RFC 6891 defines this range as used for experimental/local purposes.
-                                    logger.debug("There was an OPT answer using an experimental/local option code: {} data: {}", optionCodeInt, this._hexString(optiondata));
-                                } else {
-                                    logger.warn("There was an OPT answer. Not currently handled. Option code: {} data: {}", optionCodeInt, this._hexString(optiondata));
-                                }
-                                break;
-                            default:
-                                // This is to keep the compiler happy.
-                                break;
-                        }
-                    }
-                } else {
-                    logger.warn("There was an OPT answer. Wrong version number: {} result code: {}", version, extendedResultCode);
-                }
-                break;
-            default:
-                    logger.debug("DNSIncoming() unknown type: {}", type);
-                _messageInputStream.skip(len);
-                break;
-        }
-        return rec;
+    public MessageInputStream(byte[] buffer, int length) {
+      this(buffer, 0, length);
     }
 
     /**
-     * Debugging.
+     * @param buffer
+     * @param offset
+     * @param length
      */
-    String print(boolean dump) {
+    public MessageInputStream(byte[] buffer, int offset, int length) {
+      super(buffer, offset, length);
+      _names = new HashMap<Integer, String>();
+    }
+
+    public int readByte() {
+      return this.read();
+    }
+
+    public int readUnsignedByte() {
+      return (this.read() & 0xFF);
+    }
+
+    public int readUnsignedShort() {
+      return (this.readUnsignedByte() << 8) | this.readUnsignedByte();
+    }
+
+    public int readInt() {
+      return (this.readUnsignedShort() << 16) | this.readUnsignedShort();
+    }
+
+    public byte[] readBytes(int len) {
+      byte bytes[] = new byte[len];
+      this.read(bytes, 0, len);
+      return bytes;
+    }
+
+    public String readUTF(int len) {
+      final StringBuilder sb = new StringBuilder(len);
+      for (int index = 0; index < len; index++) {
+        int ch = this.readUnsignedByte();
+        switch (ch >> 4) {
+          case 0:
+          case 1:
+          case 2:
+          case 3:
+          case 4:
+          case 5:
+          case 6:
+          case 7:
+            // 0xxxxxxx
+            break;
+          case 12:
+          case 13:
+            // 110x xxxx 10xx xxxx
+            ch = ((ch & 0x1F) << 6) | (this.readUnsignedByte() & 0x3F);
+            index++;
+            break;
+          case 14:
+            // 1110 xxxx 10xx xxxx 10xx xxxx
+            ch =
+                ((ch & 0x0f) << 12)
+                    | ((this.readUnsignedByte() & 0x3F) << 6)
+                    | (this.readUnsignedByte() & 0x3F);
+            index++;
+            index++;
+            break;
+          default:
+            // 10xx xxxx, 1111 xxxx
+            ch = ((ch & 0x3F) << 4) | (this.readUnsignedByte() & 0x0f);
+            index++;
+            break;
+        }
+        sb.append((char) ch);
+      }
+      return sb.toString();
+    }
+
+    protected synchronized int peek() {
+      return (pos < count) ? (buf[pos] & 0xff) : -1;
+    }
+
+    public String readName() {
+      Map<Integer, StringBuilder> names = new HashMap<Integer, StringBuilder>();
+      final StringBuilder sb = new StringBuilder();
+      boolean finished = false;
+      while (!finished) {
+        int len = this.readUnsignedByte();
+        if (len == 0) {
+          finished = true;
+          break;
+        }
+        switch (DNSLabel.labelForByte(len)) {
+          case Standard:
+            int offset = pos - 1;
+            String label = this.readUTF(len) + ".";
+            sb.append(label);
+            for (StringBuilder previousLabel : names.values()) {
+              previousLabel.append(label);
+            }
+            names.put(Integer.valueOf(offset), new StringBuilder(label));
+            break;
+          case Compressed:
+            int index = (DNSLabel.labelValue(len) << 8) | this.readUnsignedByte();
+            String compressedLabel = _names.get(Integer.valueOf(index));
+            if (compressedLabel == null) {
+              logger1.warn(
+                  "Bad domain name: possible circular name detected. Bad offset: 0x{} at 0x{}",
+                  Integer.toHexString(index),
+                  Integer.toHexString(pos - 2));
+              compressedLabel = "";
+            }
+            sb.append(compressedLabel);
+            for (StringBuilder previousLabel : names.values()) {
+              previousLabel.append(compressedLabel);
+            }
+            finished = true;
+            break;
+          case Extended:
+            // int extendedLabelClass = DNSLabel.labelValue(len);
+            logger1.debug("Extended label are not currently supported.");
+            break;
+          case Unknown:
+          default:
+            logger1.warn("Unsupported DNS label type: '{}'", Integer.toHexString(len & 0xC0));
+        }
+      }
+      for (final Map.Entry<Integer, StringBuilder> entry : names.entrySet()) {
+        final Integer index = entry.getKey();
+        _names.put(index, entry.getValue().toString());
+      }
+      return sb.toString();
+    }
+
+    public String readNonNameString() {
+      int len = this.readUnsignedByte();
+      return this.readUTF(len);
+    }
+  }
+
+  private final DatagramPacket _packet;
+
+  private final long _receivedTime;
+
+  private final MessageInputStream _messageInputStream;
+
+  private int _senderUDPPayload;
+
+  /**
+   * Parse a message from a datagram packet.
+   *
+   * @param packet
+   * @exception IOException
+   */
+  public DNSIncoming(DatagramPacket packet) throws IOException {
+    super(0, 0, packet.getPort() == DNSConstants.MDNS_PORT);
+    this._packet = packet;
+    InetAddress source = packet.getAddress();
+    this._messageInputStream = new MessageInputStream(packet.getData(), packet.getLength());
+    this._receivedTime = System.currentTimeMillis();
+    this._senderUDPPayload = DNSConstants.MAX_MSG_TYPICAL;
+
+    try {
+      this.setId(_messageInputStream.readUnsignedShort());
+      this.setFlags(_messageInputStream.readUnsignedShort());
+      if (this.getOperationCode() > 0) {
+        throw new IOException(
+            "Received a message with a non standard operation code. Currently unsupported in the specification.");
+      }
+      int numQuestions = _messageInputStream.readUnsignedShort();
+      int numAnswers = _messageInputStream.readUnsignedShort();
+      int numAuthorities = _messageInputStream.readUnsignedShort();
+      int numAdditionals = _messageInputStream.readUnsignedShort();
+
+      logger.debug(
+          "DNSIncoming() questions:{} answers:{} authorities:{} additionals:{}",
+          numQuestions,
+          numAnswers,
+          numAuthorities,
+          numAdditionals);
+
+      // We need some sanity checks
+      // A question is at least 5 bytes and answer 11 so check what we have
+
+      if ((numQuestions * 5 + (numAnswers + numAuthorities + numAdditionals) * 11)
+          > packet.getLength()) {
+        throw new IOException(
+            "questions:"
+                + numQuestions
+                + " answers:"
+                + numAnswers
+                + " authorities:"
+                + numAuthorities
+                + " additionals:"
+                + numAdditionals);
+      }
+
+      // parse questions
+      for (int i = 0; i < numQuestions; i++) {
+        DNSQuestion question = this.readQuestion();
+        if (question != null) _questions.add(question);
+      }
+
+      // parse answers
+      for (int i = 0; i < numAnswers; i++) {
+        DNSRecord rec = this.readAnswer();
+        if (rec != null) {
+          // Add a record, if we were able to create one.
+          _answers.add(rec);
+        }
+      }
+
+      for (int i = 0; i < numAuthorities; i++) {
+        DNSRecord rec = this.readAnswer();
+        if (rec != null) {
+          // Add a record, if we were able to create one.
+          _authoritativeAnswers.add(rec);
+        }
+      }
+
+      for (int i = 0; i < numAdditionals; i++) {
+        DNSRecord rec = this.readAnswer();
+        if (rec != null) {
+          // Add a record, if we were able to create one.
+          _additionals.add(rec);
+        }
+      }
+
+      // We should have drained the entire stream by now
+      if (_messageInputStream.available() > 0) {
+        throw new IOException("Received a message with the wrong length.");
+      }
+    } catch (Exception e) {
+      logger.warn("DNSIncoming() dump " + print(true) + "\n exception ", e);
+      // This ugly but some JVM don't implement the cause on IOException
+      IOException ioe = new IOException("DNSIncoming corrupted message");
+      ioe.initCause(e);
+      throw ioe;
+    } finally {
+      try {
+        _messageInputStream.close();
+      } catch (Exception e) {
+        logger.warn("MessageInputStream close error");
+      }
+    }
+  }
+
+  private DNSIncoming(
+      int flags, int id, boolean multicast, DatagramPacket packet, long receivedTime) {
+    super(flags, id, multicast);
+    this._packet = packet;
+    this._messageInputStream = new MessageInputStream(packet.getData(), packet.getLength());
+    this._receivedTime = receivedTime;
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see java.lang.Object#clone()
+   */
+  @Override
+  public DNSIncoming clone() {
+    DNSIncoming in =
+        new DNSIncoming(
+            this.getFlags(), this.getId(), this.isMulticast(), this._packet, this._receivedTime);
+    in._senderUDPPayload = this._senderUDPPayload;
+    in._questions.addAll(this._questions);
+    in._answers.addAll(this._answers);
+    in._authoritativeAnswers.addAll(this._authoritativeAnswers);
+    in._additionals.addAll(this._additionals);
+    return in;
+  }
+
+  private DNSQuestion readQuestion() {
+    String domain = _messageInputStream.readName();
+    DNSRecordType type = DNSRecordType.typeForIndex(_messageInputStream.readUnsignedShort());
+    if (type == DNSRecordType.TYPE_IGNORE) {
+      logger.warn("Could not find record type: {}", this.print(true));
+    }
+    int recordClassIndex = _messageInputStream.readUnsignedShort();
+    DNSRecordClass recordClass = DNSRecordClass.classForIndex(recordClassIndex);
+    boolean unique = recordClass.isUnique(recordClassIndex);
+    return DNSQuestion.newQuestion(domain, type, recordClass, unique);
+  }
+
+  private DNSRecord readAnswer() {
+    String domain = _messageInputStream.readName();
+    DNSRecordType type = DNSRecordType.typeForIndex(_messageInputStream.readUnsignedShort());
+    if (type == DNSRecordType.TYPE_IGNORE) {
+      logger.warn("Could not find record type. domain: {}\n{}", domain, this.print(true));
+    }
+    int recordClassIndex = _messageInputStream.readUnsignedShort();
+    DNSRecordClass recordClass =
+        (type == DNSRecordType.TYPE_OPT
+            ? DNSRecordClass.CLASS_UNKNOWN
+            : DNSRecordClass.classForIndex(recordClassIndex));
+    if ((recordClass == DNSRecordClass.CLASS_UNKNOWN) && (type != DNSRecordType.TYPE_OPT)) {
+      logger.warn(
+          "Could not find record class. domain: {} type: {}\n{}", domain, type, this.print(true));
+    }
+    boolean unique = recordClass.isUnique(recordClassIndex);
+    int ttl = _messageInputStream.readInt();
+    int len = _messageInputStream.readUnsignedShort();
+    DNSRecord rec = null;
+
+    switch (type) {
+      case TYPE_A: // IPv4
+        rec =
+            new DNSRecord.IPv4Address(
+                domain, recordClass, unique, ttl, _messageInputStream.readBytes(len));
+        break;
+      case TYPE_AAAA: // IPv6
+        rec =
+            new DNSRecord.IPv6Address(
+                domain, recordClass, unique, ttl, _messageInputStream.readBytes(len));
+        break;
+      case TYPE_CNAME:
+      case TYPE_PTR:
+        String service = "";
+        service = _messageInputStream.readName();
+        if (service.length() > 0) {
+          rec = new DNSRecord.Pointer(domain, recordClass, unique, ttl, service);
+        } else {
+          logger.warn(
+              "PTR record of class: {}, there was a problem reading the service name of the answer for domain: {}",
+              recordClass,
+              domain);
+        }
+        break;
+      case TYPE_TXT:
+        rec =
+            new DNSRecord.Text(
+                domain, recordClass, unique, ttl, _messageInputStream.readBytes(len));
+        break;
+      case TYPE_SRV:
+        int priority = _messageInputStream.readUnsignedShort();
+        int weight = _messageInputStream.readUnsignedShort();
+        int port = _messageInputStream.readUnsignedShort();
+        String target = "";
+        // This is a hack to handle a bug in the BonjourConformanceTest
+        // It is sending out target strings that don't follow the "domain name" format.
+        if (USE_DOMAIN_NAME_FORMAT_FOR_SRV_TARGET) {
+          target = _messageInputStream.readName();
+        } else {
+          // [PJYF Nov 13 2010] Do we still need this? This looks really bad. All label are supposed
+          // to start by a length.
+          target = _messageInputStream.readNonNameString();
+        }
+        rec =
+            new DNSRecord.Service(domain, recordClass, unique, ttl, priority, weight, port, target);
+        break;
+      case TYPE_HINFO:
         final StringBuilder sb = new StringBuilder();
-        sb.append(this.print());
-        if (dump) {
-            byte[] data = new byte[_packet.getLength()];
-            System.arraycopy(_packet.getData(), 0, data, 0, data.length);
-            sb.append(this.print(data));
+        sb.append(_messageInputStream.readUTF(len));
+        int index = sb.indexOf(" ");
+        String cpu = (index > 0 ? sb.substring(0, index) : sb.toString()).trim();
+        String os = (index > 0 ? sb.substring(index + 1) : "").trim();
+        rec = new DNSRecord.HostInformation(domain, recordClass, unique, ttl, cpu, os);
+        break;
+      case TYPE_OPT:
+        DNSResultCode extendedResultCode = DNSResultCode.resultCodeForFlags(this.getFlags(), ttl);
+        int version = (ttl & 0x00ff0000) >> 16;
+        if (version == 0) {
+          _senderUDPPayload = recordClassIndex;
+          while (_messageInputStream.available() > 0) {
+            // Read RDData
+            int optionCodeInt = 0;
+            DNSOptionCode optionCode = null;
+            if (_messageInputStream.available() >= 2) {
+              optionCodeInt = _messageInputStream.readUnsignedShort();
+              optionCode = DNSOptionCode.resultCodeForFlags(optionCodeInt);
+            } else {
+              logger.warn("There was a problem reading the OPT record. Ignoring.");
+              break;
+            }
+            int optionLength = 0;
+            if (_messageInputStream.available() >= 2) {
+              optionLength = _messageInputStream.readUnsignedShort();
+            } else {
+              logger.warn("There was a problem reading the OPT record. Ignoring.");
+              break;
+            }
+            byte[] optiondata = new byte[0];
+            if (_messageInputStream.available() >= optionLength) {
+              optiondata = _messageInputStream.readBytes(optionLength);
+            }
+            //
+            // We should really do something with those options.
+            switch (optionCode) {
+              case Owner:
+                // Valid length values are 8, 14, 18 and 20
+                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                // |Opt|Len|V|S|Primary MAC|Wakeup MAC | Password |
+                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                //
+                int ownerVersion = 0;
+                int ownerSequence = 0;
+                byte[] ownerPrimaryMacAddress = null;
+                byte[] ownerWakeupMacAddress = null;
+                byte[] ownerPassword = null;
+                try {
+                  ownerVersion = optiondata[0];
+                  ownerSequence = optiondata[1];
+                  ownerPrimaryMacAddress =
+                      new byte[] {
+                        optiondata[2],
+                        optiondata[3],
+                        optiondata[4],
+                        optiondata[5],
+                        optiondata[6],
+                        optiondata[7]
+                      };
+                  ownerWakeupMacAddress = ownerPrimaryMacAddress;
+                  if (optiondata.length > 8) {
+                    // We have a wakeupMacAddress.
+                    ownerWakeupMacAddress =
+                        new byte[] {
+                          optiondata[8],
+                          optiondata[9],
+                          optiondata[10],
+                          optiondata[11],
+                          optiondata[12],
+                          optiondata[13]
+                        };
+                  }
+                  if (optiondata.length == 18) {
+                    // We have a short password.
+                    ownerPassword =
+                        new byte[] {optiondata[14], optiondata[15], optiondata[16], optiondata[17]};
+                  }
+                  if (optiondata.length == 22) {
+                    // We have a long password.
+                    ownerPassword =
+                        new byte[] {
+                          optiondata[14],
+                          optiondata[15],
+                          optiondata[16],
+                          optiondata[17],
+                          optiondata[18],
+                          optiondata[19],
+                          optiondata[20],
+                          optiondata[21]
+                        };
+                  }
+                } catch (Exception exception) {
+                  logger.warn(
+                      "Malformed OPT answer. Option code: Owner data: {}",
+                      this._hexString(optiondata));
+                }
+                if (logger.isDebugEnabled()) {
+                  logger.debug(
+                      "Unhandled Owner OPT version: {} sequence: {} MAC address: {} {}{} {}{}",
+                      ownerVersion,
+                      ownerSequence,
+                      this._hexString(ownerPrimaryMacAddress),
+                      (ownerWakeupMacAddress != ownerPrimaryMacAddress
+                          ? " wakeup MAC address: "
+                          : ""),
+                      (ownerWakeupMacAddress != ownerPrimaryMacAddress
+                          ? this._hexString(ownerWakeupMacAddress)
+                          : ""),
+                      (ownerPassword != null ? " password: " : ""),
+                      (ownerPassword != null ? this._hexString(ownerPassword) : ""));
+                }
+                break;
+              case LLQ:
+              case NSID:
+              case UL:
+                if (logger.isDebugEnabled()) {
+                  logger.debug(
+                      "There was an OPT answer. Option code: {} data: {}",
+                      optionCode,
+                      this._hexString(optiondata));
+                }
+                break;
+              case Unknown:
+                if (optionCodeInt >= 65001 && optionCodeInt <= 65534) {
+                  // RFC 6891 defines this range as used for experimental/local purposes.
+                  logger.debug(
+                      "There was an OPT answer using an experimental/local option code: {} data: {}",
+                      optionCodeInt,
+                      this._hexString(optiondata));
+                } else {
+                  logger.warn(
+                      "There was an OPT answer. Not currently handled. Option code: {} data: {}",
+                      optionCodeInt,
+                      this._hexString(optiondata));
+                }
+                break;
+              default:
+                // This is to keep the compiler happy.
+                break;
+            }
+          }
+        } else {
+          logger.warn(
+              "There was an OPT answer. Wrong version number: {} result code: {}",
+              version,
+              extendedResultCode);
         }
-        return sb.toString();
+        break;
+      default:
+        logger.debug("DNSIncoming() unknown type: {}", type);
+        _messageInputStream.skip(len);
+        break;
+    }
+    return rec;
+  }
+
+  /** Debugging. */
+  String print(boolean dump) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(this.print());
+    if (dump) {
+      byte[] data = new byte[_packet.getLength()];
+      System.arraycopy(_packet.getData(), 0, data, 0, data.length);
+      sb.append(this.print(data));
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(isQuery() ? "dns[query," : "dns[response,");
+    if (_packet.getAddress() != null) {
+      sb.append(_packet.getAddress().getHostAddress());
+    }
+    sb.append(':');
+    sb.append(_packet.getPort());
+    sb.append(", length=");
+    sb.append(_packet.getLength());
+    sb.append(", id=0x");
+    sb.append(Integer.toHexString(this.getId()));
+    if (this.getFlags() != 0) {
+      sb.append(", flags=0x");
+      sb.append(Integer.toHexString(this.getFlags()));
+      if ((this.getFlags() & DNSConstants.FLAGS_QR_RESPONSE) != 0) {
+        sb.append(":r");
+      }
+      if ((this.getFlags() & DNSConstants.FLAGS_AA) != 0) {
+        sb.append(":aa");
+      }
+      if ((this.getFlags() & DNSConstants.FLAGS_TC) != 0) {
+        sb.append(":tc");
+      }
+    }
+    if (this.getNumberOfQuestions() > 0) {
+      sb.append(", questions=");
+      sb.append(this.getNumberOfQuestions());
+    }
+    if (this.getNumberOfAnswers() > 0) {
+      sb.append(", answers=");
+      sb.append(this.getNumberOfAnswers());
+    }
+    if (this.getNumberOfAuthorities() > 0) {
+      sb.append(", authorities=");
+      sb.append(this.getNumberOfAuthorities());
+    }
+    if (this.getNumberOfAdditionals() > 0) {
+      sb.append(", additionals=");
+      sb.append(this.getNumberOfAdditionals());
+    }
+    if (this.getNumberOfQuestions() > 0) {
+      sb.append("\nquestions:");
+      for (DNSQuestion question : _questions) {
+        sb.append("\n\t");
+        sb.append(question);
+      }
+    }
+    if (this.getNumberOfAnswers() > 0) {
+      sb.append("\nanswers:");
+      for (DNSRecord record : _answers) {
+        sb.append("\n\t");
+        sb.append(record);
+      }
+    }
+    if (this.getNumberOfAuthorities() > 0) {
+      sb.append("\nauthorities:");
+      for (DNSRecord record : _authoritativeAnswers) {
+        sb.append("\n\t");
+        sb.append(record);
+      }
+    }
+    if (this.getNumberOfAdditionals() > 0) {
+      sb.append("\nadditionals:");
+      for (DNSRecord record : _additionals) {
+        sb.append("\n\t");
+        sb.append(record);
+      }
+    }
+    sb.append(']');
+
+    return sb.toString();
+  }
+
+  public int elapseSinceArrival() {
+    return (int) (System.currentTimeMillis() - _receivedTime);
+  }
+
+  /**
+   * This will return the default UDP payload except if an OPT record was found with a different
+   * size.
+   *
+   * @return the senderUDPPayload
+   */
+  public int getSenderUDPPayload() {
+    return this._senderUDPPayload;
+  }
+
+  private static final char[] _nibbleToHex = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+  };
+
+  /**
+   * Returns a hex-string for printing
+   *
+   * @param bytes
+   * @return Returns a hex-string which can be used within a SQL expression
+   */
+  private String _hexString(byte[] bytes) {
+
+    final StringBuilder result = new StringBuilder(2 * bytes.length);
+
+    for (int i = 0; i < bytes.length; i++) {
+      int b = bytes[i] & 0xFF;
+      result.append(_nibbleToHex[b / 16]);
+      result.append(_nibbleToHex[b % 16]);
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append(isQuery() ? "dns[query," : "dns[response,");
-        if (_packet.getAddress() != null) {
-            sb.append(_packet.getAddress().getHostAddress());
-        }
-        sb.append(':');
-        sb.append(_packet.getPort());
-        sb.append(", length=");
-        sb.append(_packet.getLength());
-        sb.append(", id=0x");
-        sb.append(Integer.toHexString(this.getId()));
-        if (this.getFlags() != 0) {
-            sb.append(", flags=0x");
-            sb.append(Integer.toHexString(this.getFlags()));
-            if ((this.getFlags() & DNSConstants.FLAGS_QR_RESPONSE) != 0) {
-                sb.append(":r");
-            }
-            if ((this.getFlags() & DNSConstants.FLAGS_AA) != 0) {
-                sb.append(":aa");
-            }
-            if ((this.getFlags() & DNSConstants.FLAGS_TC) != 0) {
-                sb.append(":tc");
-            }
-        }
-        if (this.getNumberOfQuestions() > 0) {
-            sb.append(", questions=");
-            sb.append(this.getNumberOfQuestions());
-        }
-        if (this.getNumberOfAnswers() > 0) {
-            sb.append(", answers=");
-            sb.append(this.getNumberOfAnswers());
-        }
-        if (this.getNumberOfAuthorities() > 0) {
-            sb.append(", authorities=");
-            sb.append(this.getNumberOfAuthorities());
-        }
-        if (this.getNumberOfAdditionals() > 0) {
-            sb.append(", additionals=");
-            sb.append(this.getNumberOfAdditionals());
-        }
-        if (this.getNumberOfQuestions() > 0) {
-            sb.append("\nquestions:");
-            for (DNSQuestion question : _questions) {
-                sb.append("\n\t");
-                sb.append(question);
-            }
-        }
-        if (this.getNumberOfAnswers() > 0) {
-            sb.append("\nanswers:");
-            for (DNSRecord record : _answers) {
-                sb.append("\n\t");
-                sb.append(record);
-            }
-        }
-        if (this.getNumberOfAuthorities() > 0) {
-            sb.append("\nauthorities:");
-            for (DNSRecord record : _authoritativeAnswers) {
-                sb.append("\n\t");
-                sb.append(record);
-            }
-        }
-        if (this.getNumberOfAdditionals() > 0) {
-            sb.append("\nadditionals:");
-            for (DNSRecord record : _additionals) {
-                sb.append("\n\t");
-                sb.append(record);
-            }
-        }
-        sb.append(']');
-
-        return sb.toString();
-    }
-
-    public int elapseSinceArrival() {
-        return (int) (System.currentTimeMillis() - _receivedTime);
-    }
-
-    /**
-     * This will return the default UDP payload except if an OPT record was found with a different size.
-     *
-     * @return the senderUDPPayload
-     */
-    public int getSenderUDPPayload() {
-        return this._senderUDPPayload;
-    }
-
-    private static final char[] _nibbleToHex = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
-
-    /**
-     * Returns a hex-string for printing
-     *
-     * @param bytes
-     * @return Returns a hex-string which can be used within a SQL expression
-     */
-    private String _hexString(byte[] bytes) {
-
-        final StringBuilder result = new StringBuilder(2 * bytes.length);
-
-        for (int i = 0; i < bytes.length; i++) {
-            int b = bytes[i] & 0xFF;
-            result.append(_nibbleToHex[b / 16]);
-            result.append(_nibbleToHex[b % 16]);
-        }
-
-        return result.toString();
-    }
-
+    return result.toString();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSMessage.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSMessage.java
@@ -1,15 +1,12 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
 
 /**
  * DNSMessage define a DNS message either incoming or outgoing.
@@ -18,318 +15,315 @@ import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
  */
 public abstract class DNSMessage {
 
-    /**
-     *
-     */
-    public static final boolean       MULTICAST = true;
+  /** */
+  public static final boolean MULTICAST = true;
 
-    /**
-     *
-     */
-    public static final boolean       UNICAST   = false;
+  /** */
+  public static final boolean UNICAST = false;
 
-    // protected DatagramPacket _packet;
-    // protected int _off;
-    // protected int _len;
-    // protected byte[] _data;
+  // protected DatagramPacket _packet;
+  // protected int _off;
+  // protected int _len;
+  // protected byte[] _data;
 
-    private int                       _id;
+  private int _id;
 
-    boolean                           _multicast;
+  boolean _multicast;
 
-    private int                       _flags;
+  private int _flags;
 
-    protected final List<DNSQuestion> _questions;
+  protected final List<DNSQuestion> _questions;
 
-    protected final List<DNSRecord>   _answers;
+  protected final List<DNSRecord> _answers;
 
-    protected final List<DNSRecord>   _authoritativeAnswers;
+  protected final List<DNSRecord> _authoritativeAnswers;
 
-    protected final List<DNSRecord>   _additionals;
+  protected final List<DNSRecord> _additionals;
 
-    /**
-     * @param flags
-     * @param id
-     * @param multicast
-     */
-    protected DNSMessage(int flags, int id, boolean multicast) {
-        super();
-        _flags = flags;
-        _id = id;
-        _multicast = multicast;
-        _questions = Collections.synchronizedList(new LinkedList<DNSQuestion>());
-        _answers = Collections.synchronizedList(new LinkedList<DNSRecord>());
-        _authoritativeAnswers = Collections.synchronizedList(new LinkedList<DNSRecord>());
-        _additionals = Collections.synchronizedList(new LinkedList<DNSRecord>());
+  /**
+   * @param flags
+   * @param id
+   * @param multicast
+   */
+  protected DNSMessage(int flags, int id, boolean multicast) {
+    super();
+    _flags = flags;
+    _id = id;
+    _multicast = multicast;
+    _questions = Collections.synchronizedList(new LinkedList<DNSQuestion>());
+    _answers = Collections.synchronizedList(new LinkedList<DNSRecord>());
+    _authoritativeAnswers = Collections.synchronizedList(new LinkedList<DNSRecord>());
+    _additionals = Collections.synchronizedList(new LinkedList<DNSRecord>());
+  }
+
+  // public DatagramPacket getPacket() {
+  // return _packet;
+  // }
+  //
+  // public int getOffset() {
+  // return _off;
+  // }
+  //
+  // public int getLength() {
+  // return _len;
+  // }
+  //
+  // public byte[] getData() {
+  // if ( _data == null ) _data = new byte[DNSConstants.MAX_MSG_TYPICAL];
+  // return _data;
+  // }
+
+  /**
+   * @return message id
+   */
+  public int getId() {
+    return (_multicast ? 0 : _id);
+  }
+
+  /**
+   * @param id the id to set
+   */
+  public void setId(int id) {
+    this._id = id;
+  }
+
+  /**
+   * @return message flags
+   */
+  public int getFlags() {
+    return _flags;
+  }
+
+  /**
+   * @param flags the flags to set
+   */
+  public void setFlags(int flags) {
+    this._flags = flags;
+  }
+
+  /**
+   * @return true if multicast
+   */
+  public boolean isMulticast() {
+    return _multicast;
+  }
+
+  /**
+   * @return list of questions
+   */
+  public Collection<? extends DNSQuestion> getQuestions() {
+    return _questions;
+  }
+
+  /**
+   * @return number of questions in the message
+   */
+  public int getNumberOfQuestions() {
+    return this.getQuestions().size();
+  }
+
+  public List<DNSRecord> getAllAnswers() {
+    List<DNSRecord> aList =
+        new ArrayList<DNSRecord>(
+            _answers.size() + _authoritativeAnswers.size() + _additionals.size());
+    aList.addAll(_answers);
+    aList.addAll(_authoritativeAnswers);
+    aList.addAll(_additionals);
+    return aList;
+  }
+
+  /**
+   * @return list of answers
+   */
+  public Collection<? extends DNSRecord> getAnswers() {
+    return _answers;
+  }
+
+  /**
+   * @return number of answers in the message
+   */
+  public int getNumberOfAnswers() {
+    return this.getAnswers().size();
+  }
+
+  /**
+   * @return list of authorities
+   */
+  public Collection<? extends DNSRecord> getAuthorities() {
+    return _authoritativeAnswers;
+  }
+
+  /**
+   * @return number of authorities in the message
+   */
+  public int getNumberOfAuthorities() {
+    return this.getAuthorities().size();
+  }
+
+  /**
+   * @return list of additional answers
+   */
+  public Collection<? extends DNSRecord> getAdditionals() {
+    return _additionals;
+  }
+
+  /**
+   * @return number of additional in the message
+   */
+  public int getNumberOfAdditionals() {
+    return this.getAdditionals().size();
+  }
+
+  /**
+   * Check is the response code is valid<br>
+   * The only valid value is zero all other values signify an error and the message must be ignored.
+   *
+   * @return true if the message has a valid response code.
+   */
+  public boolean isValidResponseCode() {
+    return (_flags & DNSConstants.FLAGS_RCODE) == 0;
+  }
+
+  /**
+   * Returns the operation code value. Currently only standard query 0 is valid.
+   *
+   * @return The operation code value.
+   */
+  public int getOperationCode() {
+    return (_flags & DNSConstants.FLAGS_OPCODE) >> 11;
+  }
+
+  /**
+   * Check if the message is truncated.
+   *
+   * @return true if the message was truncated
+   */
+  public boolean isTruncated() {
+    return (_flags & DNSConstants.FLAGS_TC) != 0;
+  }
+
+  /**
+   * Check if the message is an authoritative answer.
+   *
+   * @return true if the message is an authoritative answer
+   */
+  public boolean isAuthoritativeAnswer() {
+    return (_flags & DNSConstants.FLAGS_AA) != 0;
+  }
+
+  /**
+   * Check if the message is a query.
+   *
+   * @return true is the message is a query
+   */
+  public boolean isQuery() {
+    return (_flags & DNSConstants.FLAGS_QR_MASK) == DNSConstants.FLAGS_QR_QUERY;
+  }
+
+  /**
+   * Check if the message is a response.
+   *
+   * @return true is the message is a response
+   */
+  public boolean isResponse() {
+    return (_flags & DNSConstants.FLAGS_QR_MASK) == DNSConstants.FLAGS_QR_RESPONSE;
+  }
+
+  /**
+   * Check if the message is empty
+   *
+   * @return true is the message is empty
+   */
+  public boolean isEmpty() {
+    return (this.getNumberOfQuestions()
+            + this.getNumberOfAnswers()
+            + this.getNumberOfAuthorities()
+            + this.getNumberOfAdditionals())
+        == 0;
+  }
+
+  /** Debugging. */
+  String print() {
+    final StringBuilder sb = new StringBuilder(200);
+    sb.append(this.toString());
+    sb.append("\n");
+    for (final DNSQuestion question : _questions) {
+      sb.append("\tquestion:      ");
+      sb.append(question);
+      sb.append("\n");
     }
-
-    // public DatagramPacket getPacket() {
-    // return _packet;
-    // }
-    //
-    // public int getOffset() {
-    // return _off;
-    // }
-    //
-    // public int getLength() {
-    // return _len;
-    // }
-    //
-    // public byte[] getData() {
-    // if ( _data == null ) _data = new byte[DNSConstants.MAX_MSG_TYPICAL];
-    // return _data;
-    // }
-
-    /**
-     * @return message id
-     */
-    public int getId() {
-        return (_multicast ? 0 : _id);
+    for (final DNSRecord answer : _answers) {
+      sb.append("\tanswer:        ");
+      sb.append(answer);
+      sb.append("\n");
     }
-
-    /**
-     * @param id
-     *            the id to set
-     */
-    public void setId(int id) {
-        this._id = id;
+    for (final DNSRecord answer : _authoritativeAnswers) {
+      sb.append("\tauthoritative: ");
+      sb.append(answer);
+      sb.append("\n");
     }
-
-    /**
-     * @return message flags
-     */
-    public int getFlags() {
-        return _flags;
+    for (DNSRecord answer : _additionals) {
+      sb.append("\tadditional:    ");
+      sb.append(answer);
+      sb.append("\n");
     }
+    return sb.toString();
+  }
 
-    /**
-     * @param flags
-     *            the flags to set
-     */
-    public void setFlags(int flags) {
-        this._flags = flags;
-    }
-
-    /**
-     * @return true if multicast
-     */
-    public boolean isMulticast() {
-        return _multicast;
-    }
-
-    /**
-     * @return list of questions
-     */
-    public Collection<? extends DNSQuestion> getQuestions() {
-        return _questions;
-    }
-
-    /**
-     * @return number of questions in the message
-     */
-    public int getNumberOfQuestions() {
-        return this.getQuestions().size();
-    }
-
-    public List<DNSRecord> getAllAnswers() {
-        List<DNSRecord> aList = new ArrayList<DNSRecord>(_answers.size() + _authoritativeAnswers.size() + _additionals.size());
-        aList.addAll(_answers);
-        aList.addAll(_authoritativeAnswers);
-        aList.addAll(_additionals);
-        return aList;
-    }
-
-    /**
-     * @return list of answers
-     */
-    public Collection<? extends DNSRecord> getAnswers() {
-        return _answers;
-    }
-
-    /**
-     * @return number of answers in the message
-     */
-    public int getNumberOfAnswers() {
-        return this.getAnswers().size();
-    }
-
-    /**
-     * @return list of authorities
-     */
-    public Collection<? extends DNSRecord> getAuthorities() {
-        return _authoritativeAnswers;
-    }
-
-    /**
-     * @return number of authorities in the message
-     */
-    public int getNumberOfAuthorities() {
-        return this.getAuthorities().size();
-    }
-
-    /**
-     * @return list of additional answers
-     */
-    public Collection<? extends DNSRecord> getAdditionals() {
-        return _additionals;
-    }
-
-    /**
-     * @return number of additional in the message
-     */
-    public int getNumberOfAdditionals() {
-        return this.getAdditionals().size();
-    }
-
-    /**
-     * Check is the response code is valid<br/>
-     * The only valid value is zero all other values signify an error and the message must be ignored.
-     *
-     * @return true if the message has a valid response code.
-     */
-    public boolean isValidResponseCode() {
-        return (_flags & DNSConstants.FLAGS_RCODE) == 0;
-    }
-
-    /**
-     * Returns the operation code value. Currently only standard query 0 is valid.
-     *
-     * @return The operation code value.
-     */
-    public int getOperationCode() {
-        return (_flags & DNSConstants.FLAGS_OPCODE) >> 11;
-    }
-
-    /**
-     * Check if the message is truncated.
-     *
-     * @return true if the message was truncated
-     */
-    public boolean isTruncated() {
-        return (_flags & DNSConstants.FLAGS_TC) != 0;
-    }
-
-    /**
-     * Check if the message is an authoritative answer.
-     *
-     * @return true if the message is an authoritative answer
-     */
-    public boolean isAuthoritativeAnswer() {
-        return (_flags & DNSConstants.FLAGS_AA) != 0;
-    }
-
-    /**
-     * Check if the message is a query.
-     *
-     * @return true is the message is a query
-     */
-    public boolean isQuery() {
-        return (_flags & DNSConstants.FLAGS_QR_MASK) == DNSConstants.FLAGS_QR_QUERY;
-    }
-
-    /**
-     * Check if the message is a response.
-     *
-     * @return true is the message is a response
-     */
-    public boolean isResponse() {
-        return (_flags & DNSConstants.FLAGS_QR_MASK) == DNSConstants.FLAGS_QR_RESPONSE;
-    }
-
-    /**
-     * Check if the message is empty
-     *
-     * @return true is the message is empty
-     */
-    public boolean isEmpty() {
-        return (this.getNumberOfQuestions() + this.getNumberOfAnswers() + this.getNumberOfAuthorities() + this.getNumberOfAdditionals()) == 0;
-    }
-
-    /**
-     * Debugging.
-     */
-    String print() {
-        final StringBuilder sb = new StringBuilder(200);
-        sb.append(this.toString());
-        sb.append("\n");
-        for (final DNSQuestion question : _questions) {
-            sb.append("\tquestion:      ");
-            sb.append(question);
-            sb.append("\n");
+  /**
+   * Debugging.
+   *
+   * @param data
+   * @return data dump
+   */
+  protected String print(byte[] data) {
+    final StringBuilder sb = new StringBuilder(4000);
+    for (int off = 0, len = data.length; off < len; off += 32) {
+      int n = Math.min(32, len - off);
+      if (off < 0x10) {
+        sb.append(' ');
+      }
+      if (off < 0x100) {
+        sb.append(' ');
+      }
+      if (off < 0x1000) {
+        sb.append(' ');
+      }
+      sb.append(Integer.toHexString(off));
+      sb.append(':');
+      int index = 0;
+      for (index = 0; index < n; index++) {
+        if ((index % 8) == 0) {
+          sb.append(' ');
         }
-        for (final DNSRecord answer : _answers) {
-            sb.append("\tanswer:        ");
-            sb.append(answer);
-            sb.append("\n");
+        sb.append(Integer.toHexString((data[off + index] & 0xF0) >> 4));
+        sb.append(Integer.toHexString((data[off + index] & 0x0F) >> 0));
+      }
+      // for incomplete lines
+      if (index < 32) {
+        for (int i = index; i < 32; i++) {
+          if ((i % 8) == 0) {
+            sb.append(' ');
+          }
+          sb.append("  ");
         }
-        for (final DNSRecord answer : _authoritativeAnswers) {
-            sb.append("\tauthoritative: ");
-            sb.append(answer);
-            sb.append("\n");
+      }
+      sb.append("    ");
+      for (index = 0; index < n; index++) {
+        if ((index % 8) == 0) {
+          sb.append(' ');
         }
-        for (DNSRecord answer : _additionals) {
-            sb.append("\tadditional:    ");
-            sb.append(answer);
-            sb.append("\n");
-        }
-        return sb.toString();
+        int ch = data[off + index] & 0xFF;
+        sb.append(((ch > ' ') && (ch < 127)) ? (char) ch : '.');
+      }
+      sb.append("\n");
+
+      // limit message size
+      if (off + 32 >= 2048) {
+        sb.append("....\n");
+        break;
+      }
     }
-
-    /**
-     * Debugging.
-     *
-     * @param data
-     * @return data dump
-     */
-    protected String print(byte[] data) {
-        final StringBuilder sb = new StringBuilder(4000);
-        for (int off = 0, len = data.length; off < len; off += 32) {
-            int n = Math.min(32, len - off);
-            if (off < 0x10) {
-                sb.append(' ');
-            }
-            if (off < 0x100) {
-                sb.append(' ');
-            }
-            if (off < 0x1000) {
-                sb.append(' ');
-            }
-            sb.append(Integer.toHexString(off));
-            sb.append(':');
-            int index = 0;
-            for (index = 0; index < n; index++) {
-                if ((index % 8) == 0) {
-                    sb.append(' ');
-                }
-                sb.append(Integer.toHexString((data[off + index] & 0xF0) >> 4));
-                sb.append(Integer.toHexString((data[off + index] & 0x0F) >> 0));
-            }
-            // for incomplete lines
-            if (index < 32) {
-                for (int i = index; i < 32; i++) {
-                    if ((i % 8) == 0) {
-                        sb.append(' ');
-                    }
-                    sb.append("  ");
-                }
-            }
-            sb.append("    ");
-            for (index = 0; index < n; index++) {
-                if ((index % 8) == 0) {
-                    sb.append(' ');
-                }
-                int ch = data[off + index] & 0xFF;
-                sb.append(((ch > ' ') && (ch < 127)) ? (char) ch : '.');
-            }
-            sb.append("\n");
-
-            // limit message size
-            if (off + 32 >= 2048) {
-                sb.append("....\n");
-                break;
-            }
-        }
-        return sb.toString();
-    }
-
+    return sb.toString();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSQuestion.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSQuestion.java
@@ -4,15 +4,13 @@
 
 package io.libp2p.discovery.mdns.impl;
 
-import java.util.Set;
-
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
-import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.libp2p.discovery.mdns.ServiceInfo;
 import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
+import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A DNS question.
@@ -20,71 +18,75 @@ import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
  * @author Arthur van Hoff, Pierre Frisch
  */
 public class DNSQuestion extends DNSEntry {
-    private static Logger logger = LoggerFactory.getLogger(DNSQuestion.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(DNSQuestion.class.getName());
 
-    /**
-     * Pointer question.
-     */
-    private static class Pointer extends DNSQuestion {
-        Pointer(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
-            super(name, type, recordClass, unique);
-        }
-
-        @Override
-        public void addAnswers(JmDNSImpl jmDNSImpl, Set<DNSRecord> answers) {
-            // find matching services
-            for (ServiceInfo serviceInfo : jmDNSImpl.getServices().values()) {
-                this.addAnswersForServiceInfo(jmDNSImpl, answers, (ServiceInfoImpl) serviceInfo);
-            }
-        }
-    }
-
-    DNSQuestion(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
-        super(name, type, recordClass, unique);
-    }
-
-    /**
-     * Create a question.
-     *
-     * @param name
-     *            DNS name to be resolved
-     * @param type
-     *            Record type to resolve
-     * @param recordClass
-     *            Record class to resolve
-     * @param unique
-     *            Request unicast response (Currently not supported in this implementation)
-     * @return new question
-     */
-    public static DNSQuestion newQuestion(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
-        return (type == DNSRecordType.TYPE_PTR)
-                ? new Pointer(name, type, recordClass, unique)
-                : null;
-    }
-
-    /**
-     * Adds answers to the list for our question.
-     *
-     * @param jmDNSImpl
-     *            DNS holding the records
-     * @param answers
-     *            List of previous answer to append.
-     */
-    public void addAnswers(JmDNSImpl jmDNSImpl, Set<DNSRecord> answers) {
-        // By default we do nothing
-    }
-
-    protected void addAnswersForServiceInfo(JmDNSImpl jmDNSImpl, Set<DNSRecord> answers, ServiceInfoImpl info) {
-        if (info != null) {
-            if (this.getName().equalsIgnoreCase(info.getQualifiedName()) || this.getName().equalsIgnoreCase(info.getType()) || this.getName().equalsIgnoreCase(info.getTypeWithSubtype())) {
-                answers.addAll(info.answers(this.getRecordClass(), DNSRecordClass.UNIQUE, DNSConstants.DNS_TTL, jmDNSImpl.getLocalHost()));
-            }
-            logger.debug("{} DNSQuestion({}).addAnswersForServiceInfo(): info: {}\n{}", jmDNSImpl.getName(), this.getName(), info, answers);
-        }
+  /** Pointer question. */
+  private static class Pointer extends DNSQuestion {
+    Pointer(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
+      super(name, type, recordClass, unique);
     }
 
     @Override
-    public boolean isExpired(long now) {
-        return false;
+    public void addAnswers(JmDNSImpl jmDNSImpl, Set<DNSRecord> answers) {
+      // find matching services
+      for (ServiceInfo serviceInfo : jmDNSImpl.getServices().values()) {
+        this.addAnswersForServiceInfo(jmDNSImpl, answers, (ServiceInfoImpl) serviceInfo);
+      }
     }
+  }
+
+  DNSQuestion(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
+    super(name, type, recordClass, unique);
+  }
+
+  /**
+   * Create a question.
+   *
+   * @param name DNS name to be resolved
+   * @param type Record type to resolve
+   * @param recordClass Record class to resolve
+   * @param unique Request unicast response (Currently not supported in this implementation)
+   * @return new question
+   */
+  public static DNSQuestion newQuestion(
+      String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique) {
+    return (type == DNSRecordType.TYPE_PTR) ? new Pointer(name, type, recordClass, unique) : null;
+  }
+
+  /**
+   * Adds answers to the list for our question.
+   *
+   * @param jmDNSImpl DNS holding the records
+   * @param answers List of previous answer to append.
+   */
+  public void addAnswers(JmDNSImpl jmDNSImpl, Set<DNSRecord> answers) {
+    // By default we do nothing
+  }
+
+  protected void addAnswersForServiceInfo(
+      JmDNSImpl jmDNSImpl, Set<DNSRecord> answers, ServiceInfoImpl info) {
+    if (info != null) {
+      if (this.getName().equalsIgnoreCase(info.getQualifiedName())
+          || this.getName().equalsIgnoreCase(info.getType())
+          || this.getName().equalsIgnoreCase(info.getTypeWithSubtype())) {
+        answers.addAll(
+            info.answers(
+                this.getRecordClass(),
+                DNSRecordClass.UNIQUE,
+                DNSConstants.DNS_TTL,
+                jmDNSImpl.getLocalHost()));
+      }
+      logger.debug(
+          "{} DNSQuestion({}).addAnswersForServiceInfo(): info: {}\n{}",
+          jmDNSImpl.getName(),
+          this.getName(),
+          info,
+          answers);
+    }
+  }
+
+  @Override
+  public boolean isExpired(long now) {
+    return false;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSRecord.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/DNSRecord.java
@@ -8,9 +8,6 @@ import io.libp2p.discovery.mdns.impl.DNSOutgoing.MessageOutputStream;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
 import io.libp2p.discovery.mdns.impl.util.ByteWrangler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -18,7 +15,8 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * DNS record
@@ -26,358 +24,378 @@ import java.util.Objects;
  * @author Arthur van Hoff, Rick Blair, Werner Randelshofer, Pierre Frisch
  */
 public abstract class DNSRecord extends DNSEntry {
-    private static Logger logger = LoggerFactory.getLogger(DNSRecord.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(DNSRecord.class.getName());
 
-    private int           _ttl;
-    private long          _created;
+  private int _ttl;
+  private long _created;
 
-    /**
-     * Create a DNSRecord with a name, type, class, and ttl.
-     */
-    DNSRecord(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique, int ttl) {
-        super(name, type, recordClass, unique);
-        this._ttl = ttl;
-        this._created = System.currentTimeMillis();
+  /** Create a DNSRecord with a name, type, class, and ttl. */
+  DNSRecord(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique, int ttl) {
+    super(name, type, recordClass, unique);
+    this._ttl = ttl;
+    this._created = System.currentTimeMillis();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return (other instanceof DNSRecord) && super.equals(other) && sameValue((DNSRecord) other);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), _ttl, _created);
+  }
+
+  abstract boolean sameValue(DNSRecord other);
+
+  /** Get the expiration time of this record. */
+  long getExpirationTime(int percent) {
+    // ttl is in seconds the constant 10 is 1000 ms / 100 %
+    return _created + (percent * ((long) _ttl) * 10L);
+  }
+
+  /** Get the remaining TTL for this record. */
+  int getRemainingTTL(long now) {
+    return (int) Math.max(0, (getExpirationTime(100) - now) / 1000);
+  }
+
+  @Override
+  public boolean isExpired(long now) {
+    return getExpirationTime(100) <= now;
+  }
+
+  abstract void write(MessageOutputStream out);
+
+  public static class IPv4Address extends Address {
+    IPv4Address(
+        String name, DNSRecordClass recordClass, boolean unique, int ttl, InetAddress addr) {
+      super(name, DNSRecordType.TYPE_A, recordClass, unique, ttl, addr);
+    }
+
+    IPv4Address(
+        String name, DNSRecordClass recordClass, boolean unique, int ttl, byte[] rawAddress) {
+      super(name, DNSRecordType.TYPE_A, recordClass, unique, ttl, rawAddress);
     }
 
     @Override
-    public boolean equals(Object other) {
-        return (other instanceof DNSRecord) && super.equals(other) && sameValue((DNSRecord) other);
+    void write(MessageOutputStream out) {
+      if (_addr != null) {
+        byte[] buffer = _addr.getAddress();
+        // If we have a type A records we should answer with a IPv4 address
+        if (_addr instanceof Inet4Address) {
+          // All is good
+        } else {
+          // Get the last four bytes
+          byte[] tempbuffer = buffer;
+          buffer = new byte[4];
+          System.arraycopy(tempbuffer, 12, buffer, 0, 4);
+        }
+        int length = buffer.length;
+        out.writeBytes(buffer, 0, length);
+      }
+    }
+  }
+
+  public static class IPv6Address extends Address {
+    IPv6Address(
+        String name, DNSRecordClass recordClass, boolean unique, int ttl, InetAddress addr) {
+      super(name, DNSRecordType.TYPE_AAAA, recordClass, unique, ttl, addr);
+    }
+
+    IPv6Address(
+        String name, DNSRecordClass recordClass, boolean unique, int ttl, byte[] rawAddress) {
+      super(name, DNSRecordType.TYPE_AAAA, recordClass, unique, ttl, rawAddress);
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), _ttl, _created);
-    }
-
-    abstract boolean sameValue(DNSRecord other);
-
-    /**
-     * Get the expiration time of this record.
-     */
-    long getExpirationTime(int percent) {
-        // ttl is in seconds the constant 10 is 1000 ms / 100 %
-        return _created + (percent * ((long)_ttl) * 10L);
-    }
-
-    /**
-     * Get the remaining TTL for this record.
-     */
-    int getRemainingTTL(long now) {
-        return (int) Math.max(0, (getExpirationTime(100) - now) / 1000);
-    }
-
-    @Override
-    public boolean isExpired(long now) {
-        return getExpirationTime(100) <= now;
-    }
-
-    abstract void write(MessageOutputStream out);
-
-    public static class IPv4Address extends Address {
-        IPv4Address(String name, DNSRecordClass recordClass, boolean unique, int ttl, InetAddress addr) {
-            super(name, DNSRecordType.TYPE_A, recordClass, unique, ttl, addr);
-        }
-
-        IPv4Address(String name, DNSRecordClass recordClass, boolean unique, int ttl, byte[] rawAddress) {
-            super(name, DNSRecordType.TYPE_A, recordClass, unique, ttl, rawAddress);
-        }
-
-        @Override
-        void write(MessageOutputStream out) {
-            if (_addr != null) {
-                byte[] buffer = _addr.getAddress();
-                // If we have a type A records we should answer with a IPv4 address
-                if (_addr instanceof Inet4Address) {
-                    // All is good
-                } else {
-                    // Get the last four bytes
-                    byte[] tempbuffer = buffer;
-                    buffer = new byte[4];
-                    System.arraycopy(tempbuffer, 12, buffer, 0, 4);
-                }
-                int length = buffer.length;
-                out.writeBytes(buffer, 0, length);
-            }
-        }
-    }
-
-    public static class IPv6Address extends Address {
-        IPv6Address(String name, DNSRecordClass recordClass, boolean unique, int ttl, InetAddress addr) {
-            super(name, DNSRecordType.TYPE_AAAA, recordClass, unique, ttl, addr);
-        }
-
-        IPv6Address(String name, DNSRecordClass recordClass, boolean unique, int ttl, byte[] rawAddress) {
-            super(name, DNSRecordType.TYPE_AAAA, recordClass, unique, ttl, rawAddress);
-        }
-
-        @Override
-        void write(MessageOutputStream out) {
-            if (_addr != null) {
-                byte[] buffer = _addr.getAddress();
-                // If we have a type AAAA records we should answer with a IPv6 address
-                if (_addr instanceof Inet4Address) {
-                    byte[] tempbuffer = buffer;
-                    buffer = new byte[16];
-                    for (int i = 0; i < 16; i++) {
-                        if (i < 11) {
-                            buffer[i] = tempbuffer[i - 12];
-                        } else {
-                            buffer[i] = 0;
-                        }
-                    }
-                }
-                int length = buffer.length;
-                out.writeBytes(buffer, 0, length);
-            }
-        }
-    }
-
-    /**
-     * Address record.
-     */
-    public static abstract class Address extends DNSRecord {
-        InetAddress           _addr;
-
-        protected Address(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique, int ttl, InetAddress addr) {
-            super(name, type, recordClass, unique, ttl);
-            this._addr = addr;
-        }
-
-        protected Address(String name, DNSRecordType type, DNSRecordClass recordClass, boolean unique, int ttl, byte[] rawAddress) {
-            super(name, type, recordClass, unique, ttl);
-            try {
-                this._addr = InetAddress.getByAddress(rawAddress);
-            } catch (UnknownHostException exception) {
-                logger.warn("Address() exception ", exception);
-            }
-        }
-
-        @Override
-        boolean sameValue(DNSRecord other) {
-            try {
-                if (!(other instanceof Address)) {
-                    return false;
-                }
-                Address address = (Address) other;
-                if ((this.getAddress() == null) && (address.getAddress() != null)) {
-                    return false;
-                }
-                return this.getAddress().equals(address.getAddress());
-            } catch (Exception e) {
-                logger.info("Failed to compare addresses of DNSRecords", e);
-                return false;
-            }
-        }
-
-        public InetAddress getAddress() {
-            return _addr;
-        }
-
-        /**
-         * Creates a byte array representation of this record. This is needed for tie-break tests according to draft-cheshire-dnsext-multicastdns-04.txt chapter 9.2.
-         */
-        @Override
-        protected void toByteArray(DataOutputStream dout) throws IOException {
-            super.toByteArray(dout);
-            byte[] buffer = this.getAddress().getAddress();
-            for (int i = 0; i < buffer.length; i++) {
-                dout.writeByte(buffer[i]);
-            }
-        }
-    }
-
-    /**
-     * Pointer record.
-     */
-    public static class Pointer extends DNSRecord {
-        private final String _alias;
-
-        public Pointer(String name, DNSRecordClass recordClass, boolean unique, int ttl, String alias) {
-            super(name, DNSRecordType.TYPE_PTR, recordClass, unique, ttl);
-            this._alias = alias;
-        }
-
-        @Override
-        public boolean isSameEntry(DNSEntry entry) {
-            return super.isSameEntry(entry) && (entry instanceof Pointer) && this.sameValue((Pointer) entry);
-        }
-
-        @Override
-        void write(MessageOutputStream out) {
-            out.writeName(_alias);
-        }
-
-        @Override
-        boolean sameValue(DNSRecord other) {
-            if (!(other instanceof Pointer)) {
-                return false;
-            }
-            Pointer pointer = (Pointer) other;
-            if ((_alias == null) && (pointer._alias != null)) {
-                return false;
-            }
-            return _alias.equals(pointer._alias);
-        }
-    }
-
-    public static class Text extends DNSRecord {
-        private final byte[] _text;
-
-        public Text(String name, DNSRecordClass recordClass, boolean unique, int ttl, byte text[]) {
-            super(name, DNSRecordType.TYPE_TXT, recordClass, unique, ttl);
-            this._text = (text != null && text.length > 0 ? text : ByteWrangler.EMPTY_TXT);
-        }
-
-        /**
-         * @return the text
-         */
-        public byte[] getText() {
-            return this._text;
-        }
-
-        @Override
-        void write(MessageOutputStream out) {
-            out.writeBytes(_text, 0, _text.length);
-        }
-
-        @Override
-        boolean sameValue(DNSRecord other) {
-            if (!(other instanceof Text)) {
-                return false;
-            }
-            Text txt = (Text) other;
-            if ((_text == null) && (txt._text != null)) {
-                return false;
-            }
-            if (txt._text.length != _text.length) {
-                return false;
-            }
-            for (int i = _text.length; i-- > 0;) {
-                if (txt._text[i] != _text[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
-    }
-
-    /**
-     * Service record.
-     */
-    public static class Service extends DNSRecord {
-        private final int     _priority;
-        private final int     _weight;
-        private final int     _port;
-        private final String  _server;
-
-        public Service(String name, DNSRecordClass recordClass, boolean unique, int ttl, int priority, int weight, int port, String server) {
-            super(name, DNSRecordType.TYPE_SRV, recordClass, unique, ttl);
-            this._priority = priority;
-            this._weight = weight;
-            this._port = port;
-            this._server = server;
-        }
-
-        @Override
-        void write(MessageOutputStream out) {
-            out.writeShort(_priority);
-            out.writeShort(_weight);
-            out.writeShort(_port);
-            if (DNSIncoming.USE_DOMAIN_NAME_FORMAT_FOR_SRV_TARGET) {
-                out.writeName(_server);
+    void write(MessageOutputStream out) {
+      if (_addr != null) {
+        byte[] buffer = _addr.getAddress();
+        // If we have a type AAAA records we should answer with a IPv6 address
+        if (_addr instanceof Inet4Address) {
+          byte[] tempbuffer = buffer;
+          buffer = new byte[16];
+          for (int i = 0; i < 16; i++) {
+            if (i < 11) {
+              buffer[i] = tempbuffer[i - 12];
             } else {
-                // [PJYF Nov 13 2010] Do we still need this? This looks really bad. All label are supposed to start by a length.
-                out.writeUTF(_server, 0, _server.length());
-
-                // add a zero byte to the end just to be safe, this is the strange form
-                // used by the BonjourConformanceTest
-                out.writeByte(0);
+              buffer[i] = 0;
             }
+          }
         }
+        int length = buffer.length;
+        out.writeBytes(buffer, 0, length);
+      }
+    }
+  }
 
-        @Override
-        protected void toByteArray(DataOutputStream dout) throws IOException {
-            super.toByteArray(dout);
-            dout.writeShort(_priority);
-            dout.writeShort(_weight);
-            dout.writeShort(_port);
-            try {
-                dout.write(_server.getBytes("UTF-8"));
-            } catch (UnsupportedEncodingException exception) {
-                /* UTF-8 is always present */
-            }
-        }
+  /** Address record. */
+  public abstract static class Address extends DNSRecord {
+    InetAddress _addr;
 
-        /**
-         * @return the weight
-         */
-        public int getWeight() {
-            return this._weight;
-        }
-
-        /**
-         * @return the port
-         */
-        public int getPort() {
-            return this._port;
-        }
-
-        @Override
-        boolean sameValue(DNSRecord other) {
-            if (!(other instanceof Service)) {
-                return false;
-            }
-            Service s = (Service) other;
-            return (_priority == s._priority) && (_weight == s._weight) && (_port == s._port) && _server.equals(s._server);
-        }
+    protected Address(
+        String name,
+        DNSRecordType type,
+        DNSRecordClass recordClass,
+        boolean unique,
+        int ttl,
+        InetAddress addr) {
+      super(name, type, recordClass, unique, ttl);
+      this._addr = addr;
     }
 
-    public static class HostInformation extends DNSRecord {
-        String _os;
-        String _cpu;
-
-        /**
-         * @param name
-         * @param recordClass
-         * @param unique
-         * @param ttl
-         * @param cpu
-         * @param os
-         */
-        public HostInformation(String name, DNSRecordClass recordClass, boolean unique, int ttl, String cpu, String os) {
-            super(name, DNSRecordType.TYPE_HINFO, recordClass, unique, ttl);
-            _cpu = cpu;
-            _os = os;
-        }
-
-        /*
-         * (non-Javadoc)
-         * @see javax.jmdns.impl.DNSRecord#sameValue(javax.jmdns.impl.DNSRecord)
-         */
-        @Override
-        boolean sameValue(DNSRecord other) {
-            if (!(other instanceof HostInformation)) {
-                return false;
-            }
-            HostInformation hinfo = (HostInformation) other;
-            if ((_cpu == null) && (hinfo._cpu != null)) {
-                return false;
-            }
-            if ((_os == null) && (hinfo._os != null)) {
-                return false;
-            }
-            return _cpu.equals(hinfo._cpu) && _os.equals(hinfo._os);
-        }
-
-        @Override
-        void write(MessageOutputStream out) {
-            String hostInfo = _cpu + " " + _os;
-            out.writeUTF(hostInfo, 0, hostInfo.length());
-        }
+    protected Address(
+        String name,
+        DNSRecordType type,
+        DNSRecordClass recordClass,
+        boolean unique,
+        int ttl,
+        byte[] rawAddress) {
+      super(name, type, recordClass, unique, ttl);
+      try {
+        this._addr = InetAddress.getByAddress(rawAddress);
+      } catch (UnknownHostException exception) {
+        logger.warn("Address() exception ", exception);
+      }
     }
 
-    public int getTTL() {
-        return _ttl;
+    @Override
+    boolean sameValue(DNSRecord other) {
+      try {
+        if (!(other instanceof Address)) {
+          return false;
+        }
+        Address address = (Address) other;
+        if ((this.getAddress() == null) && (address.getAddress() != null)) {
+          return false;
+        }
+        return this.getAddress().equals(address.getAddress());
+      } catch (Exception e) {
+        logger.info("Failed to compare addresses of DNSRecords", e);
+        return false;
+      }
     }
+
+    public InetAddress getAddress() {
+      return _addr;
+    }
+
+    /**
+     * Creates a byte array representation of this record. This is needed for tie-break tests
+     * according to draft-cheshire-dnsext-multicastdns-04.txt chapter 9.2.
+     */
+    @Override
+    protected void toByteArray(DataOutputStream dout) throws IOException {
+      super.toByteArray(dout);
+      byte[] buffer = this.getAddress().getAddress();
+      for (int i = 0; i < buffer.length; i++) {
+        dout.writeByte(buffer[i]);
+      }
+    }
+  }
+
+  /** Pointer record. */
+  public static class Pointer extends DNSRecord {
+    private final String _alias;
+
+    public Pointer(String name, DNSRecordClass recordClass, boolean unique, int ttl, String alias) {
+      super(name, DNSRecordType.TYPE_PTR, recordClass, unique, ttl);
+      this._alias = alias;
+    }
+
+    @Override
+    public boolean isSameEntry(DNSEntry entry) {
+      return super.isSameEntry(entry)
+          && (entry instanceof Pointer)
+          && this.sameValue((Pointer) entry);
+    }
+
+    @Override
+    void write(MessageOutputStream out) {
+      out.writeName(_alias);
+    }
+
+    @Override
+    boolean sameValue(DNSRecord other) {
+      if (!(other instanceof Pointer)) {
+        return false;
+      }
+      Pointer pointer = (Pointer) other;
+      if ((_alias == null) && (pointer._alias != null)) {
+        return false;
+      }
+      return _alias.equals(pointer._alias);
+    }
+  }
+
+  public static class Text extends DNSRecord {
+    private final byte[] _text;
+
+    public Text(String name, DNSRecordClass recordClass, boolean unique, int ttl, byte text[]) {
+      super(name, DNSRecordType.TYPE_TXT, recordClass, unique, ttl);
+      this._text = (text != null && text.length > 0 ? text : ByteWrangler.EMPTY_TXT);
+    }
+
+    /**
+     * @return the text
+     */
+    public byte[] getText() {
+      return this._text;
+    }
+
+    @Override
+    void write(MessageOutputStream out) {
+      out.writeBytes(_text, 0, _text.length);
+    }
+
+    @Override
+    boolean sameValue(DNSRecord other) {
+      if (!(other instanceof Text)) {
+        return false;
+      }
+      Text txt = (Text) other;
+      if ((_text == null) && (txt._text != null)) {
+        return false;
+      }
+      if (txt._text.length != _text.length) {
+        return false;
+      }
+      for (int i = _text.length; i-- > 0; ) {
+        if (txt._text[i] != _text[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  /** Service record. */
+  public static class Service extends DNSRecord {
+    private final int _priority;
+    private final int _weight;
+    private final int _port;
+    private final String _server;
+
+    public Service(
+        String name,
+        DNSRecordClass recordClass,
+        boolean unique,
+        int ttl,
+        int priority,
+        int weight,
+        int port,
+        String server) {
+      super(name, DNSRecordType.TYPE_SRV, recordClass, unique, ttl);
+      this._priority = priority;
+      this._weight = weight;
+      this._port = port;
+      this._server = server;
+    }
+
+    @Override
+    void write(MessageOutputStream out) {
+      out.writeShort(_priority);
+      out.writeShort(_weight);
+      out.writeShort(_port);
+      if (DNSIncoming.USE_DOMAIN_NAME_FORMAT_FOR_SRV_TARGET) {
+        out.writeName(_server);
+      } else {
+        // [PJYF Nov 13 2010] Do we still need this? This looks really bad. All label are supposed
+        // to start by a length.
+        out.writeUTF(_server, 0, _server.length());
+
+        // add a zero byte to the end just to be safe, this is the strange form
+        // used by the BonjourConformanceTest
+        out.writeByte(0);
+      }
+    }
+
+    @Override
+    protected void toByteArray(DataOutputStream dout) throws IOException {
+      super.toByteArray(dout);
+      dout.writeShort(_priority);
+      dout.writeShort(_weight);
+      dout.writeShort(_port);
+      try {
+        dout.write(_server.getBytes("UTF-8"));
+      } catch (UnsupportedEncodingException exception) {
+        /* UTF-8 is always present */
+      }
+    }
+
+    /**
+     * @return the weight
+     */
+    public int getWeight() {
+      return this._weight;
+    }
+
+    /**
+     * @return the port
+     */
+    public int getPort() {
+      return this._port;
+    }
+
+    @Override
+    boolean sameValue(DNSRecord other) {
+      if (!(other instanceof Service)) {
+        return false;
+      }
+      Service s = (Service) other;
+      return (_priority == s._priority)
+          && (_weight == s._weight)
+          && (_port == s._port)
+          && _server.equals(s._server);
+    }
+  }
+
+  public static class HostInformation extends DNSRecord {
+    String _os;
+    String _cpu;
+
+    /**
+     * @param name
+     * @param recordClass
+     * @param unique
+     * @param ttl
+     * @param cpu
+     * @param os
+     */
+    public HostInformation(
+        String name, DNSRecordClass recordClass, boolean unique, int ttl, String cpu, String os) {
+      super(name, DNSRecordType.TYPE_HINFO, recordClass, unique, ttl);
+      _cpu = cpu;
+      _os = os;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see javax.jmdns.impl.DNSRecord#sameValue(javax.jmdns.impl.DNSRecord)
+     */
+    @Override
+    boolean sameValue(DNSRecord other) {
+      if (!(other instanceof HostInformation)) {
+        return false;
+      }
+      HostInformation hinfo = (HostInformation) other;
+      if ((_cpu == null) && (hinfo._cpu != null)) {
+        return false;
+      }
+      if ((_os == null) && (hinfo._os != null)) {
+        return false;
+      }
+      return _cpu.equals(hinfo._cpu) && _os.equals(hinfo._os);
+    }
+
+    @Override
+    void write(MessageOutputStream out) {
+      String hostInfo = _cpu + " " + _os;
+      out.writeUTF(hostInfo, 0, hostInfo.length());
+    }
+  }
+
+  public int getTTL() {
+    return _ttl;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/HostInfo.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/HostInfo.java
@@ -7,7 +7,6 @@ package io.libp2p.discovery.mdns.impl;
 import java.io.IOException;
 import java.net.*;
 import java.util.*;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,185 +16,192 @@ import org.slf4j.LoggerFactory;
  * @author Pierre Frisch, Werner Randelshofer
  */
 public class HostInfo {
-    private static Logger logger = LoggerFactory.getLogger(HostInfo.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(HostInfo.class.getName());
 
-    protected String            _name;
+  protected String _name;
 
-    protected InetAddress       _address;
+  protected InetAddress _address;
 
-    protected NetworkInterface  _interface;
+  protected NetworkInterface _interface;
 
-    /**
-     * @param address
-     *            IP address to bind
-     * @param dns
-     *            JmDNS instance
-     * @param jmdnsName
-     *            JmDNS name
-     * @return new HostInfo
-     */
-    public static HostInfo newHostInfo(InetAddress address, JmDNSImpl dns, String jmdnsName) {
-        HostInfo localhost = null;
-        String aName = (jmdnsName != null ? jmdnsName : "");
-        InetAddress addr = address;
-        try {
-            if (addr == null) {
-                String ip = System.getProperty("net.mdns.interface");
-                if (ip != null) {
-                    addr = InetAddress.getByName(ip);
-                } else {
-                    addr = InetAddress.getLocalHost();
-                    if (addr.isLoopbackAddress()) {
-                        // Find local address that isn't a loopback address
-                        InetAddress[] addresses = getInetAddresses();
-                        if (addresses.length > 0) {
-                            addr = addresses[0];
-                        }
-                    }
-                }
-                if (addr.isLoopbackAddress()) {
-                    logger.warn("Could not find any address beside the loopback.");
-                }
+  /**
+   * @param address IP address to bind
+   * @param dns JmDNS instance
+   * @param jmdnsName JmDNS name
+   * @return new HostInfo
+   */
+  public static HostInfo newHostInfo(InetAddress address, JmDNSImpl dns, String jmdnsName) {
+    HostInfo localhost = null;
+    String aName = (jmdnsName != null ? jmdnsName : "");
+    InetAddress addr = address;
+    try {
+      if (addr == null) {
+        String ip = System.getProperty("net.mdns.interface");
+        if (ip != null) {
+          addr = InetAddress.getByName(ip);
+        } else {
+          addr = InetAddress.getLocalHost();
+          if (addr.isLoopbackAddress()) {
+            // Find local address that isn't a loopback address
+            InetAddress[] addresses = getInetAddresses();
+            if (addresses.length > 0) {
+              addr = addresses[0];
             }
-            if (aName.length() == 0) {
-                aName = addr.getHostName();
-            }
-            if (aName.contains("in-addr.arpa") || (aName.equals(addr.getHostAddress()))) {
-                aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : addr.getHostAddress());
-            }
-        } catch (final IOException e) {
-            logger.warn("Could not initialize the host network interface on " + address + "because of an error: " + e.getMessage(), e);
-            // This is only used for running unit test on Debian / Ubuntu
-            addr = loopbackAddress();
-            aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : "computer");
+          }
         }
-        // A host name with "." is illegal. so strip off everything and append .local.
-        // We also need to be carefull that the .local may already be there
-        int index = aName.indexOf(".local");
-        if (index > 0) {
-            aName = aName.substring(0, index);
+        if (addr.isLoopbackAddress()) {
+          logger.warn("Could not find any address beside the loopback.");
         }
-        aName = aName.replaceAll("[:%\\.]", "-");
-        aName += ".local.";
-        localhost = new HostInfo(addr, aName, dns);
-        return localhost;
+      }
+      if (aName.length() == 0) {
+        aName = addr.getHostName();
+      }
+      if (aName.contains("in-addr.arpa") || (aName.equals(addr.getHostAddress()))) {
+        aName =
+            ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : addr.getHostAddress());
+      }
+    } catch (final IOException e) {
+      logger.warn(
+          "Could not initialize the host network interface on "
+              + address
+              + "because of an error: "
+              + e.getMessage(),
+          e);
+      // This is only used for running unit test on Debian / Ubuntu
+      addr = loopbackAddress();
+      aName = ((jmdnsName != null) && (jmdnsName.length() > 0) ? jmdnsName : "computer");
     }
+    // A host name with "." is illegal. so strip off everything and append .local.
+    // We also need to be carefull that the .local may already be there
+    int index = aName.indexOf(".local");
+    if (index > 0) {
+      aName = aName.substring(0, index);
+    }
+    aName = aName.replaceAll("[:%\\.]", "-");
+    aName += ".local.";
+    localhost = new HostInfo(addr, aName, dns);
+    return localhost;
+  }
 
-    private static InetAddress[] getInetAddresses() {
-        Set<InetAddress> result = new HashSet<InetAddress>();
-        try {
+  private static InetAddress[] getInetAddresses() {
+    Set<InetAddress> result = new HashSet<InetAddress>();
+    try {
 
-            for (Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces(); nifs.hasMoreElements();) {
-                NetworkInterface nif = nifs.nextElement();
-                if (useInterface(nif)) {
-                    for (Enumeration<InetAddress> iaenum = nif.getInetAddresses(); iaenum.hasMoreElements();) {
-                        InetAddress interfaceAddress = iaenum.nextElement();
-                        logger.trace("Found NetworkInterface/InetAddress: {} -- {}",  nif , interfaceAddress);
-                        result.add(interfaceAddress);
-                    }
-                }
-            }
-        } catch (SocketException se) {
-            logger.warn("Error while fetching network interfaces addresses: " + se);
+      for (Enumeration<NetworkInterface> nifs = NetworkInterface.getNetworkInterfaces();
+          nifs.hasMoreElements(); ) {
+        NetworkInterface nif = nifs.nextElement();
+        if (useInterface(nif)) {
+          for (Enumeration<InetAddress> iaenum = nif.getInetAddresses();
+              iaenum.hasMoreElements(); ) {
+            InetAddress interfaceAddress = iaenum.nextElement();
+            logger.trace("Found NetworkInterface/InetAddress: {} -- {}", nif, interfaceAddress);
+            result.add(interfaceAddress);
+          }
         }
-        return result.toArray(new InetAddress[result.size()]);
+      }
+    } catch (SocketException se) {
+      logger.warn("Error while fetching network interfaces addresses: " + se);
     }
+    return result.toArray(new InetAddress[result.size()]);
+  }
 
-    private static boolean useInterface(NetworkInterface networkInterface) {
-        try {
-            if (!networkInterface.isUp()) {
-                return false;
-            }
+  private static boolean useInterface(NetworkInterface networkInterface) {
+    try {
+      if (!networkInterface.isUp()) {
+        return false;
+      }
 
-            if (!networkInterface.supportsMulticast()) {
-                return false;
-            }
+      if (!networkInterface.supportsMulticast()) {
+        return false;
+      }
 
-            if (networkInterface.isLoopback()) {
-                return false;
-            }
+      if (networkInterface.isLoopback()) {
+        return false;
+      }
 
-            return true;
-        } catch (Exception exception) {
-            return false;
+      return true;
+    } catch (Exception exception) {
+      return false;
+    }
+  }
+
+  private static InetAddress loopbackAddress() {
+    try {
+      return InetAddress.getByName(null);
+    } catch (UnknownHostException exception) {
+      return null;
+    }
+  }
+
+  private HostInfo(final InetAddress address, final String name, final JmDNSImpl dns) {
+    super();
+    this._address = address;
+    this._name = name;
+    if (address != null) {
+      try {
+        _interface = NetworkInterface.getByInetAddress(address);
+      } catch (Exception exception) {
+        logger.warn("LocalHostInfo() exception ", exception);
+      }
+    }
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public InetAddress getInetAddress() {
+    return _address;
+  }
+
+  public NetworkInterface getInterface() {
+    return _interface;
+  }
+
+  boolean shouldIgnorePacket(DatagramPacket packet) {
+    boolean result = false;
+    if (this.getInetAddress() != null) {
+      InetAddress from = packet.getAddress();
+      if (from != null) {
+        if ((this.getInetAddress().isLinkLocalAddress() || this.getInetAddress().isMCLinkLocal())
+            && (!from.isLinkLocalAddress())) {
+          // A host sending Multicast DNS queries to a link-local destination
+          // address (including the 224.0.0.251 and FF02::FB link-local multicast
+          // addresses) MUST only accept responses to that query that originate
+          // from the local link, and silently discard any other response packets.
+          // Without this check, it could be possible for remote rogue hosts to
+          // send spoof answer packets (perhaps unicast to the victim host) which
+          // the receiving machine could misinterpret as having originated on the
+          // local link.
+          result = true;
         }
-    }
-
-    private static InetAddress loopbackAddress() {
-        try {
-            return InetAddress.getByName(null);
-        } catch (UnknownHostException exception) {
-            return null;
+        // if (from.isLinkLocalAddress() && (!this.getInetAddress().isLinkLocalAddress())) {
+        // // Ignore linklocal packets on regular interfaces, unless this is
+        // // also a linklocal interface. This is to avoid duplicates. This is
+        // // a terrible hack caused by the lack of an API to get the address
+        // // of the interface on which the packet was received.
+        // result = true;
+        // }
+        if (from.isLoopbackAddress() && (!this.getInetAddress().isLoopbackAddress())) {
+          // Ignore loopback packets on a regular interface unless this is also a loopback
+          // interface.
+          result = true;
         }
+      }
     }
+    return result;
+  }
 
-    private HostInfo(final InetAddress address, final String name, final JmDNSImpl dns) {
-        super();
-        this._address = address;
-        this._name = name;
-        if (address != null) {
-            try {
-                _interface = NetworkInterface.getByInetAddress(address);
-            } catch (Exception exception) {
-                logger.warn("LocalHostInfo() exception ", exception);
-            }
-        }
-    }
-
-    public String getName() {
-        return _name;
-    }
-
-    public InetAddress getInetAddress() {
-        return _address;
-    }
-
-    public NetworkInterface getInterface() {
-        return _interface;
-    }
-
-    boolean shouldIgnorePacket(DatagramPacket packet) {
-        boolean result = false;
-        if (this.getInetAddress() != null) {
-            InetAddress from = packet.getAddress();
-            if (from != null) {
-                if ((this.getInetAddress().isLinkLocalAddress() || this.getInetAddress().isMCLinkLocal()) && (!from.isLinkLocalAddress())) {
-                    // A host sending Multicast DNS queries to a link-local destination
-                    // address (including the 224.0.0.251 and FF02::FB link-local multicast
-                    // addresses) MUST only accept responses to that query that originate
-                    // from the local link, and silently discard any other response packets.
-                    // Without this check, it could be possible for remote rogue hosts to
-                    // send spoof answer packets (perhaps unicast to the victim host) which
-                    // the receiving machine could misinterpret as having originated on the
-                    // local link.
-                    result = true;
-                }
-                // if (from.isLinkLocalAddress() && (!this.getInetAddress().isLinkLocalAddress())) {
-                // // Ignore linklocal packets on regular interfaces, unless this is
-                // // also a linklocal interface. This is to avoid duplicates. This is
-                // // a terrible hack caused by the lack of an API to get the address
-                // // of the interface on which the packet was received.
-                // result = true;
-                // }
-                if (from.isLoopbackAddress() && (!this.getInetAddress().isLoopbackAddress())) {
-                    // Ignore loopback packets on a regular interface unless this is also a loopback interface.
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder(1024);
-        sb.append("local host info[");
-        sb.append(getName() != null ? getName() : "no name");
-        sb.append(", ");
-        sb.append(getInterface() != null ? getInterface().getDisplayName() : "???");
-        sb.append(":");
-        sb.append(getInetAddress() != null ? getInetAddress().getHostAddress() : "no address");
-        sb.append("]");
-        return sb.toString();
-    }
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(1024);
+    sb.append("local host info[");
+    sb.append(getName() != null ? getName() : "no name");
+    sb.append(", ");
+    sb.append(getInterface() != null ? getInterface().getDisplayName() : "???");
+    sb.append(":");
+    sb.append(getInetAddress() != null ? getInetAddress().getHostAddress() : "no address");
+    sb.append("]");
+    return sb.toString();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/JmDNSImpl.java
@@ -12,9 +12,6 @@ import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
 import io.libp2p.discovery.mdns.impl.tasks.Responder;
 import io.libp2p.discovery.mdns.impl.tasks.ServiceResolver;
 import io.libp2p.discovery.mdns.impl.util.NamedThreadFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.Inet6Address;
@@ -39,431 +36,426 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Derived from mDNS implementation in Java.
  *
- * @author Arthur van Hoff, Rick Blair, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Scott Lewis, Kai Kreuzer, Victor Toni
+ * @author Arthur van Hoff, Rick Blair, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Scott
+ *     Lewis, Kai Kreuzer, Victor Toni
  */
 public class JmDNSImpl extends JmDNS {
-    private static Logger logger = LoggerFactory.getLogger(JmDNSImpl.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(JmDNSImpl.class.getName());
 
-    /**
-     * This is the multicast group, we are listening to for multicast DNS messages.
-     */
-    private volatile InetAddress _group;
-    /**
-     * This is our multicast socket.
-     */
-    private volatile MulticastSocket _socket;
+  /** This is the multicast group, we are listening to for multicast DNS messages. */
+  private volatile InetAddress _group;
 
-    private final ConcurrentMap<String, List<AnswerListener>> _answerListeners;
-    private final ConcurrentMap<String, ServiceResolver> _serviceResolvers;
+  /** This is our multicast socket. */
+  private volatile MulticastSocket _socket;
 
-    /**
-     * This hashtable holds the services that have been registered. Keys are instances of String which hold an all lower-case version of the fully qualified service name. Values are instances of ServiceInfo.
-     */
-    private final ConcurrentMap<String, ServiceInfo> _services;
+  private final ConcurrentMap<String, List<AnswerListener>> _answerListeners;
+  private final ConcurrentMap<String, ServiceResolver> _serviceResolvers;
 
-    /**
-     * Handle on the local host
-     */
-    private HostInfo _localHost;
+  /**
+   * This hashtable holds the services that have been registered. Keys are instances of String which
+   * hold an all lower-case version of the fully qualified service name. Values are instances of
+   * ServiceInfo.
+   */
+  private final ConcurrentMap<String, ServiceInfo> _services;
 
-    private SocketListener _incomingListener;
+  /** Handle on the local host */
+  private HostInfo _localHost;
 
-    private final ExecutorService _executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("JmDNS"));
+  private SocketListener _incomingListener;
 
-    /**
-     * The source for random values. This is used to introduce random delays in responses. This reduces the potential for collisions on the network.
-     */
-    private final static Random _random = new Random();
+  private final ExecutorService _executor =
+      Executors.newSingleThreadExecutor(new NamedThreadFactory("JmDNS"));
 
-    /**
-     * This lock is used to coordinate processing of incoming and outgoing messages. This is needed, because the Rendezvous Conformance Test does not forgive race conditions.
-     */
-    private final ReentrantLock _ioLock = new ReentrantLock();
+  /**
+   * The source for random values. This is used to introduce random delays in responses. This
+   * reduces the potential for collisions on the network.
+   */
+  private static final Random _random = new Random();
 
-    private final String _name;
+  /**
+   * This lock is used to coordinate processing of incoming and outgoing messages. This is needed,
+   * because the Rendezvous Conformance Test does not forgive race conditions.
+   */
+  private final ReentrantLock _ioLock = new ReentrantLock();
 
-    /**
-     * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
-     *
-     * @param address IP address to bind to.
-     * @param name    name of the newly created JmDNS
-     * @throws IOException
-     */
-    public JmDNSImpl(InetAddress address, String name) {
-        super();
-        logger.debug("JmDNS instance created");
+  private final String _name;
 
-        _answerListeners = new ConcurrentHashMap<>();
-        _serviceResolvers = new ConcurrentHashMap<>();
+  /**
+   * Create an instance of JmDNS and bind it to a specific network interface given its IP-address.
+   *
+   * @param address IP address to bind to.
+   * @param name name of the newly created JmDNS
+   * @throws IOException
+   */
+  public JmDNSImpl(InetAddress address, String name) {
+    super();
+    logger.debug("JmDNS instance created");
 
-        _services = new ConcurrentHashMap<>(20);
+    _answerListeners = new ConcurrentHashMap<>();
+    _serviceResolvers = new ConcurrentHashMap<>();
 
-        _localHost = HostInfo.newHostInfo(address, this, name);
-        _name = (name != null ? name : _localHost.getName());
+    _services = new ConcurrentHashMap<>(20);
+
+    _localHost = HostInfo.newHostInfo(address, this, name);
+    _name = (name != null ? name : _localHost.getName());
+  }
+
+  public void start() throws IOException {
+    // Bind to multicast socket
+    this.openMulticastSocket(this.getLocalHost());
+    this.start(this.getServices().values());
+  }
+
+  private void start(Collection<? extends ServiceInfo> serviceInfos) {
+    if (_incomingListener == null) {
+      _incomingListener = new SocketListener(this);
+      _incomingListener.start();
+    }
+    for (ServiceInfo info : serviceInfos) {
+      try {
+        this.registerService(new ServiceInfoImpl(info));
+      } catch (final Exception exception) {
+        logger.warn("start() Registration exception ", exception);
+      }
+    }
+  }
+
+  private void openMulticastSocket(HostInfo hostInfo) throws IOException {
+    if (_group == null) {
+      if (hostInfo.getInetAddress() instanceof Inet6Address) {
+        _group = InetAddress.getByName(DNSConstants.MDNS_GROUP_IPV6);
+      } else {
+        _group = InetAddress.getByName(DNSConstants.MDNS_GROUP);
+      }
+    }
+    if (_socket != null) {
+      this.closeMulticastSocket();
+    }
+    // SocketAddress address = new InetSocketAddress((hostInfo != null ? hostInfo.getInetAddress() :
+    // null), DNSConstants.MDNS_PORT);
+    // System.out.println("Socket Address: " + address);
+    // try {
+    // _socket = new MulticastSocket(address);
+    // } catch (Exception exception) {
+    // logger.warn("openMulticastSocket() Open socket exception Address: " + address + ", ",
+    // exception);
+    // // The most likely cause is a duplicate address lets open without specifying the address
+    // _socket = new MulticastSocket(DNSConstants.MDNS_PORT);
+    // }
+    _socket = new MulticastSocket(DNSConstants.MDNS_PORT);
+    if ((hostInfo != null) && (hostInfo.getInterface() != null)) {
+      final SocketAddress multicastAddr = new InetSocketAddress(_group, DNSConstants.MDNS_PORT);
+      _socket.setNetworkInterface(hostInfo.getInterface());
+
+      logger.trace("Trying to joinGroup({}, {})", multicastAddr, hostInfo.getInterface());
+
+      // this joinGroup() might be less surprisingly so this is the default
+      _socket.joinGroup(multicastAddr, hostInfo.getInterface());
+    } else {
+      logger.trace("Trying to joinGroup({})", _group);
+      _socket.joinGroup(_group);
     }
 
-    public void start() throws IOException {
-        // Bind to multicast socket
-        this.openMulticastSocket(this.getLocalHost());
-        this.start(this.getServices().values());
-    }
+    _socket.setTimeToLive(255);
+  }
 
-    private void start(Collection<? extends ServiceInfo> serviceInfos) {
-        if (_incomingListener == null) {
-            _incomingListener = new SocketListener(this);
-            _incomingListener.start();
-        }
-        for (ServiceInfo info : serviceInfos) {
-            try {
-                this.registerService(new ServiceInfoImpl(info));
-            } catch (final Exception exception) {
-                logger.warn("start() Registration exception ", exception);
-            }
-        }
-    }
-
-    private void openMulticastSocket(HostInfo hostInfo) throws IOException {
-        if (_group == null) {
-            if (hostInfo.getInetAddress() instanceof Inet6Address) {
-                _group = InetAddress.getByName(DNSConstants.MDNS_GROUP_IPV6);
-            } else {
-                _group = InetAddress.getByName(DNSConstants.MDNS_GROUP);
-            }
-        }
-        if (_socket != null) {
-            this.closeMulticastSocket();
-        }
-        // SocketAddress address = new InetSocketAddress((hostInfo != null ? hostInfo.getInetAddress() : null), DNSConstants.MDNS_PORT);
-        // System.out.println("Socket Address: " + address);
-        // try {
-        // _socket = new MulticastSocket(address);
-        // } catch (Exception exception) {
-        // logger.warn("openMulticastSocket() Open socket exception Address: " + address + ", ", exception);
-        // // The most likely cause is a duplicate address lets open without specifying the address
-        // _socket = new MulticastSocket(DNSConstants.MDNS_PORT);
-        // }
-        _socket = new MulticastSocket(DNSConstants.MDNS_PORT);
-        if ((hostInfo != null) && (hostInfo.getInterface() != null)) {
-            final SocketAddress multicastAddr = new InetSocketAddress(_group, DNSConstants.MDNS_PORT);
-            _socket.setNetworkInterface(hostInfo.getInterface());
-
-            logger.trace("Trying to joinGroup({}, {})", multicastAddr, hostInfo.getInterface());
-
-            // this joinGroup() might be less surprisingly so this is the default
-            _socket.joinGroup(multicastAddr, hostInfo.getInterface());
-        } else {
-            logger.trace("Trying to joinGroup({})", _group);
-            _socket.joinGroup(_group);
-        }
-
-        _socket.setTimeToLive(255);
-    }
-
-    private void closeMulticastSocket() {
-        // jP: 20010-01-18. See below. We'll need this monitor...
-        // assert (Thread.holdsLock(this));
-        logger.debug("closeMulticastSocket()");
-        if (_socket != null) {
-            // close socket
-            try {
-                try {
-                    _socket.leaveGroup(_group);
-                } catch (SocketException exception) {
-                    //
-                }
-                _socket.close();
-            } catch (final Exception exception) {
-                logger.warn("closeMulticastSocket() Close socket exception ", exception);
-            }
-            _socket = null;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getName() {
-        return _name;
-    }
-
-    /**
-     * Returns the local host info
-     *
-     * @return local host info
-     */
-    public HostInfo getLocalHost() {
-        return _localHost;
-    }
-
-    void handleServiceAnswers(List<DNSRecord> answers) {
-        DNSRecord ptr = answers.get(0);
-        if (!DNSRecordType.TYPE_PTR.equals(ptr.getRecordType()))
-            return;
-        List<AnswerListener> list = _answerListeners.get(ptr.getKey());
-
-        if ((list != null) && (!list.isEmpty())) {
-            final List<AnswerListener> listCopy;
-            synchronized (list) {
-                listCopy = new ArrayList<>(list);
-            }
-            for (final AnswerListener listener : listCopy) {
-                _executor.submit(new Runnable() {
-                    @Override
-                    public void run() {
-                        listener.answersReceived(answers);
-                    }
-                });
-            }
-        }
-    }
-
-    @Override
-    public void addAnswerListener(String type, int queryInterval, AnswerListener listener) {
-        final String loType = type.toLowerCase();
-        List<AnswerListener> list = _answerListeners.get(loType);
-        if (list == null) {
-            _answerListeners.putIfAbsent(loType, new LinkedList<>());
-            list = _answerListeners.get(loType);
-        }
-        if (list != null) {
-            synchronized (list) {
-                if (!list.contains(listener)) {
-                    list.add(listener);
-                }
-            }
-        }
-
-        startServiceResolver(loType, queryInterval);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void registerService(ServiceInfo infoAbstract) throws IOException {
-        final ServiceInfoImpl info = (ServiceInfoImpl) infoAbstract;
-
-        info.setServer(_localHost.getName());
-
-        _services.putIfAbsent(info.getKey(), info);
-
-        logger.debug("registerService() JmDNS registered service as {}", info);
-    }
-
-    /**
-     * Handle an incoming response. Cache answers, and pass them on to the appropriate questions.
-     *
-     * @throws IOException
-     */
-    void handleResponse(DNSIncoming msg) throws IOException {
-        List<DNSRecord> allAnswers = msg.getAllAnswers();
-        allAnswers = aRecordsLast(allAnswers);
-
-        handleServiceAnswers(allAnswers);
-    }
-
-    /**
-     * In case the a record is received before the srv record the ip address would not be set.
-     * <p>
-     * Multicast Domain Name System (response)
-     * Transaction ID: 0x0000
-     * Flags: 0x8400 Standard query response, No error
-     * Questions: 0
-     * Answer RRs: 2
-     * Authority RRs: 0
-     * Additional RRs: 8
-     * Answers
-     * _ibisip_http._tcp.local: type PTR, class IN, DeviceManagementService._ibisip_http._tcp.local
-     * _ibisip_http._tcp.local: type PTR, class IN, PassengerCountingService._ibisip_http._tcp.local
-     * Additional records
-     * DeviceManagementService._ibisip_http._tcp.local: type TXT, class IN, cache flush
-     * PassengerCountingService._ibisip_http._tcp.local: type TXT, class IN, cache flush
-     * DIST500_7-F07_OC030_05_03941.local: type A, class IN, cache flush, addr 192.168.88.236
-     * DeviceManagementService._ibisip_http._tcp.local: type SRV, class IN, cache flush, priority 0, weight 0, port 5000, target DIST500_7-F07_OC030_05_03941.local
-     * PassengerCountingService._ibisip_http._tcp.local: type SRV, class IN, cache flush, priority 0, weight 0, port 5001, target DIST500_7-F07_OC030_05_03941.local
-     * DeviceManagementService._ibisip_http._tcp.local: type NSEC, class IN, cache flush, next domain name DeviceManagementService._ibisip_http._tcp.local
-     * PassengerCountingService._ibisip_http._tcp.local: type NSEC, class IN, cache flush, next domain name PassengerCountingService._ibisip_http._tcp.local
-     * DIST500_7-F07_OC030_05_03941.local: type NSEC, class IN, cache flush, next domain name DIST500_7-F07_OC030_05_03941.local
-     */
-    private List<DNSRecord> aRecordsLast(List<DNSRecord> allAnswers) {
-        ArrayList<DNSRecord> ret = new ArrayList<DNSRecord>(allAnswers.size());
-        ArrayList<DNSRecord> arecords = new ArrayList<DNSRecord>();
-
-        for (DNSRecord answer : allAnswers) {
-            DNSRecordType type = answer.getRecordType();
-            if (type.equals(DNSRecordType.TYPE_A) || type.equals(DNSRecordType.TYPE_AAAA)) {
-                arecords.add(answer);
-            } else if (type.equals(DNSRecordType.TYPE_PTR)) {
-                ret.add(0, answer);
-            } else {
-                ret.add(answer);
-            }
-        }
-        ret.addAll(arecords);
-        return ret;
-    }
-
-
-    /**
-     * Handle an incoming query. See if we can answer any part of it given our service infos.
-     *
-     * @param in
-     * @param addr
-     * @param port
-     * @throws IOException
-     */
-    void handleQuery(DNSIncoming in, InetAddress addr, int port) throws IOException {
-        logger.debug("{} handle query: {}", this.getName(), in);
-        this.ioLock();
+  private void closeMulticastSocket() {
+    // jP: 20010-01-18. See below. We'll need this monitor...
+    // assert (Thread.holdsLock(this));
+    logger.debug("closeMulticastSocket()");
+    if (_socket != null) {
+      // close socket
+      try {
         try {
-            DNSIncoming plannedAnswer = in.clone();
-            this.startResponder(plannedAnswer, addr, port);
-        } finally {
-            this.ioUnlock();
+          _socket.leaveGroup(_group);
+        } catch (SocketException exception) {
+          //
         }
+        _socket.close();
+      } catch (final Exception exception) {
+        logger.warn("closeMulticastSocket() Close socket exception ", exception);
+      }
+      _socket = null;
     }
+  }
 
-    /**
-     * Send an outgoing multicast DNS message.
-     *
-     * @param out
-     * @throws IOException
-     */
-    public void send(DNSOutgoing out) throws IOException {
-        if (!out.isEmpty()) {
-            final InetAddress addr;
-            final int port;
+  /** {@inheritDoc} */
+  @Override
+  public String getName() {
+    return _name;
+  }
 
-            if (out.getDestination() != null) {
-                addr = out.getDestination().getAddress();
-                port = out.getDestination().getPort();
-            } else {
-                addr = _group;
-                port = DNSConstants.MDNS_PORT;
-            }
+  /**
+   * Returns the local host info
+   *
+   * @return local host info
+   */
+  public HostInfo getLocalHost() {
+    return _localHost;
+  }
 
-            byte[] message = out.data();
-            final DatagramPacket packet = new DatagramPacket(message, message.length, addr, port);
+  void handleServiceAnswers(List<DNSRecord> answers) {
+    DNSRecord ptr = answers.get(0);
+    if (!DNSRecordType.TYPE_PTR.equals(ptr.getRecordType())) return;
+    List<AnswerListener> list = _answerListeners.get(ptr.getKey());
 
-            if (logger.isTraceEnabled()) {
-                try {
-                    final DNSIncoming msg = new DNSIncoming(packet);
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("send({}) JmDNS out:{}", this.getName(), msg.print(true));
-                    }
-                } catch (final IOException e) {
-                    logger.debug(getClass().toString(), ".send(" + this.getName() + ") - JmDNS can not parse what it sends!!!", e);
-                }
-            }
-            final MulticastSocket ms = _socket;
-            if (ms != null && !ms.isClosed()) {
-                ms.send(packet);
-            }
+    if ((list != null) && (!list.isEmpty())) {
+      final List<AnswerListener> listCopy;
+      synchronized (list) {
+        listCopy = new ArrayList<>(list);
+      }
+      for (final AnswerListener listener : listCopy) {
+        _executor.submit(
+            new Runnable() {
+              @Override
+              public void run() {
+                listener.answersReceived(answers);
+              }
+            });
+      }
+    }
+  }
+
+  @Override
+  public void addAnswerListener(String type, int queryInterval, AnswerListener listener) {
+    final String loType = type.toLowerCase();
+    List<AnswerListener> list = _answerListeners.get(loType);
+    if (list == null) {
+      _answerListeners.putIfAbsent(loType, new LinkedList<>());
+      list = _answerListeners.get(loType);
+    }
+    if (list != null) {
+      synchronized (list) {
+        if (!list.contains(listener)) {
+          list.add(listener);
         }
+      }
     }
 
-    private void startServiceResolver(String type, int queryInterval) {
-        if (_serviceResolvers.containsKey(type))
-            return;
+    startServiceResolver(loType, queryInterval);
+  }
 
-        ServiceResolver resolver = new ServiceResolver(this, type, queryInterval);
-        if (_serviceResolvers.putIfAbsent(type, resolver) == null)
-            resolver.start();
+  /** {@inheritDoc} */
+  @Override
+  public void registerService(ServiceInfo infoAbstract) throws IOException {
+    final ServiceInfoImpl info = (ServiceInfoImpl) infoAbstract;
+
+    info.setServer(_localHost.getName());
+
+    _services.putIfAbsent(info.getKey(), info);
+
+    logger.debug("registerService() JmDNS registered service as {}", info);
+  }
+
+  /**
+   * Handle an incoming response. Cache answers, and pass them on to the appropriate questions.
+   *
+   * @throws IOException
+   */
+  void handleResponse(DNSIncoming msg) throws IOException {
+    List<DNSRecord> allAnswers = msg.getAllAnswers();
+    allAnswers = aRecordsLast(allAnswers);
+
+    handleServiceAnswers(allAnswers);
+  }
+
+  /**
+   * In case the a record is received before the srv record the ip address would not be set.
+   *
+   * <p>Multicast Domain Name System (response) Transaction ID: 0x0000 Flags: 0x8400 Standard query
+   * response, No error Questions: 0 Answer RRs: 2 Authority RRs: 0 Additional RRs: 8 Answers
+   * _ibisip_http._tcp.local: type PTR, class IN, DeviceManagementService._ibisip_http._tcp.local
+   * _ibisip_http._tcp.local: type PTR, class IN, PassengerCountingService._ibisip_http._tcp.local
+   * Additional records DeviceManagementService._ibisip_http._tcp.local: type TXT, class IN, cache
+   * flush PassengerCountingService._ibisip_http._tcp.local: type TXT, class IN, cache flush
+   * DIST500_7-F07_OC030_05_03941.local: type A, class IN, cache flush, addr 192.168.88.236
+   * DeviceManagementService._ibisip_http._tcp.local: type SRV, class IN, cache flush, priority 0,
+   * weight 0, port 5000, target DIST500_7-F07_OC030_05_03941.local
+   * PassengerCountingService._ibisip_http._tcp.local: type SRV, class IN, cache flush, priority 0,
+   * weight 0, port 5001, target DIST500_7-F07_OC030_05_03941.local
+   * DeviceManagementService._ibisip_http._tcp.local: type NSEC, class IN, cache flush, next domain
+   * name DeviceManagementService._ibisip_http._tcp.local
+   * PassengerCountingService._ibisip_http._tcp.local: type NSEC, class IN, cache flush, next domain
+   * name PassengerCountingService._ibisip_http._tcp.local DIST500_7-F07_OC030_05_03941.local: type
+   * NSEC, class IN, cache flush, next domain name DIST500_7-F07_OC030_05_03941.local
+   */
+  private List<DNSRecord> aRecordsLast(List<DNSRecord> allAnswers) {
+    ArrayList<DNSRecord> ret = new ArrayList<DNSRecord>(allAnswers.size());
+    ArrayList<DNSRecord> arecords = new ArrayList<DNSRecord>();
+
+    for (DNSRecord answer : allAnswers) {
+      DNSRecordType type = answer.getRecordType();
+      if (type.equals(DNSRecordType.TYPE_A) || type.equals(DNSRecordType.TYPE_AAAA)) {
+        arecords.add(answer);
+      } else if (type.equals(DNSRecordType.TYPE_PTR)) {
+        ret.add(0, answer);
+      } else {
+        ret.add(answer);
+      }
     }
+    ret.addAll(arecords);
+    return ret;
+  }
 
-    private void startResponder(DNSIncoming in, InetAddress addr, int port) {
-        new Responder(this, in, addr, port).start();
+  /**
+   * Handle an incoming query. See if we can answer any part of it given our service infos.
+   *
+   * @param in
+   * @param addr
+   * @param port
+   * @throws IOException
+   */
+  void handleQuery(DNSIncoming in, InetAddress addr, int port) throws IOException {
+    logger.debug("{} handle query: {}", this.getName(), in);
+    this.ioLock();
+    try {
+      DNSIncoming plannedAnswer = in.clone();
+      this.startResponder(plannedAnswer, addr, port);
+    } finally {
+      this.ioUnlock();
     }
+  }
 
-    public void stop() {
-        logger.debug("Stopping JmDNS: {}", this);
+  /**
+   * Send an outgoing multicast DNS message.
+   *
+   * @param out
+   * @throws IOException
+   */
+  public void send(DNSOutgoing out) throws IOException {
+    if (!out.isEmpty()) {
+      final InetAddress addr;
+      final int port;
 
-        List<Future<Void>> shutdowns = new ArrayList<>();
+      if (out.getDestination() != null) {
+        addr = out.getDestination().getAddress();
+        port = out.getDestination().getPort();
+      } else {
+        addr = _group;
+        port = DNSConstants.MDNS_PORT;
+      }
 
-        shutdowns.add(_incomingListener.stop());
-        _incomingListener = null;
+      byte[] message = out.data();
+      final DatagramPacket packet = new DatagramPacket(message, message.length, addr, port);
 
-        for (ServiceResolver resolver : _serviceResolvers.values())
-            shutdowns.add(resolver.stop());
-
-        // close socket
-        this.closeMulticastSocket();
-
-        logger.debug("JmDNS waiting for service stop...");
-
-        for (Future<Void> shutdown : shutdowns) {
-            try {
-                shutdown.get(10, TimeUnit.SECONDS);
-            } catch (CancellationException e) {
-                logger.trace("Task was already cancelled", e);
-            } catch (InterruptedException e) {
-                logger.trace("Stopping was interrupted", e);
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException | TimeoutException e) {
-                logger.debug("Exception when stopping JmDNS: ", e);
-                throw new RuntimeException(e);
-            }
+      if (logger.isTraceEnabled()) {
+        try {
+          final DNSIncoming msg = new DNSIncoming(packet);
+          if (logger.isTraceEnabled()) {
+            logger.trace("send({}) JmDNS out:{}", this.getName(), msg.print(true));
+          }
+        } catch (final IOException e) {
+          logger.debug(
+              getClass().toString(),
+              ".send(" + this.getName() + ") - JmDNS can not parse what it sends!!!",
+              e);
         }
+      }
+      final MulticastSocket ms = _socket;
+      if (ms != null && !ms.isClosed()) {
+        ms.send(packet);
+      }
+    }
+  }
 
-        _executor.shutdown();
+  private void startServiceResolver(String type, int queryInterval) {
+    if (_serviceResolvers.containsKey(type)) return;
 
-        logger.debug("JmDNS stopped.");
+    ServiceResolver resolver = new ServiceResolver(this, type, queryInterval);
+    if (_serviceResolvers.putIfAbsent(type, resolver) == null) resolver.start();
+  }
+
+  private void startResponder(DNSIncoming in, InetAddress addr, int port) {
+    new Responder(this, in, addr, port).start();
+  }
+
+  public void stop() {
+    logger.debug("Stopping JmDNS: {}", this);
+
+    List<Future<Void>> shutdowns = new ArrayList<>();
+
+    shutdowns.add(_incomingListener.stop());
+    _incomingListener = null;
+
+    for (ServiceResolver resolver : _serviceResolvers.values()) shutdowns.add(resolver.stop());
+
+    // close socket
+    this.closeMulticastSocket();
+
+    logger.debug("JmDNS waiting for service stop...");
+
+    for (Future<Void> shutdown : shutdowns) {
+      try {
+        shutdown.get(10, TimeUnit.SECONDS);
+      } catch (CancellationException e) {
+        logger.trace("Task was already cancelled", e);
+      } catch (InterruptedException e) {
+        logger.trace("Stopping was interrupted", e);
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException | TimeoutException e) {
+        logger.debug("Exception when stopping JmDNS: ", e);
+        throw new RuntimeException(e);
+      }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder(2048);
-        sb.append("\n");
-        sb.append("\t---- Local Host -----");
-        sb.append("\n\t");
-        sb.append(_localHost);
-        sb.append("\n\t---- Services -----");
-        for (final Map.Entry<String, ServiceInfo> entry : _services.entrySet()) {
-            sb.append("\n\t\tService: ");
-            sb.append(entry.getKey());
-            sb.append(": ");
-            sb.append(entry.getValue());
-        }
-        sb.append("\n");
-        sb.append("\t---- Answer Listeners ----");
-        for (final Map.Entry<String, List<AnswerListener>> entry : _answerListeners.entrySet()) {
-            sb.append("\n\t\tAnswer Listener: ");
-            sb.append(entry.getKey());
-            sb.append(": ");
-            sb.append(entry.getValue());
-        }
-        return sb.toString();
-    }
+    _executor.shutdown();
 
-    public Map<String, ServiceInfo> getServices() {
-        return _services;
-    }
+    logger.debug("JmDNS stopped.");
+  }
 
-    public static Random getRandom() {
-        return _random;
+  /** {@inheritDoc} */
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder(2048);
+    sb.append("\n");
+    sb.append("\t---- Local Host -----");
+    sb.append("\n\t");
+    sb.append(_localHost);
+    sb.append("\n\t---- Services -----");
+    for (final Map.Entry<String, ServiceInfo> entry : _services.entrySet()) {
+      sb.append("\n\t\tService: ");
+      sb.append(entry.getKey());
+      sb.append(": ");
+      sb.append(entry.getValue());
     }
+    sb.append("\n");
+    sb.append("\t---- Answer Listeners ----");
+    for (final Map.Entry<String, List<AnswerListener>> entry : _answerListeners.entrySet()) {
+      sb.append("\n\t\tAnswer Listener: ");
+      sb.append(entry.getKey());
+      sb.append(": ");
+      sb.append(entry.getValue());
+    }
+    return sb.toString();
+  }
 
-    private void ioLock() {
-        _ioLock.lock();
-    }
+  public Map<String, ServiceInfo> getServices() {
+    return _services;
+  }
 
-    private void ioUnlock() {
-        _ioLock.unlock();
-    }
+  public static Random getRandom() {
+    return _random;
+  }
 
-    public MulticastSocket getSocket() {
-        return _socket;
-    }
+  private void ioLock() {
+    _ioLock.lock();
+  }
 
-    public InetAddress getGroup() {
-        return _group;
-    }
+  private void ioUnlock() {
+    _ioLock.unlock();
+  }
+
+  public MulticastSocket getSocket() {
+    return _socket;
+  }
+
+  public InetAddress getGroup() {
+    return _group;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/ServiceInfoImpl.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/ServiceInfoImpl.java
@@ -7,9 +7,6 @@ package io.libp2p.discovery.mdns.impl;
 import io.libp2p.discovery.mdns.ServiceInfo;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
 import io.libp2p.discovery.mdns.impl.util.ByteWrangler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -23,6 +20,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * JmDNS service information.
@@ -30,435 +29,488 @@ import java.util.Set;
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Victor Toni
  */
 public class ServiceInfoImpl extends ServiceInfo {
-    private static Logger logger = LoggerFactory.getLogger(ServiceInfoImpl.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ServiceInfoImpl.class.getName());
 
-    private String                  _domain;
-    private String                  _protocol;
-    private String                  _application;
-    private String                  _name;
-    private String                  _subtype;
-    private String                  _server;
-    private int                     _port;
-    private int                     _weight;
-    private int                     _priority;
-    private byte[]                  _text;
-    private final Set<Inet4Address> _ipv4Addresses;
-    private final Set<Inet6Address> _ipv6Addresses;
+  private String _domain;
+  private String _protocol;
+  private String _application;
+  private String _name;
+  private String _subtype;
+  private String _server;
+  private int _port;
+  private int _weight;
+  private int _priority;
+  private byte[] _text;
+  private final Set<Inet4Address> _ipv4Addresses;
+  private final Set<Inet6Address> _ipv6Addresses;
 
-    private transient String        _key;
+  private transient String _key;
 
-    /**
-     * @param type
-     * @param name
-     * @param subtype
-     * @param port
-     * @param weight
-     * @param priority
-     * @param text
-     */
-    public ServiceInfoImpl(String type, String name, String subtype, int port, int weight, int priority, String text) {
-        this(ServiceInfoImpl.decodeQualifiedNameMap(type, name, subtype), port, weight, priority, (byte[]) null);
+  /**
+   * @param type
+   * @param name
+   * @param subtype
+   * @param port
+   * @param weight
+   * @param priority
+   * @param text
+   */
+  public ServiceInfoImpl(
+      String type, String name, String subtype, int port, int weight, int priority, String text) {
+    this(
+        ServiceInfoImpl.decodeQualifiedNameMap(type, name, subtype),
+        port,
+        weight,
+        priority,
+        (byte[]) null);
 
-        try {
-            this._text = ByteWrangler.encodeText(text);
-        } catch (final IOException e) {
-            throw new RuntimeException("Unexpected exception: " + e);
+    try {
+      this._text = ByteWrangler.encodeText(text);
+    } catch (final IOException e) {
+      throw new RuntimeException("Unexpected exception: " + e);
+    }
+
+    _server = text;
+  }
+
+  ServiceInfoImpl(
+      Map<Fields, String> qualifiedNameMap, int port, int weight, int priority, byte text[]) {
+    Map<Fields, String> map = ServiceInfoImpl.checkQualifiedNameMap(qualifiedNameMap);
+
+    this._domain = map.get(Fields.Domain);
+    this._protocol = map.get(Fields.Protocol);
+    this._application = map.get(Fields.Application);
+    this._name = map.get(Fields.Instance);
+    this._subtype = map.get(Fields.Subtype);
+
+    this._port = port;
+    this._weight = weight;
+    this._priority = priority;
+    this._text = text;
+    this._ipv4Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet4Address>());
+    this._ipv6Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet6Address>());
+  }
+
+  ServiceInfoImpl(ServiceInfo info) {
+    this._ipv4Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet4Address>());
+    this._ipv6Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet6Address>());
+    if (info != null) {
+      this._domain = info.getDomain();
+      this._protocol = info.getProtocol();
+      this._application = info.getApplication();
+      this._name = info.getName();
+      this._subtype = info.getSubtype();
+      this._port = info.getPort();
+      this._weight = info.getWeight();
+      this._priority = info.getPriority();
+      this._text = info.getTextBytes();
+      Inet6Address[] ipv6Addresses = info.getInet6Addresses();
+      for (Inet6Address address : ipv6Addresses) {
+        this._ipv6Addresses.add(address);
+      }
+      Inet4Address[] ipv4Addresses = info.getInet4Addresses();
+      for (Inet4Address address : ipv4Addresses) {
+        this._ipv4Addresses.add(address);
+      }
+    }
+  }
+
+  public static Map<Fields, String> decodeQualifiedNameMap(
+      String type, String name, String subtype) {
+    Map<Fields, String> qualifiedNameMap = decodeQualifiedNameMapForType(type);
+
+    qualifiedNameMap.put(Fields.Instance, name);
+    qualifiedNameMap.put(Fields.Subtype, subtype);
+
+    return checkQualifiedNameMap(qualifiedNameMap);
+  }
+
+  public static Map<Fields, String> decodeQualifiedNameMapForType(String type) {
+    int index;
+
+    String casePreservedType = type;
+
+    String aType = type.toLowerCase();
+    String application = aType;
+    String protocol = "";
+    String subtype = "";
+    String name = "";
+    String domain = "";
+
+    if (aType.contains("in-addr.arpa") || aType.contains("ip6.arpa")) {
+      index =
+          (aType.contains("in-addr.arpa")
+              ? aType.indexOf("in-addr.arpa")
+              : aType.indexOf("ip6.arpa"));
+      name = removeSeparators(casePreservedType.substring(0, index));
+      domain = casePreservedType.substring(index);
+      application = "";
+    } else if ((!aType.contains("_")) && aType.contains(".")) {
+      index = aType.indexOf('.');
+      name = removeSeparators(casePreservedType.substring(0, index));
+      domain = removeSeparators(casePreservedType.substring(index));
+      application = "";
+    } else {
+      // First remove the name if it there.
+      if (!aType.startsWith("_") || aType.startsWith("_services")) {
+        index = aType.indexOf("._");
+        if (index > 0) {
+          // We need to preserve the case for the user readable name.
+          name = casePreservedType.substring(0, index);
+          if (index + 1 < aType.length()) {
+            aType = aType.substring(index + 1);
+            casePreservedType = casePreservedType.substring(index + 1);
+          }
         }
+      }
 
-        _server = text;
-    }
-
-    ServiceInfoImpl(Map<Fields, String> qualifiedNameMap, int port, int weight, int priority, byte text[]) {
-        Map<Fields, String> map = ServiceInfoImpl.checkQualifiedNameMap(qualifiedNameMap);
-
-        this._domain = map.get(Fields.Domain);
-        this._protocol = map.get(Fields.Protocol);
-        this._application = map.get(Fields.Application);
-        this._name = map.get(Fields.Instance);
-        this._subtype = map.get(Fields.Subtype);
-
-        this._port = port;
-        this._weight = weight;
-        this._priority = priority;
-        this._text = text;
-        this._ipv4Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet4Address>());
-        this._ipv6Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet6Address>());
-    }
-
-    ServiceInfoImpl(ServiceInfo info) {
-        this._ipv4Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet4Address>());
-        this._ipv6Addresses = Collections.synchronizedSet(new LinkedHashSet<Inet6Address>());
-        if (info != null) {
-            this._domain = info.getDomain();
-            this._protocol = info.getProtocol();
-            this._application = info.getApplication();
-            this._name = info.getName();
-            this._subtype = info.getSubtype();
-            this._port = info.getPort();
-            this._weight = info.getWeight();
-            this._priority = info.getPriority();
-            this._text = info.getTextBytes();
-            Inet6Address[] ipv6Addresses = info.getInet6Addresses();
-            for (Inet6Address address : ipv6Addresses) {
-                this._ipv6Addresses.add(address);
-            }
-            Inet4Address[] ipv4Addresses = info.getInet4Addresses();
-            for (Inet4Address address : ipv4Addresses) {
-                this._ipv4Addresses.add(address);
-            }
+      index = aType.lastIndexOf("._");
+      if (index > 0) {
+        int start = index + 2;
+        int end = aType.indexOf('.', start);
+        protocol = casePreservedType.substring(start, end);
+      }
+      if (protocol.length() > 0) {
+        index = aType.indexOf("_" + protocol.toLowerCase() + ".");
+        int start = index + protocol.length() + 2;
+        int end = aType.length() - (aType.endsWith(".") ? 1 : 0);
+        if (end > start) {
+          domain = casePreservedType.substring(start, end);
         }
-    }
-
-    public static Map<Fields, String> decodeQualifiedNameMap(String type, String name, String subtype) {
-        Map<Fields, String> qualifiedNameMap = decodeQualifiedNameMapForType(type);
-
-        qualifiedNameMap.put(Fields.Instance, name);
-        qualifiedNameMap.put(Fields.Subtype, subtype);
-
-        return checkQualifiedNameMap(qualifiedNameMap);
-    }
-
-    public static Map<Fields, String> decodeQualifiedNameMapForType(String type) {
-        int index;
-
-        String casePreservedType = type;
-
-        String aType = type.toLowerCase();
-        String application = aType;
-        String protocol = "";
-        String subtype = "";
-        String name = "";
-        String domain = "";
-
-        if (aType.contains("in-addr.arpa") || aType.contains("ip6.arpa")) {
-            index = (aType.contains("in-addr.arpa") ? aType.indexOf("in-addr.arpa") : aType.indexOf("ip6.arpa"));
-            name = removeSeparators(casePreservedType.substring(0, index));
-            domain = casePreservedType.substring(index);
-            application = "";
-        } else if ((!aType.contains("_")) && aType.contains(".")) {
-            index = aType.indexOf('.');
-            name = removeSeparators(casePreservedType.substring(0, index));
-            domain = removeSeparators(casePreservedType.substring(index));
-            application = "";
+        if (index > 0) {
+          application = casePreservedType.substring(0, index - 1);
         } else {
-            // First remove the name if it there.
-            if (!aType.startsWith("_") || aType.startsWith("_services")) {
-                index = aType.indexOf("._");
-                if (index > 0) {
-                    // We need to preserve the case for the user readable name.
-                    name = casePreservedType.substring(0, index);
-                    if (index + 1 < aType.length()) {
-                        aType = aType.substring(index + 1);
-                        casePreservedType = casePreservedType.substring(index + 1);
-                    }
-                }
-            }
-
-            index = aType.lastIndexOf("._");
-            if (index > 0) {
-                int start = index + 2;
-                int end = aType.indexOf('.', start);
-                protocol = casePreservedType.substring(start, end);
-            }
-            if (protocol.length() > 0) {
-                index = aType.indexOf("_" + protocol.toLowerCase() + ".");
-                int start = index + protocol.length() + 2;
-                int end = aType.length() - (aType.endsWith(".") ? 1 : 0);
-                if (end > start) {
-                    domain = casePreservedType.substring(start, end);
-                }
-                if (index > 0) {
-                    application = casePreservedType.substring(0, index - 1);
-                } else {
-                    application = "";
-                }
-            }
-            index = application.toLowerCase().indexOf("._sub");
-            if (index > 0) {
-                int start = index + 5;
-                subtype = removeSeparators(application.substring(0, index));
-                application = application.substring(start);
-            }
+          application = "";
         }
-
-        final Map<Fields, String> qualifiedNameMap = new HashMap<Fields, String>(5);
-        qualifiedNameMap.put(Fields.Domain, removeSeparators(domain));
-        qualifiedNameMap.put(Fields.Protocol, protocol);
-        qualifiedNameMap.put(Fields.Application, removeSeparators(application));
-        qualifiedNameMap.put(Fields.Instance, name);
-        qualifiedNameMap.put(Fields.Subtype, subtype);
-
-        return qualifiedNameMap;
+      }
+      index = application.toLowerCase().indexOf("._sub");
+      if (index > 0) {
+        int start = index + 5;
+        subtype = removeSeparators(application.substring(0, index));
+        application = application.substring(start);
+      }
     }
 
-    protected static Map<Fields, String> checkQualifiedNameMap(Map<Fields, String> qualifiedNameMap) {
-        Map<Fields, String> checkedQualifiedNameMap = new HashMap<Fields, String>(5);
+    final Map<Fields, String> qualifiedNameMap = new HashMap<Fields, String>(5);
+    qualifiedNameMap.put(Fields.Domain, removeSeparators(domain));
+    qualifiedNameMap.put(Fields.Protocol, protocol);
+    qualifiedNameMap.put(Fields.Application, removeSeparators(application));
+    qualifiedNameMap.put(Fields.Instance, name);
+    qualifiedNameMap.put(Fields.Subtype, subtype);
 
-        // Optional domain
-        String domain = (qualifiedNameMap.containsKey(Fields.Domain) ? qualifiedNameMap.get(Fields.Domain) : "local");
-        if ((domain == null) || (domain.length() == 0)) {
-            domain = "local";
-        }
-        domain = removeSeparators(domain);
-        checkedQualifiedNameMap.put(Fields.Domain, domain);
-        // Optional protocol
-        String protocol = (qualifiedNameMap.containsKey(Fields.Protocol) ? qualifiedNameMap.get(Fields.Protocol) : "tcp");
-        if ((protocol == null) || (protocol.length() == 0)) {
-            protocol = "tcp";
-        }
-        protocol = removeSeparators(protocol);
-        checkedQualifiedNameMap.put(Fields.Protocol, protocol);
-        // Application
-        String application = (qualifiedNameMap.containsKey(Fields.Application) ? qualifiedNameMap.get(Fields.Application) : "");
-        if ((application == null) || (application.length() == 0)) {
-            application = "";
-        }
-        application = removeSeparators(application);
-        checkedQualifiedNameMap.put(Fields.Application, application);
-        // Instance
-        String instance = (qualifiedNameMap.containsKey(Fields.Instance) ? qualifiedNameMap.get(Fields.Instance) : "");
-        if ((instance == null) || (instance.length() == 0)) {
-            instance = "";
-            // throw new IllegalArgumentException("The instance name component of a fully qualified service cannot be empty.");
-        }
-        instance = removeSeparators(instance);
-        checkedQualifiedNameMap.put(Fields.Instance, instance);
-        // Optional Subtype
-        String subtype = (qualifiedNameMap.containsKey(Fields.Subtype) ? qualifiedNameMap.get(Fields.Subtype) : "");
-        if ((subtype == null) || (subtype.length() == 0)) {
-            subtype = "";
-        }
-        subtype = removeSeparators(subtype);
-        checkedQualifiedNameMap.put(Fields.Subtype, subtype);
+    return qualifiedNameMap;
+  }
 
-        return checkedQualifiedNameMap;
+  protected static Map<Fields, String> checkQualifiedNameMap(Map<Fields, String> qualifiedNameMap) {
+    Map<Fields, String> checkedQualifiedNameMap = new HashMap<Fields, String>(5);
+
+    // Optional domain
+    String domain =
+        (qualifiedNameMap.containsKey(Fields.Domain)
+            ? qualifiedNameMap.get(Fields.Domain)
+            : "local");
+    if ((domain == null) || (domain.length() == 0)) {
+      domain = "local";
+    }
+    domain = removeSeparators(domain);
+    checkedQualifiedNameMap.put(Fields.Domain, domain);
+    // Optional protocol
+    String protocol =
+        (qualifiedNameMap.containsKey(Fields.Protocol)
+            ? qualifiedNameMap.get(Fields.Protocol)
+            : "tcp");
+    if ((protocol == null) || (protocol.length() == 0)) {
+      protocol = "tcp";
+    }
+    protocol = removeSeparators(protocol);
+    checkedQualifiedNameMap.put(Fields.Protocol, protocol);
+    // Application
+    String application =
+        (qualifiedNameMap.containsKey(Fields.Application)
+            ? qualifiedNameMap.get(Fields.Application)
+            : "");
+    if ((application == null) || (application.length() == 0)) {
+      application = "";
+    }
+    application = removeSeparators(application);
+    checkedQualifiedNameMap.put(Fields.Application, application);
+    // Instance
+    String instance =
+        (qualifiedNameMap.containsKey(Fields.Instance)
+            ? qualifiedNameMap.get(Fields.Instance)
+            : "");
+    if ((instance == null) || (instance.length() == 0)) {
+      instance = "";
+      // throw new IllegalArgumentException("The instance name component of a fully qualified
+      // service cannot be empty.");
+    }
+    instance = removeSeparators(instance);
+    checkedQualifiedNameMap.put(Fields.Instance, instance);
+    // Optional Subtype
+    String subtype =
+        (qualifiedNameMap.containsKey(Fields.Subtype) ? qualifiedNameMap.get(Fields.Subtype) : "");
+    if ((subtype == null) || (subtype.length() == 0)) {
+      subtype = "";
+    }
+    subtype = removeSeparators(subtype);
+    checkedQualifiedNameMap.put(Fields.Subtype, subtype);
+
+    return checkedQualifiedNameMap;
+  }
+
+  private static String removeSeparators(String name) {
+    if (name == null) {
+      return "";
+    }
+    String newName = name.trim();
+    if (newName.startsWith(".")) {
+      newName = newName.substring(1);
+    }
+    if (newName.startsWith("_")) {
+      newName = newName.substring(1);
+    }
+    if (newName.endsWith(".")) {
+      newName = newName.substring(0, newName.length() - 1);
+    }
+    return newName;
+  }
+
+  @Override
+  public String getType() {
+    String domain = this.getDomain();
+    String protocol = this.getProtocol();
+    String application = this.getApplication();
+    return (application.length() > 0 ? "_" + application + "." : "")
+        + (protocol.length() > 0 ? "_" + protocol + "." : "")
+        + domain
+        + ".";
+  }
+
+  @Override
+  public String getTypeWithSubtype() {
+    String subtype = this.getSubtype();
+    return (subtype.length() > 0 ? "_" + subtype + "._sub." : "") + this.getType();
+  }
+
+  @Override
+  public String getName() {
+    return (_name != null ? _name : "");
+  }
+
+  @Override
+  public String getKey() {
+    if (this._key == null) {
+      this._key = this.getQualifiedName().toLowerCase();
+    }
+    return this._key;
+  }
+
+  @Override
+  public String getQualifiedName() {
+    String domain = this.getDomain();
+    String protocol = this.getProtocol();
+    String application = this.getApplication();
+    String instance = this.getName();
+    return (instance.length() > 0 ? instance + "." : "")
+        + (application.length() > 0 ? "_" + application + "." : "")
+        + (protocol.length() > 0 ? "_" + protocol + "." : "")
+        + domain
+        + ".";
+  }
+
+  @Override
+  public String getServer() {
+    return (_server != null ? _server : "");
+  }
+
+  void setServer(String server) {
+    this._server = server;
+  }
+
+  public void addAddress(Inet4Address addr) {
+    _ipv4Addresses.add(addr);
+  }
+
+  public void addAddress(Inet6Address addr) {
+    _ipv6Addresses.add(addr);
+  }
+
+  @Override
+  public Inet4Address[] getInet4Addresses() {
+    return _ipv4Addresses.toArray(new Inet4Address[_ipv4Addresses.size()]);
+  }
+
+  @Override
+  public Inet6Address[] getInet6Addresses() {
+    return _ipv6Addresses.toArray(new Inet6Address[_ipv6Addresses.size()]);
+  }
+
+  @Override
+  public int getPort() {
+    return _port;
+  }
+
+  @Override
+  public int getPriority() {
+    return _priority;
+  }
+
+  @Override
+  public int getWeight() {
+    return _weight;
+  }
+
+  @Override
+  public byte[] getTextBytes() {
+    return (this._text != null && this._text.length > 0 ? this._text : ByteWrangler.EMPTY_TXT);
+  }
+
+  @Override
+  public String getApplication() {
+    return (_application != null ? _application : "");
+  }
+
+  @Override
+  public String getDomain() {
+    return (_domain != null ? _domain : "local");
+  }
+
+  @Override
+  public String getProtocol() {
+    return (_protocol != null ? _protocol : "tcp");
+  }
+
+  @Override
+  public String getSubtype() {
+    return (_subtype != null ? _subtype : "");
+  }
+
+  @Override
+  public Map<Fields, String> getQualifiedNameMap() {
+    Map<Fields, String> map = new HashMap<Fields, String>(5);
+
+    map.put(Fields.Domain, this.getDomain());
+    map.put(Fields.Protocol, this.getProtocol());
+    map.put(Fields.Application, this.getApplication());
+    map.put(Fields.Instance, this.getName());
+    map.put(Fields.Subtype, this.getSubtype());
+    return map;
+  }
+
+  @Override
+  public synchronized boolean hasData() {
+    return this.getServer() != null
+        && this.hasInetAddress()
+        && this.getTextBytes() != null
+        && this.getTextBytes().length > 0;
+  }
+
+  private boolean hasInetAddress() {
+    return _ipv4Addresses.size() > 0 || _ipv6Addresses.size() > 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return getQualifiedName().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return (obj instanceof ServiceInfoImpl)
+        && getQualifiedName().equals(((ServiceInfoImpl) obj).getQualifiedName());
+  }
+
+  @Override
+  public ServiceInfoImpl clone() {
+    ServiceInfoImpl serviceInfo =
+        new ServiceInfoImpl(this.getQualifiedNameMap(), _port, _weight, _priority, _text);
+    serviceInfo._ipv6Addresses.addAll(Arrays.asList(getInet6Addresses()));
+    serviceInfo._ipv4Addresses.addAll(Arrays.asList(getInet4Addresses()));
+    serviceInfo._server = _server;
+    return serviceInfo;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append('[')
+        .append(this.getClass().getSimpleName())
+        .append('@')
+        .append(System.identityHashCode(this));
+    sb.append(" name: '");
+    if (0 < this.getName().length()) {
+      sb.append(this.getName()).append('.');
+    }
+    sb.append(this.getTypeWithSubtype());
+    sb.append("' address: '");
+    Inet4Address[] addresses4 = this.getInet4Addresses();
+    for (InetAddress address : addresses4) {
+      sb.append(address).append(':').append(this.getPort()).append(' ');
+    }
+    Inet6Address[] addresses6 = this.getInet6Addresses();
+    for (InetAddress address : addresses6) {
+      sb.append(address).append(':').append(this.getPort()).append(' ');
     }
 
-    private static String removeSeparators(String name) {
-        if (name == null) {
-            return "";
-        }
-        String newName = name.trim();
-        if (newName.startsWith(".")) {
-            newName = newName.substring(1);
-        }
-        if (newName.startsWith("_")) {
-            newName = newName.substring(1);
-        }
-        if (newName.endsWith(".")) {
-            newName = newName.substring(0, newName.length() - 1);
-        }
-        return newName;
+    sb.append(this.hasData() ? " has data" : " has NO data");
+    sb.append(']');
+
+    return sb.toString();
+  }
+
+  /**
+   * Create a series of answer that correspond with the give service info.
+   *
+   * @param recordClass record class of the query
+   * @param unique
+   * @param ttl
+   * @param localHost
+   * @return collection of answers
+   */
+  public Collection<DNSRecord> answers(
+      DNSRecordClass recordClass, boolean unique, int ttl, HostInfo localHost) {
+    List<DNSRecord> list = new ArrayList<DNSRecord>();
+
+    if ((recordClass == DNSRecordClass.CLASS_ANY) || (recordClass == DNSRecordClass.CLASS_IN)) {
+      if (this.getSubtype().length() > 0) {
+        list.add(
+            new DNSRecord.Pointer(
+                this.getTypeWithSubtype(),
+                DNSRecordClass.CLASS_IN,
+                DNSRecordClass.NOT_UNIQUE,
+                ttl,
+                this.getQualifiedName()));
+      }
+      list.add(
+          new DNSRecord.Pointer(
+              this.getType(),
+              DNSRecordClass.CLASS_IN,
+              DNSRecordClass.NOT_UNIQUE,
+              ttl,
+              this.getQualifiedName()));
+      list.add(
+          new DNSRecord.Service(
+              this.getQualifiedName(),
+              DNSRecordClass.CLASS_IN,
+              unique,
+              ttl,
+              _priority,
+              _weight,
+              _port,
+              localHost.getName()));
+      list.add(
+          new DNSRecord.Text(
+              this.getQualifiedName(), DNSRecordClass.CLASS_IN, unique, ttl, this.getTextBytes()));
+      for (InetAddress address : _ipv4Addresses)
+        list.add(
+            new DNSRecord.IPv4Address(
+                this.getQualifiedName(), DNSRecordClass.CLASS_IN, unique, ttl, address));
+      for (InetAddress address : _ipv6Addresses)
+        list.add(
+            new DNSRecord.IPv6Address(
+                this.getQualifiedName(), DNSRecordClass.CLASS_IN, unique, ttl, address));
     }
 
-    @Override
-    public String getType() {
-        String domain = this.getDomain();
-        String protocol = this.getProtocol();
-        String application = this.getApplication();
-        return (application.length() > 0 ? "_" + application + "." : "") + (protocol.length() > 0 ? "_" + protocol + "." : "") + domain + ".";
-    }
-
-    @Override
-    public String getTypeWithSubtype() {
-        String subtype = this.getSubtype();
-        return (subtype.length() > 0 ? "_" + subtype + "._sub." : "") + this.getType();
-    }
-
-    @Override
-    public String getName() {
-        return (_name != null ? _name : "");
-    }
-
-    @Override
-    public String getKey() {
-        if (this._key == null) {
-            this._key = this.getQualifiedName().toLowerCase();
-        }
-        return this._key;
-    }
-
-    @Override
-    public String getQualifiedName() {
-        String domain = this.getDomain();
-        String protocol = this.getProtocol();
-        String application = this.getApplication();
-        String instance = this.getName();
-        return (instance.length() > 0 ? instance + "." : "") + (application.length() > 0 ? "_" + application + "." : "") + (protocol.length() > 0 ? "_" + protocol + "." : "") + domain + ".";
-    }
-
-    @Override
-    public String getServer() {
-        return (_server != null ? _server : "");
-    }
-    void setServer(String server) {
-        this._server = server;
-    }
-
-    public void addAddress(Inet4Address addr) {
-        _ipv4Addresses.add(addr);
-    }
-    public void addAddress(Inet6Address addr) {
-        _ipv6Addresses.add(addr);
-    }
-
-    @Override
-    public Inet4Address[] getInet4Addresses() {
-        return _ipv4Addresses.toArray(new Inet4Address[_ipv4Addresses.size()]);
-    }
-
-    @Override
-    public Inet6Address[] getInet6Addresses() {
-        return _ipv6Addresses.toArray(new Inet6Address[_ipv6Addresses.size()]);
-    }
-
-    @Override
-    public int getPort() {
-        return _port;
-    }
-
-    @Override
-    public int getPriority() {
-        return _priority;
-    }
-
-    @Override
-    public int getWeight() {
-        return _weight;
-    }
-
-    @Override
-    public byte[] getTextBytes() {
-        return (this._text != null && this._text.length > 0 ? this._text : ByteWrangler.EMPTY_TXT);
-    }
-
-    @Override
-    public String getApplication() {
-        return (_application != null ? _application : "");
-    }
-
-    @Override
-    public String getDomain() {
-        return (_domain != null ? _domain : "local");
-    }
-
-    @Override
-    public String getProtocol() {
-        return (_protocol != null ? _protocol : "tcp");
-    }
-
-    @Override
-    public String getSubtype() {
-        return (_subtype != null ? _subtype : "");
-    }
-
-    @Override
-    public Map<Fields, String> getQualifiedNameMap() {
-        Map<Fields, String> map = new HashMap<Fields, String>(5);
-
-        map.put(Fields.Domain, this.getDomain());
-        map.put(Fields.Protocol, this.getProtocol());
-        map.put(Fields.Application, this.getApplication());
-        map.put(Fields.Instance, this.getName());
-        map.put(Fields.Subtype, this.getSubtype());
-        return map;
-    }
-
-    @Override
-    public synchronized boolean hasData() {
-        return this.getServer() != null && this.hasInetAddress() && this.getTextBytes() != null && this.getTextBytes().length > 0;
-    }
-
-    private boolean hasInetAddress() {
-        return _ipv4Addresses.size() > 0 || _ipv6Addresses.size() > 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return getQualifiedName().hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return (obj instanceof ServiceInfoImpl) && getQualifiedName().equals(((ServiceInfoImpl) obj).getQualifiedName());
-    }
-
-    @Override
-    public ServiceInfoImpl clone() {
-        ServiceInfoImpl serviceInfo = new ServiceInfoImpl(this.getQualifiedNameMap(), _port, _weight, _priority, _text);
-        serviceInfo._ipv6Addresses.addAll(Arrays.asList(getInet6Addresses()));
-        serviceInfo._ipv4Addresses.addAll(Arrays.asList(getInet4Addresses()));
-        serviceInfo._server = _server;
-        return serviceInfo;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append('[').append(this.getClass().getSimpleName()).append('@').append(System.identityHashCode(this));
-        sb.append(" name: '");
-        if (0 < this.getName().length()) {
-            sb.append(this.getName()).append('.');
-        }
-        sb.append(this.getTypeWithSubtype());
-        sb.append("' address: '");
-        Inet4Address[] addresses4 = this.getInet4Addresses();
-        for (InetAddress address : addresses4) {
-            sb.append(address).append(':').append(this.getPort()).append(' ');
-        }
-        Inet6Address[] addresses6 = this.getInet6Addresses();
-        for (InetAddress address : addresses6) {
-            sb.append(address).append(':').append(this.getPort()).append(' ');
-        }
-
-        sb.append(this.hasData() ? " has data" : " has NO data");
-        sb.append(']');
-
-        return sb.toString();
-    }
-
-    /**
-     * Create a series of answer that correspond with the give service info.
-     *
-     * @param recordClass
-     *            record class of the query
-     * @param unique
-     * @param ttl
-     * @param localHost
-     * @return collection of answers
-     */
-    public Collection<DNSRecord> answers(DNSRecordClass recordClass, boolean unique, int ttl, HostInfo localHost) {
-        List<DNSRecord> list = new ArrayList<DNSRecord>();
-
-        if ((recordClass == DNSRecordClass.CLASS_ANY) || (recordClass == DNSRecordClass.CLASS_IN)) {
-            if (this.getSubtype().length() > 0) {
-                list.add(new DNSRecord.Pointer(this.getTypeWithSubtype(), DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE, ttl, this.getQualifiedName()));
-            }
-            list.add(new DNSRecord.Pointer(this.getType(), DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE, ttl, this.getQualifiedName()));
-            list.add(new DNSRecord.Service(this.getQualifiedName(), DNSRecordClass.CLASS_IN, unique, ttl, _priority, _weight, _port, localHost.getName()));
-            list.add(new DNSRecord.Text(this.getQualifiedName(), DNSRecordClass.CLASS_IN, unique, ttl, this.getTextBytes()));
-            for (InetAddress address : _ipv4Addresses)
-                list.add(
-                    new DNSRecord.IPv4Address(
-                            this.getQualifiedName(),
-                            DNSRecordClass.CLASS_IN,
-                            unique,
-                            ttl,
-                            address
-                    )
-                );
-            for (InetAddress address : _ipv6Addresses)
-                list.add(
-                    new DNSRecord.IPv6Address(
-                            this.getQualifiedName(),
-                            DNSRecordClass.CLASS_IN,
-                            unique,
-                            ttl,
-                            address
-                    )
-                );
-        }
-
-        return list;
-    }
+    return list;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/SocketListener.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/SocketListener.java
@@ -4,85 +4,81 @@
 
 package io.libp2p.discovery.mdns.impl;
 
+import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
+import io.libp2p.discovery.mdns.impl.util.NamedThreadFactory;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-
-import io.libp2p.discovery.mdns.impl.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
-
-/**
- * Listen for multicast packets.
- */
+/** Listen for multicast packets. */
 class SocketListener implements Runnable {
-    static Logger logger = LoggerFactory.getLogger(SocketListener.class.getName());
+  static Logger logger = LoggerFactory.getLogger(SocketListener.class.getName());
 
-    private final JmDNSImpl _jmDNSImpl;
-    private final String _name;
-    private volatile boolean _closed;
-    private final ExecutorService _executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("JmDNS"));
-    private Future<Void> _isShutdown;
+  private final JmDNSImpl _jmDNSImpl;
+  private final String _name;
+  private volatile boolean _closed;
+  private final ExecutorService _executor =
+      Executors.newSingleThreadExecutor(new NamedThreadFactory("JmDNS"));
+  private Future<Void> _isShutdown;
 
-    SocketListener(JmDNSImpl jmDNSImpl) {
-        _name = "SocketListener(" + (jmDNSImpl != null ? jmDNSImpl.getName() : "") + ")";
-        this._jmDNSImpl = jmDNSImpl;
-    }
+  SocketListener(JmDNSImpl jmDNSImpl) {
+    _name = "SocketListener(" + (jmDNSImpl != null ? jmDNSImpl.getName() : "") + ")";
+    this._jmDNSImpl = jmDNSImpl;
+  }
 
-    public void start() {
-        _isShutdown = _executor.submit(this, null);
-    }
-    public Future<Void> stop() {
-        _closed = true;
-        _executor.shutdown();
-        return _isShutdown;
-    }
+  public void start() {
+    _isShutdown = _executor.submit(this, null);
+  }
 
-    @Override
-    public void run() {
+  public Future<Void> stop() {
+    _closed = true;
+    _executor.shutdown();
+    return _isShutdown;
+  }
+
+  @Override
+  public void run() {
+    try {
+      byte buf[] = new byte[DNSConstants.MAX_MSG_ABSOLUTE];
+      DatagramPacket packet = new DatagramPacket(buf, buf.length);
+      while (!_closed) {
+        packet.setLength(buf.length);
+        this._jmDNSImpl.getSocket().receive(packet);
+        if (_closed) break;
         try {
-            byte buf[] = new byte[DNSConstants.MAX_MSG_ABSOLUTE];
-            DatagramPacket packet = new DatagramPacket(buf, buf.length);
-            while (!_closed) {
-                packet.setLength(buf.length);
-                this._jmDNSImpl.getSocket().receive(packet);
-                if (_closed)
-                    break;
-                try {
-                    if (this._jmDNSImpl.getLocalHost().shouldIgnorePacket(packet)) {
-                        continue;
-                    }
+          if (this._jmDNSImpl.getLocalHost().shouldIgnorePacket(packet)) {
+            continue;
+          }
 
-                    DNSIncoming msg = new DNSIncoming(packet);
-                    if (msg.isValidResponseCode()) {
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("{}.run() JmDNS in:{}", _name, msg.print(true));
-                        }
-                        if (msg.isQuery()) {
-                            if (packet.getPort() != DNSConstants.MDNS_PORT) {
-                                this._jmDNSImpl.handleQuery(msg, packet.getAddress(), packet.getPort());
-                            }
-                            this._jmDNSImpl.handleQuery(msg, this._jmDNSImpl.getGroup(), DNSConstants.MDNS_PORT);
-                        } else {
-                            this._jmDNSImpl.handleResponse(msg);
-                        }
-                    } else {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("{}.run() JmDNS in message with error code: {}", _name, msg.print(true));
-                        }
-                    }
-                } catch (IOException e) {
-                    logger.warn(_name + ".run() exception ", e);
-                }
+          DNSIncoming msg = new DNSIncoming(packet);
+          if (msg.isValidResponseCode()) {
+            if (logger.isTraceEnabled()) {
+              logger.trace("{}.run() JmDNS in:{}", _name, msg.print(true));
             }
+            if (msg.isQuery()) {
+              if (packet.getPort() != DNSConstants.MDNS_PORT) {
+                this._jmDNSImpl.handleQuery(msg, packet.getAddress(), packet.getPort());
+              }
+              this._jmDNSImpl.handleQuery(msg, this._jmDNSImpl.getGroup(), DNSConstants.MDNS_PORT);
+            } else {
+              this._jmDNSImpl.handleResponse(msg);
+            }
+          } else {
+            if (logger.isDebugEnabled()) {
+              logger.debug("{}.run() JmDNS in message with error code: {}", _name, msg.print(true));
+            }
+          }
         } catch (IOException e) {
-            if (!_closed)
-                logger.warn(_name + ".run() exception ", e);
+          logger.warn(_name + ".run() exception ", e);
         }
-        logger.trace("{}.run() exiting.", _name);
+      }
+    } catch (IOException e) {
+      if (!_closed) logger.warn(_name + ".run() exception ", e);
     }
+    logger.trace("{}.run() exiting.", _name);
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSConstants.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSConstants.java
@@ -10,57 +10,63 @@ package io.libp2p.discovery.mdns.impl.constants;
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Rick Blair
  */
 public final class DNSConstants {
-    // http://www.iana.org/assignments/dns-parameters
+  // http://www.iana.org/assignments/dns-parameters
 
-    // changed to final class - jeffs
-    public static final String MDNS_GROUP                     = "224.0.0.251";
-    public static final String MDNS_GROUP_IPV6                = "FF02::FB";
-    public static final int    MDNS_PORT                      = Integer.getInteger("net.mdns.port", 5353);
-    public static final int    DNS_PORT                       = 53;
-    public static final int    DNS_TTL                        = Integer.getInteger("net.dns.ttl", 60 * 60);                   // default one hour TTL
-    // public static final int DNS_TTL = 120 * 60; // two hour TTL (draft-cheshire-dnsext-multicastdns.txt ch 13)
+  // changed to final class - jeffs
+  public static final String MDNS_GROUP = "224.0.0.251";
+  public static final String MDNS_GROUP_IPV6 = "FF02::FB";
+  public static final int MDNS_PORT = Integer.getInteger("net.mdns.port", 5353);
+  public static final int DNS_PORT = 53;
+  public static final int DNS_TTL =
+      Integer.getInteger("net.dns.ttl", 60 * 60); // default one hour TTL
+  // public static final int DNS_TTL = 120 * 60; // two hour TTL
+  // (draft-cheshire-dnsext-multicastdns.txt ch 13)
 
-    public static final int    MAX_MSG_TYPICAL                = 1460;
-    public static final int    MAX_MSG_ABSOLUTE               = 8972;
+  public static final int MAX_MSG_TYPICAL = 1460;
+  public static final int MAX_MSG_ABSOLUTE = 8972;
 
-    public static final int    FLAGS_QR_MASK                  = 0x8000;                                                       // Query response mask
-    public static final int    FLAGS_QR_QUERY                 = 0x0000;                                                       // Query
-    public static final int    FLAGS_QR_RESPONSE              = 0x8000;                                                       // Response
+  public static final int FLAGS_QR_MASK = 0x8000; // Query response mask
+  public static final int FLAGS_QR_QUERY = 0x0000; // Query
+  public static final int FLAGS_QR_RESPONSE = 0x8000; // Response
 
-    public static final int    FLAGS_OPCODE                   = 0x7800;                                                       // Operation code
-    public static final int    FLAGS_AA                       = 0x0400;                                                       // Authorative answer
-    public static final int    FLAGS_TC                       = 0x0200;                                                       // Truncated
-    public static final int    FLAGS_RD                       = 0x0100;                                                       // Recursion desired
-    public static final int    FLAGS_RA                       = 0x8000;                                                       // Recursion available
+  public static final int FLAGS_OPCODE = 0x7800; // Operation code
+  public static final int FLAGS_AA = 0x0400; // Authorative answer
+  public static final int FLAGS_TC = 0x0200; // Truncated
+  public static final int FLAGS_RD = 0x0100; // Recursion desired
+  public static final int FLAGS_RA = 0x8000; // Recursion available
 
-    public static final int    FLAGS_Z                        = 0x0040;                                                       // Zero
-    public static final int    FLAGS_AD                       = 0x0020;                                                       // Authentic data
-    public static final int    FLAGS_CD                       = 0x0010;                                                       // Checking disabled
-    public static final int    FLAGS_RCODE                    = 0x000F;                                                       // Response code
+  public static final int FLAGS_Z = 0x0040; // Zero
+  public static final int FLAGS_AD = 0x0020; // Authentic data
+  public static final int FLAGS_CD = 0x0010; // Checking disabled
+  public static final int FLAGS_RCODE = 0x000F; // Response code
 
-    // Time Intervals for various functions
+  // Time Intervals for various functions
 
-    public static final int    SHARED_QUERY_TIME              = 20;                                                           // milliseconds before send shared query
-    public static final int    QUERY_WAIT_INTERVAL            = 225;                                                          // milliseconds between query loops.
-    public static final int    PROBE_WAIT_INTERVAL            = 250;                                                          // milliseconds between probe loops.
-    public static final int    RESPONSE_MIN_WAIT_INTERVAL     = 20;                                                           // minimal wait interval for response.
-    public static final int    RESPONSE_MAX_WAIT_INTERVAL     = 115;                                                          // maximal wait interval for response
-    public static final int    PROBE_CONFLICT_INTERVAL        = 1000;                                                         // milliseconds to wait after conflict.
-    public static final int    PROBE_THROTTLE_COUNT           = 10;                                                           // After x tries go 1 time a sec. on probes.
-    public static final int    PROBE_THROTTLE_COUNT_INTERVAL  = 5000;                                                         // We only increment the throttle count, if the previous increment is inside this interval.
-    public static final int    ANNOUNCE_WAIT_INTERVAL         = 1000;                                                         // milliseconds between Announce loops.
-    public static final int    RECORD_REAPER_INTERVAL         = 10000;                                                        // milliseconds between cache cleanups.
-    public static final int    RECORD_EXPIRY_DELAY            = 1;                                                            // This is 1s delay used in ttl and therefore in seconds
-    public static final int    KNOWN_ANSWER_TTL               = 120;
-    public static final int    ANNOUNCED_RENEWAL_TTL_INTERVAL = DNS_TTL * 500;                                                // 50% of the TTL in milliseconds
-    public static final int    FLUSH_RECORD_OLDER_THAN_1_SECOND  = 1;                                                         // rfc6762, section 10.2 Flush outdated cache (older than 1 second)
+  public static final int SHARED_QUERY_TIME = 20; // milliseconds before send shared query
+  public static final int QUERY_WAIT_INTERVAL = 225; // milliseconds between query loops.
+  public static final int PROBE_WAIT_INTERVAL = 250; // milliseconds between probe loops.
+  public static final int RESPONSE_MIN_WAIT_INTERVAL = 20; // minimal wait interval for response.
+  public static final int RESPONSE_MAX_WAIT_INTERVAL = 115; // maximal wait interval for response
+  public static final int PROBE_CONFLICT_INTERVAL = 1000; // milliseconds to wait after conflict.
+  public static final int PROBE_THROTTLE_COUNT = 10; // After x tries go 1 time a sec. on probes.
+  public static final int PROBE_THROTTLE_COUNT_INTERVAL =
+      5000; // We only increment the throttle count, if the previous increment is inside this
+  // interval.
+  public static final int ANNOUNCE_WAIT_INTERVAL = 1000; // milliseconds between Announce loops.
+  public static final int RECORD_REAPER_INTERVAL = 10000; // milliseconds between cache cleanups.
+  public static final int RECORD_EXPIRY_DELAY =
+      1; // This is 1s delay used in ttl and therefore in seconds
+  public static final int KNOWN_ANSWER_TTL = 120;
+  public static final int ANNOUNCED_RENEWAL_TTL_INTERVAL =
+      DNS_TTL * 500; // 50% of the TTL in milliseconds
+  public static final int FLUSH_RECORD_OLDER_THAN_1_SECOND =
+      1; // rfc6762, section 10.2 Flush outdated cache (older than 1 second)
 
-    public static final int    STALE_REFRESH_INCREMENT           = 5;
-    public static final int    STALE_REFRESH_STARTING_PERCENTAGE = 80;
+  public static final int STALE_REFRESH_INCREMENT = 5;
+  public static final int STALE_REFRESH_STARTING_PERCENTAGE = 80;
 
-    public static final long   CLOSE_TIMEOUT                  = ANNOUNCE_WAIT_INTERVAL * 5L;
-    public static final long   SERVICE_INFO_TIMEOUT           = ANNOUNCE_WAIT_INTERVAL * 6L;
+  public static final long CLOSE_TIMEOUT = ANNOUNCE_WAIT_INTERVAL * 5L;
+  public static final long SERVICE_INFO_TIMEOUT = ANNOUNCE_WAIT_INTERVAL * 6L;
 
-    public static final int    NETWORK_CHECK_INTERVAL         = 10 * 1000;                                                    // 10 secondes
-
+  public static final int NETWORK_CHECK_INTERVAL = 10 * 1000; // 10 secondes
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSLabel.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSLabel.java
@@ -1,87 +1,75 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl.constants;
 
 /**
  * DNS label.
- * 
+ *
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Rick Blair
  */
 public enum DNSLabel {
-    /**
-     * This is unallocated.
-     */
-    Unknown("", 0x80),
-    /**
-     * Standard label [RFC 1035]
-     */
-    Standard("standard label", 0x00),
-    /**
-     * Compressed label [RFC 1035]
-     */
-    Compressed("compressed label", 0xC0),
-    /**
-     * Extended label [RFC 2671]
-     */
-    Extended("extended label", 0x40);
+  /** This is unallocated. */
+  Unknown("", 0x80),
+  /** Standard label [RFC 1035] */
+  Standard("standard label", 0x00),
+  /** Compressed label [RFC 1035] */
+  Compressed("compressed label", 0xC0),
+  /** Extended label [RFC 2671] */
+  Extended("extended label", 0x40);
 
-    /**
-     * DNS label types are encoded on the first 2 bits
-     */
-    static final int     LABEL_MASK     = 0xC0;
-    static final int     LABEL_NOT_MASK = 0x3F;
+  /** DNS label types are encoded on the first 2 bits */
+  static final int LABEL_MASK = 0xC0;
 
-    private final String _externalName;
+  static final int LABEL_NOT_MASK = 0x3F;
 
-    private final int    _index;
+  private final String _externalName;
 
-    DNSLabel(String name, int index) {
-        _externalName = name;
-        _index = index;
+  private final int _index;
+
+  DNSLabel(String name, int index) {
+    _externalName = name;
+    _index = index;
+  }
+
+  /**
+   * Return the string representation of this type
+   *
+   * @return String
+   */
+  public String externalName() {
+    return _externalName;
+  }
+
+  /**
+   * Return the numeric value of this type
+   *
+   * @return String
+   */
+  public int indexValue() {
+    return _index;
+  }
+
+  /**
+   * @param index
+   * @return label
+   */
+  public static DNSLabel labelForByte(int index) {
+    int maskedIndex = index & LABEL_MASK;
+    for (DNSLabel aLabel : DNSLabel.values()) {
+      if (aLabel._index == maskedIndex) return aLabel;
     }
+    return Unknown;
+  }
 
-    /**
-     * Return the string representation of this type
-     * 
-     * @return String
-     */
-    public String externalName() {
-        return _externalName;
-    }
+  /**
+   * @param index
+   * @return masked value
+   */
+  public static int labelValue(int index) {
+    return index & LABEL_NOT_MASK;
+  }
 
-    /**
-     * Return the numeric value of this type
-     * 
-     * @return String
-     */
-    public int indexValue() {
-        return _index;
-    }
-
-    /**
-     * @param index
-     * @return label
-     */
-    public static DNSLabel labelForByte(int index) {
-        int maskedIndex = index & LABEL_MASK;
-        for (DNSLabel aLabel : DNSLabel.values()) {
-            if (aLabel._index == maskedIndex) return aLabel;
-        }
-        return Unknown;
-    }
-
-    /**
-     * @param index
-     * @return masked value
-     */
-    public static int labelValue(int index) {
-        return index & LABEL_NOT_MASK;
-    }
-
-    @Override
-    public String toString() {
-        return this.name() + " index " + this.indexValue();
-    }
-
+  @Override
+  public String toString() {
+    return this.name() + " index " + this.indexValue();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSOperationCode.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSOperationCode.java
@@ -1,86 +1,69 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl.constants;
 
 /**
  * DNS operation code.
- * 
+ *
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Rick Blair
  */
 public enum DNSOperationCode {
-    /**
-     * Query [RFC1035]
-     */
-    Query("Query", 0),
-    /**
-     * IQuery (Inverse Query, Obsolete) [RFC3425]
-     */
-    IQuery("Inverse Query", 1),
-    /**
-     * Status [RFC1035]
-     */
-    Status("Status", 2),
-    /**
-     * Unassigned
-     */
-    Unassigned("Unassigned", 3),
-    /**
-     * Notify [RFC1996]
-     */
-    Notify("Notify", 4),
-    /**
-     * Update [RFC2136]
-     */
-    Update("Update", 5);
+  /** Query [RFC1035] */
+  Query("Query", 0),
+  /** IQuery (Inverse Query, Obsolete) [RFC3425] */
+  IQuery("Inverse Query", 1),
+  /** Status [RFC1035] */
+  Status("Status", 2),
+  /** Unassigned */
+  Unassigned("Unassigned", 3),
+  /** Notify [RFC1996] */
+  Notify("Notify", 4),
+  /** Update [RFC2136] */
+  Update("Update", 5);
 
-    /**
-     * DNS RCode types are encoded on the last 4 bits
-     */
-    static final int     OpCode_MASK = 0x7800;
+  /** DNS RCode types are encoded on the last 4 bits */
+  static final int OpCode_MASK = 0x7800;
 
-    private final String _externalName;
+  private final String _externalName;
 
-    private final int    _index;
+  private final int _index;
 
-    DNSOperationCode(String name, int index) {
-        _externalName = name;
-        _index = index;
+  DNSOperationCode(String name, int index) {
+    _externalName = name;
+    _index = index;
+  }
+
+  /**
+   * Return the string representation of this type
+   *
+   * @return String
+   */
+  public String externalName() {
+    return _externalName;
+  }
+
+  /**
+   * Return the numeric value of this type
+   *
+   * @return String
+   */
+  public int indexValue() {
+    return _index;
+  }
+
+  /**
+   * @param flags
+   * @return label
+   */
+  public static DNSOperationCode operationCodeForFlags(int flags) {
+    int maskedIndex = (flags & OpCode_MASK) >> 11;
+    for (DNSOperationCode aCode : DNSOperationCode.values()) {
+      if (aCode._index == maskedIndex) return aCode;
     }
+    return Unassigned;
+  }
 
-    /**
-     * Return the string representation of this type
-     * 
-     * @return String
-     */
-    public String externalName() {
-        return _externalName;
-    }
-
-    /**
-     * Return the numeric value of this type
-     * 
-     * @return String
-     */
-    public int indexValue() {
-        return _index;
-    }
-
-    /**
-     * @param flags
-     * @return label
-     */
-    public static DNSOperationCode operationCodeForFlags(int flags) {
-        int maskedIndex = (flags & OpCode_MASK) >> 11;
-        for (DNSOperationCode aCode : DNSOperationCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
-        }
-        return Unassigned;
-    }
-
-    @Override
-    public String toString() {
-        return this.name() + " index " + this.indexValue();
-    }
-
+  @Override
+  public String toString() {
+    return this.name() + " index " + this.indexValue();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSOptionCode.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSOptionCode.java
@@ -1,78 +1,65 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl.constants;
 
 /**
  * DNS option code.
- * 
+ *
  * @author Arthur van Hoff, Pierre Frisch, Rick Blair
  */
 public enum DNSOptionCode {
 
-    /**
-     * Token
-     */
-    Unknown("Unknown", 65535),
-    /**
-     * Long-Lived Queries Option [http://files.dns-sd.org/draft-sekar-dns-llq.txt]
-     */
-    LLQ("LLQ", 1),
-    /**
-     * Update Leases Option [http://files.dns-sd.org/draft-sekar-dns-ul.txt]
-     */
-    UL("UL", 2),
-    /**
-     * Name Server Identifier Option [RFC5001]
-     */
-    NSID("NSID", 3),
-    /**
-     * Owner Option [draft-cheshire-edns0-owner-option]
-     */
-    Owner("Owner", 4);
+  /** Token */
+  Unknown("Unknown", 65535),
+  /** Long-Lived Queries Option [http://files.dns-sd.org/draft-sekar-dns-llq.txt] */
+  LLQ("LLQ", 1),
+  /** Update Leases Option [http://files.dns-sd.org/draft-sekar-dns-ul.txt] */
+  UL("UL", 2),
+  /** Name Server Identifier Option [RFC5001] */
+  NSID("NSID", 3),
+  /** Owner Option [draft-cheshire-edns0-owner-option] */
+  Owner("Owner", 4);
 
-    private final String _externalName;
+  private final String _externalName;
 
-    private final int    _index;
+  private final int _index;
 
-    DNSOptionCode(String name, int index) {
-        _externalName = name;
-        _index = index;
+  DNSOptionCode(String name, int index) {
+    _externalName = name;
+    _index = index;
+  }
+
+  /**
+   * Return the string representation of this type
+   *
+   * @return String
+   */
+  public String externalName() {
+    return _externalName;
+  }
+
+  /**
+   * Return the numeric value of this type
+   *
+   * @return String
+   */
+  public int indexValue() {
+    return _index;
+  }
+
+  /**
+   * @param optioncode
+   * @return label
+   */
+  public static DNSOptionCode resultCodeForFlags(int optioncode) {
+    int maskedIndex = optioncode;
+    for (DNSOptionCode aCode : DNSOptionCode.values()) {
+      if (aCode._index == maskedIndex) return aCode;
     }
+    return Unknown;
+  }
 
-    /**
-     * Return the string representation of this type
-     * 
-     * @return String
-     */
-    public String externalName() {
-        return _externalName;
-    }
-
-    /**
-     * Return the numeric value of this type
-     * 
-     * @return String
-     */
-    public int indexValue() {
-        return _index;
-    }
-
-    /**
-     * @param optioncode
-     * @return label
-     */
-    public static DNSOptionCode resultCodeForFlags(int optioncode) {
-        int maskedIndex = optioncode;
-        for (DNSOptionCode aCode : DNSOptionCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
-        }
-        return Unknown;
-    }
-
-    @Override
-    public String toString() {
-        return this.name() + " index " + this.indexValue();
-    }
-
+  @Override
+  public String toString() {
+    return this.name() + " index " + this.indexValue();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSRecordClass.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSRecordClass.java
@@ -1,6 +1,4 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl.constants;
 
 import org.slf4j.Logger;
@@ -8,131 +6,112 @@ import org.slf4j.LoggerFactory;
 
 /**
  * DNS Record Class
- * 
+ *
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Rick Blair
  */
 public enum DNSRecordClass {
-    /**
-     *
-     */
-    CLASS_UNKNOWN("?", 0),
-    /**
-     * static final Internet
-     */
-    CLASS_IN("in", 1),
-    /**
-     * CSNET
-     */
-    CLASS_CS("cs", 2),
-    /**
-     * CHAOS
-     */
-    CLASS_CH("ch", 3),
-    /**
-     * Hesiod
-     */
-    CLASS_HS("hs", 4),
-    /**
-     * Used in DNS UPDATE [RFC 2136]
-     */
-    CLASS_NONE("none", 254),
-    /**
-     * Not a DNS class, but a DNS query class, meaning "all classes"
-     */
-    CLASS_ANY("any", 255);
+  /** */
+  CLASS_UNKNOWN("?", 0),
+  /** static final Internet */
+  CLASS_IN("in", 1),
+  /** CSNET */
+  CLASS_CS("cs", 2),
+  /** CHAOS */
+  CLASS_CH("ch", 3),
+  /** Hesiod */
+  CLASS_HS("hs", 4),
+  /** Used in DNS UPDATE [RFC 2136] */
+  CLASS_NONE("none", 254),
+  /** Not a DNS class, but a DNS query class, meaning "all classes" */
+  CLASS_ANY("any", 255);
 
-    private static Logger logger       = LoggerFactory.getLogger(DNSRecordClass.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(DNSRecordClass.class.getName());
 
-    /**
-     * Multicast DNS uses the bottom 15 bits to identify the record class...<br/>
-     * Except for pseudo records like OPT.
-     */
-    public static final int     CLASS_MASK   = 0x7FFF;
+  /**
+   * Multicast DNS uses the bottom 15 bits to identify the record class...<br>
+   * Except for pseudo records like OPT.
+   */
+  public static final int CLASS_MASK = 0x7FFF;
 
-    /**
-     * For answers the top bit indicates that all other cached records are now invalid.<br/>
-     * For questions it indicates that we should send a unicast response.
-     */
-    public static final int     CLASS_UNIQUE = 0x8000;
+  /**
+   * For answers the top bit indicates that all other cached records are now invalid.<br>
+   * For questions it indicates that we should send a unicast response.
+   */
+  public static final int CLASS_UNIQUE = 0x8000;
 
-    /**
-     *
-     */
-    public static final boolean UNIQUE       = true;
+  /** */
+  public static final boolean UNIQUE = true;
 
-    /**
-     *
-     */
-    public static final boolean NOT_UNIQUE   = false;
+  /** */
+  public static final boolean NOT_UNIQUE = false;
 
-    private final String        _externalName;
+  private final String _externalName;
 
-    private final int           _index;
+  private final int _index;
 
-    DNSRecordClass(String name, int index) {
-        _externalName = name;
-        _index = index;
+  DNSRecordClass(String name, int index) {
+    _externalName = name;
+    _index = index;
+  }
+
+  /**
+   * Return the string representation of this type
+   *
+   * @return String
+   */
+  public String externalName() {
+    return _externalName;
+  }
+
+  /**
+   * Return the numeric value of this type
+   *
+   * @return String
+   */
+  public int indexValue() {
+    return _index;
+  }
+
+  /**
+   * Checks if the class is unique
+   *
+   * @param index
+   * @return <code>true</code> is the class is unique, <code>false</code> otherwise.
+   */
+  public boolean isUnique(int index) {
+    return (this != CLASS_UNKNOWN) && ((index & CLASS_UNIQUE) != 0);
+  }
+
+  /**
+   * @param name
+   * @return class for name
+   */
+  public static DNSRecordClass classForName(String name) {
+    if (name != null) {
+      String aName = name.toLowerCase();
+      for (DNSRecordClass aClass : DNSRecordClass.values()) {
+        if (aClass._externalName.equals(aName)) return aClass;
+      }
     }
+    logger.warn("Could not find record class for name: {}", name);
+    return CLASS_UNKNOWN;
+  }
 
-    /**
-     * Return the string representation of this type
-     * 
-     * @return String
-     */
-    public String externalName() {
-        return _externalName;
+  /**
+   * @param index
+   * @return class for name
+   */
+  public static DNSRecordClass classForIndex(int index) {
+    int maskedIndex = index & CLASS_MASK;
+    for (DNSRecordClass aClass : DNSRecordClass.values()) {
+      if (aClass._index == maskedIndex) return aClass;
     }
+    logger.warn("Could not find record class for index: {}", index);
+    return CLASS_UNKNOWN;
+  }
 
-    /**
-     * Return the numeric value of this type
-     * 
-     * @return String
-     */
-    public int indexValue() {
-        return _index;
-    }
-
-    /**
-     * Checks if the class is unique
-     * 
-     * @param index
-     * @return <code>true</code> is the class is unique, <code>false</code> otherwise.
-     */
-    public boolean isUnique(int index) {
-        return (this != CLASS_UNKNOWN) && ((index & CLASS_UNIQUE) != 0);
-    }
-
-    /**
-     * @param name
-     * @return class for name
-     */
-    public static DNSRecordClass classForName(String name) {
-        if (name != null) {
-            String aName = name.toLowerCase();
-            for (DNSRecordClass aClass : DNSRecordClass.values()) {
-                if (aClass._externalName.equals(aName)) return aClass;
-            }
-        }
-        logger.warn("Could not find record class for name: {}", name);
-        return CLASS_UNKNOWN;
-    }
-
-    /**
-     * @param index
-     * @return class for name
-     */
-    public static DNSRecordClass classForIndex(int index) {
-        int maskedIndex = index & CLASS_MASK;
-        for (DNSRecordClass aClass : DNSRecordClass.values()) {
-            if (aClass._index == maskedIndex) return aClass;
-        }
-        logger.warn("Could not find record class for index: {}", index);
-        return CLASS_UNKNOWN;
-    }
-
-    @Override
-    public String toString() {
-        return this.name() + " index " + this.indexValue();
-    }
-
+  @Override
+  public String toString() {
+    return this.name() + " index " + this.indexValue();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSRecordType.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSRecordType.java
@@ -1,6 +1,4 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl.constants;
 
 import org.slf4j.Logger;
@@ -8,306 +6,187 @@ import org.slf4j.LoggerFactory;
 
 /**
  * DNS Record Type
- * 
+ *
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Rick Blair
  */
 public enum DNSRecordType {
-    /**
-     * Address
-     */
-    TYPE_IGNORE("ignore", 0),
-    /**
-     * Address
-     */
-    TYPE_A("a", 1),
-    /**
-     * Name Server
-     */
-    TYPE_NS("ns", 2),
-    /**
-     * Mail Destination
-     */
-    TYPE_MD("md", 3),
-    /**
-     * Mail Forwarder
-     */
-    TYPE_MF("mf", 4),
-    /**
-     * Canonical Name
-     */
-    TYPE_CNAME("cname", 5),
-    /**
-     * Start of Authority
-     */
-    TYPE_SOA("soa", 6),
-    /**
-     * Mailbox
-     */
-    TYPE_MB("mb", 7),
-    /**
-     * Mail Group
-     */
-    TYPE_MG("mg", 8),
-    /**
-     * Mail Rename
-     */
-    TYPE_MR("mr", 9),
-    /**
-     * NULL RR
-     */
-    TYPE_NULL("null", 10),
-    /**
-     * Well-known-service
-     */
-    TYPE_WKS("wks", 11),
-    /**
-     * Domain Name pointer
-     */
-    TYPE_PTR("ptr", 12),
-    /**
-     * Host information
-     */
-    TYPE_HINFO("hinfo", 13),
-    /**
-     * Mailbox information
-     */
-    TYPE_MINFO("minfo", 14),
-    /**
-     * Mail exchanger
-     */
-    TYPE_MX("mx", 15),
-    /**
-     * Arbitrary text string
-     */
-    TYPE_TXT("txt", 16),
-    /**
-     * for Responsible Person [RFC1183]
-     */
-    TYPE_RP("rp", 17),
-    /**
-     * for AFS Data Base location [RFC1183]
-     */
-    TYPE_AFSDB("afsdb", 18),
-    /**
-     * for X.25 PSDN address [RFC1183]
-     */
-    TYPE_X25("x25", 19),
-    /**
-     * for ISDN address [RFC1183]
-     */
-    TYPE_ISDN("isdn", 20),
-    /**
-     * for Route Through [RFC1183]
-     */
-    TYPE_RT("rt", 21),
-    /**
-     * for NSAP address, NSAP style A record [RFC1706]
-     */
-    TYPE_NSAP("nsap", 22),
-    /**
-     *
-     */
-    TYPE_NSAP_PTR("nsap-otr", 23),
-    /**
-     * for security signature [RFC2931]
-     */
-    TYPE_SIG("sig", 24),
-    /**
-     * for security key [RFC2535]
-     */
-    TYPE_KEY("key", 25),
-    /**
-     * X.400 mail mapping information [RFC2163]
-     */
-    TYPE_PX("px", 26),
-    /**
-     * Geographical Position [RFC1712]
-     */
-    TYPE_GPOS("gpos", 27),
-    /**
-     * IP6 Address [Thomson]
-     */
-    TYPE_AAAA("aaaa", 28),
-    /**
-     * Location Information [Vixie]
-     */
-    TYPE_LOC("loc", 29),
-    /**
-     * Next Domain - OBSOLETE [RFC2535, RFC3755]
-     */
-    TYPE_NXT("nxt", 30),
-    /**
-     * Endpoint Identifier [Patton]
-     */
-    TYPE_EID("eid", 31),
-    /**
-     * Nimrod Locator [Patton]
-     */
-    TYPE_NIMLOC("nimloc", 32),
-    /**
-     * Server Selection [RFC2782]
-     */
-    TYPE_SRV("srv", 33),
-    /**
-     * ATM Address [Dobrowski]
-     */
-    TYPE_ATMA("atma", 34),
-    /**
-     * Naming Authority Pointer [RFC2168, RFC2915]
-     */
-    TYPE_NAPTR("naptr", 35),
-    /**
-     * Key Exchanger [RFC2230]
-     */
-    TYPE_KX("kx", 36),
-    /**
-     * CERT [RFC2538]
-     */
-    TYPE_CERT("cert", 37),
-    /**
-     * A6 [RFC2874]
-     */
-    TYPE_A6("a6", 38),
-    /**
-     * DNAME [RFC2672]
-     */
-    TYPE_DNAME("dname", 39),
-    /**
-     * SINK [Eastlake]
-     */
-    TYPE_SINK("sink", 40),
-    /**
-     * OPT [RFC2671]
-     */
-    TYPE_OPT("opt", 41),
-    /**
-     * APL [RFC3123]
-     */
-    TYPE_APL("apl", 42),
-    /**
-     * Delegation Signer [RFC3658]
-     */
-    TYPE_DS("ds", 43),
-    /**
-     * SSH Key Fingerprint [RFC-ietf-secsh-dns-05.txt]
-     */
-    TYPE_SSHFP("sshfp", 44),
-    /**
-     * RRSIG [RFC3755]
-     */
-    TYPE_RRSIG("rrsig", 46),
-    /**
-     * NSEC [RFC3755]
-     */
-    TYPE_NSEC("nsec", 47),
-    /**
-     * DNSKEY [RFC3755]
-     */
-    TYPE_DNSKEY("dnskey", 48),
-    /**
-     * [IANA-Reserved]
-     */
-    TYPE_UINFO("uinfo", 100),
-    /**
-     * [IANA-Reserved]
-     */
-    TYPE_UID("uid", 101),
-    /**
-     * [IANA-Reserved]
-     */
-    TYPE_GID("gid", 102),
-    /**
-     * [IANA-Reserved]
-     */
-    TYPE_UNSPEC("unspec", 103),
-    /**
-     * Transaction Key [RFC2930]
-     */
-    TYPE_TKEY("tkey", 249),
-    /**
-     * Transaction Signature [RFC2845]
-     */
-    TYPE_TSIG("tsig", 250),
-    /**
-     * Incremental transfer [RFC1995]
-     */
-    TYPE_IXFR("ixfr", 251),
-    /**
-     * Transfer of an entire zone [RFC1035]
-     */
-    TYPE_AXFR("axfr", 252),
-    /**
-     * Mailbox-related records (MB, MG or MR) [RFC1035]
-     */
-    TYPE_MAILA("mails", 253),
-    /**
-     * Mail agent RRs (Obsolete - see MX) [RFC1035]
-     */
-    TYPE_MAILB("mailb", 254),
-    /**
-     * Request for all records [RFC1035]
-     */
-    TYPE_ANY("any", 255);
+  /** Address */
+  TYPE_IGNORE("ignore", 0),
+  /** Address */
+  TYPE_A("a", 1),
+  /** Name Server */
+  TYPE_NS("ns", 2),
+  /** Mail Destination */
+  TYPE_MD("md", 3),
+  /** Mail Forwarder */
+  TYPE_MF("mf", 4),
+  /** Canonical Name */
+  TYPE_CNAME("cname", 5),
+  /** Start of Authority */
+  TYPE_SOA("soa", 6),
+  /** Mailbox */
+  TYPE_MB("mb", 7),
+  /** Mail Group */
+  TYPE_MG("mg", 8),
+  /** Mail Rename */
+  TYPE_MR("mr", 9),
+  /** NULL RR */
+  TYPE_NULL("null", 10),
+  /** Well-known-service */
+  TYPE_WKS("wks", 11),
+  /** Domain Name pointer */
+  TYPE_PTR("ptr", 12),
+  /** Host information */
+  TYPE_HINFO("hinfo", 13),
+  /** Mailbox information */
+  TYPE_MINFO("minfo", 14),
+  /** Mail exchanger */
+  TYPE_MX("mx", 15),
+  /** Arbitrary text string */
+  TYPE_TXT("txt", 16),
+  /** for Responsible Person [RFC1183] */
+  TYPE_RP("rp", 17),
+  /** for AFS Data Base location [RFC1183] */
+  TYPE_AFSDB("afsdb", 18),
+  /** for X.25 PSDN address [RFC1183] */
+  TYPE_X25("x25", 19),
+  /** for ISDN address [RFC1183] */
+  TYPE_ISDN("isdn", 20),
+  /** for Route Through [RFC1183] */
+  TYPE_RT("rt", 21),
+  /** for NSAP address, NSAP style A record [RFC1706] */
+  TYPE_NSAP("nsap", 22),
+  /** */
+  TYPE_NSAP_PTR("nsap-otr", 23),
+  /** for security signature [RFC2931] */
+  TYPE_SIG("sig", 24),
+  /** for security key [RFC2535] */
+  TYPE_KEY("key", 25),
+  /** X.400 mail mapping information [RFC2163] */
+  TYPE_PX("px", 26),
+  /** Geographical Position [RFC1712] */
+  TYPE_GPOS("gpos", 27),
+  /** IP6 Address [Thomson] */
+  TYPE_AAAA("aaaa", 28),
+  /** Location Information [Vixie] */
+  TYPE_LOC("loc", 29),
+  /** Next Domain - OBSOLETE [RFC2535, RFC3755] */
+  TYPE_NXT("nxt", 30),
+  /** Endpoint Identifier [Patton] */
+  TYPE_EID("eid", 31),
+  /** Nimrod Locator [Patton] */
+  TYPE_NIMLOC("nimloc", 32),
+  /** Server Selection [RFC2782] */
+  TYPE_SRV("srv", 33),
+  /** ATM Address [Dobrowski] */
+  TYPE_ATMA("atma", 34),
+  /** Naming Authority Pointer [RFC2168, RFC2915] */
+  TYPE_NAPTR("naptr", 35),
+  /** Key Exchanger [RFC2230] */
+  TYPE_KX("kx", 36),
+  /** CERT [RFC2538] */
+  TYPE_CERT("cert", 37),
+  /** A6 [RFC2874] */
+  TYPE_A6("a6", 38),
+  /** DNAME [RFC2672] */
+  TYPE_DNAME("dname", 39),
+  /** SINK [Eastlake] */
+  TYPE_SINK("sink", 40),
+  /** OPT [RFC2671] */
+  TYPE_OPT("opt", 41),
+  /** APL [RFC3123] */
+  TYPE_APL("apl", 42),
+  /** Delegation Signer [RFC3658] */
+  TYPE_DS("ds", 43),
+  /** SSH Key Fingerprint [RFC-ietf-secsh-dns-05.txt] */
+  TYPE_SSHFP("sshfp", 44),
+  /** RRSIG [RFC3755] */
+  TYPE_RRSIG("rrsig", 46),
+  /** NSEC [RFC3755] */
+  TYPE_NSEC("nsec", 47),
+  /** DNSKEY [RFC3755] */
+  TYPE_DNSKEY("dnskey", 48),
+  /** [IANA-Reserved] */
+  TYPE_UINFO("uinfo", 100),
+  /** [IANA-Reserved] */
+  TYPE_UID("uid", 101),
+  /** [IANA-Reserved] */
+  TYPE_GID("gid", 102),
+  /** [IANA-Reserved] */
+  TYPE_UNSPEC("unspec", 103),
+  /** Transaction Key [RFC2930] */
+  TYPE_TKEY("tkey", 249),
+  /** Transaction Signature [RFC2845] */
+  TYPE_TSIG("tsig", 250),
+  /** Incremental transfer [RFC1995] */
+  TYPE_IXFR("ixfr", 251),
+  /** Transfer of an entire zone [RFC1035] */
+  TYPE_AXFR("axfr", 252),
+  /** Mailbox-related records (MB, MG or MR) [RFC1035] */
+  TYPE_MAILA("mails", 253),
+  /** Mail agent RRs (Obsolete - see MX) [RFC1035] */
+  TYPE_MAILB("mailb", 254),
+  /** Request for all records [RFC1035] */
+  TYPE_ANY("any", 255);
 
-    private static Logger logger = LoggerFactory.getLogger(DNSRecordType.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(DNSRecordType.class.getName());
 
-    private final String  _externalName;
+  private final String _externalName;
 
-    private final int     _index;
+  private final int _index;
 
-    DNSRecordType(String name, int index) {
-        _externalName = name;
-        _index = index;
+  DNSRecordType(String name, int index) {
+    _externalName = name;
+    _index = index;
+  }
+
+  /**
+   * Return the string representation of this type
+   *
+   * @return String
+   */
+  public String externalName() {
+    return _externalName;
+  }
+
+  /**
+   * Return the numeric value of this type
+   *
+   * @return String
+   */
+  public int indexValue() {
+    return _index;
+  }
+
+  /**
+   * @param name
+   * @return type for name
+   */
+  public static DNSRecordType typeForName(String name) {
+    if (name != null) {
+      String aName = name.toLowerCase();
+      for (DNSRecordType aType : DNSRecordType.values()) {
+        if (aType._externalName.equals(aName)) return aType;
+      }
     }
+    logger.warn("Could not find record type for name: {}", name);
+    return TYPE_IGNORE;
+  }
 
-    /**
-     * Return the string representation of this type
-     * 
-     * @return String
-     */
-    public String externalName() {
-        return _externalName;
+  /**
+   * @param index
+   * @return type for name
+   */
+  public static DNSRecordType typeForIndex(int index) {
+    for (DNSRecordType aType : DNSRecordType.values()) {
+      if (aType._index == index) return aType;
     }
+    logger.warn("Could not find record type for index: {}", index);
+    return TYPE_IGNORE;
+  }
 
-    /**
-     * Return the numeric value of this type
-     * 
-     * @return String
-     */
-    public int indexValue() {
-        return _index;
-    }
-
-    /**
-     * @param name
-     * @return type for name
-     */
-    public static DNSRecordType typeForName(String name) {
-        if (name != null) {
-            String aName = name.toLowerCase();
-            for (DNSRecordType aType : DNSRecordType.values()) {
-                if (aType._externalName.equals(aName)) return aType;
-            }
-        }
-        logger.warn("Could not find record type for name: {}", name);
-        return TYPE_IGNORE;
-    }
-
-    /**
-     * @param index
-     * @return type for name
-     */
-    public static DNSRecordType typeForIndex(int index) {
-        for (DNSRecordType aType : DNSRecordType.values()) {
-            if (aType._index == index) return aType;
-        }
-        logger.warn("Could not find record type for index: {}", index);
-        return TYPE_IGNORE;
-    }
-
-    @Override
-    public String toString() {
-        return this.name() + " index " + this.indexValue();
-    }
-
+  @Override
+  public String toString() {
+    return this.name() + " index " + this.indexValue();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSResultCode.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSResultCode.java
@@ -1,149 +1,118 @@
-/**
- *
- */
+/** */
 package io.libp2p.discovery.mdns.impl.constants;
 
 /**
  * DNS result code.
- * 
+ *
  * @author Arthur van Hoff, Jeff Sonstein, Werner Randelshofer, Pierre Frisch, Rick Blair
  */
 public enum DNSResultCode {
-    /**
-     * Token
-     */
-    Unknown("Unknown", 65535),
-    /**
-     * No Error [RFC1035]
-     */
-    NoError("No Error", 0),
-    /**
-     * Format Error [RFC1035]
-     */
-    FormErr("Format Error", 1),
-    /**
-     * Server Failure [RFC1035]
-     */
-    ServFail("Server Failure", 2),
-    /**
-     * Non-Existent Domain [RFC1035]
-     */
-    NXDomain("Non-Existent Domain", 3),
-    /**
-     * Not Implemented [RFC1035]
-     */
-    NotImp("Not Implemented", 4),
-    /**
-     * Query Refused [RFC1035]
-     */
-    Refused("Query Refused", 5),
-    /**
-     * Name Exists when it should not [RFC2136]
-     */
-    YXDomain("Name Exists when it should not", 6),
-    /**
-     * RR Set Exists when it should not [RFC2136]
-     */
-    YXRRSet("RR Set Exists when it should not", 7),
-    /**
-     * RR Set that should exist does not [RFC2136]
-     */
-    NXRRSet("RR Set that should exist does not", 8),
-    /**
-     * Server Not Authoritative for zone [RFC2136]]
-     */
-    NotAuth("Server Not Authoritative for zone", 9),
-    /**
-     * Name not contained in zone [RFC2136]
-     */
-    NotZone("NotZone Name not contained in zone", 10),
+  /** Token */
+  Unknown("Unknown", 65535),
+  /** No Error [RFC1035] */
+  NoError("No Error", 0),
+  /** Format Error [RFC1035] */
+  FormErr("Format Error", 1),
+  /** Server Failure [RFC1035] */
+  ServFail("Server Failure", 2),
+  /** Non-Existent Domain [RFC1035] */
+  NXDomain("Non-Existent Domain", 3),
+  /** Not Implemented [RFC1035] */
+  NotImp("Not Implemented", 4),
+  /** Query Refused [RFC1035] */
+  Refused("Query Refused", 5),
+  /** Name Exists when it should not [RFC2136] */
+  YXDomain("Name Exists when it should not", 6),
+  /** RR Set Exists when it should not [RFC2136] */
+  YXRRSet("RR Set Exists when it should not", 7),
+  /** RR Set that should exist does not [RFC2136] */
+  NXRRSet("RR Set that should exist does not", 8),
+  /** Server Not Authoritative for zone [RFC2136]] */
+  NotAuth("Server Not Authoritative for zone", 9),
+  /** Name not contained in zone [RFC2136] */
+  NotZone("NotZone Name not contained in zone", 10),
+  ;
 
-    ;
+  // 0 NoError No Error [RFC1035]
+  // 1 FormErr Format Error [RFC1035]
+  // 2 ServFail Server Failure [RFC1035]
+  // 3 NXDomain Non-Existent Domain [RFC1035]
+  // 4 NotImp Not Implemented [RFC1035]
+  // 5 Refused Query Refused [RFC1035]
+  // 6 YXDomain Name Exists when it should not [RFC2136]
+  // 7 YXRRSet RR Set Exists when it should not [RFC2136]
+  // 8 NXRRSet RR Set that should exist does not [RFC2136]
+  // 9 NotAuth Server Not Authoritative for zone [RFC2136]
+  // 10 NotZone Name not contained in zone [RFC2136]
+  // 11-15 Unassigned
+  // 16 BADVERS Bad OPT Version [RFC2671]
+  // 16 BADSIG TSIG Signature Failure [RFC2845]
+  // 17 BADKEY Key not recognized [RFC2845]
+  // 18 BADTIME Signature out of time window [RFC2845]
+  // 19 BADMODE Bad TKEY Mode [RFC2930]
+  // 20 BADNAME Duplicate key name [RFC2930]
+  // 21 BADALG Algorithm not supported [RFC2930]
+  // 22 BADTRUNC Bad Truncation [RFC4635]
+  // 23-3840 Unassigned
+  // 3841-4095 Reserved for Private Use [RFC5395]
+  // 4096-65534 Unassigned
+  // 65535 Reserved, can be allocated by Standards Action [RFC5395]
 
-    // 0 NoError No Error [RFC1035]
-    // 1 FormErr Format Error [RFC1035]
-    // 2 ServFail Server Failure [RFC1035]
-    // 3 NXDomain Non-Existent Domain [RFC1035]
-    // 4 NotImp Not Implemented [RFC1035]
-    // 5 Refused Query Refused [RFC1035]
-    // 6 YXDomain Name Exists when it should not [RFC2136]
-    // 7 YXRRSet RR Set Exists when it should not [RFC2136]
-    // 8 NXRRSet RR Set that should exist does not [RFC2136]
-    // 9 NotAuth Server Not Authoritative for zone [RFC2136]
-    // 10 NotZone Name not contained in zone [RFC2136]
-    // 11-15 Unassigned
-    // 16 BADVERS Bad OPT Version [RFC2671]
-    // 16 BADSIG TSIG Signature Failure [RFC2845]
-    // 17 BADKEY Key not recognized [RFC2845]
-    // 18 BADTIME Signature out of time window [RFC2845]
-    // 19 BADMODE Bad TKEY Mode [RFC2930]
-    // 20 BADNAME Duplicate key name [RFC2930]
-    // 21 BADALG Algorithm not supported [RFC2930]
-    // 22 BADTRUNC Bad Truncation [RFC4635]
-    // 23-3840 Unassigned
-    // 3841-4095 Reserved for Private Use [RFC5395]
-    // 4096-65534 Unassigned
-    // 65535 Reserved, can be allocated by Standards Action [RFC5395]
+  /** DNS Result Code types are encoded on the last 4 bits */
+  static final int RCode_MASK = 0x0F;
 
-    /**
-     * DNS Result Code types are encoded on the last 4 bits
-     */
-    final static int     RCode_MASK         = 0x0F;
-    /**
-     * DNS Extended Result Code types are encoded on the first 8 bits
-     */
-    final static int     ExtendedRCode_MASK = 0xFF;
+  /** DNS Extended Result Code types are encoded on the first 8 bits */
+  static final int ExtendedRCode_MASK = 0xFF;
 
-    private final String _externalName;
+  private final String _externalName;
 
-    private final int    _index;
+  private final int _index;
 
-    DNSResultCode(String name, int index) {
-        _externalName = name;
-        _index = index;
+  DNSResultCode(String name, int index) {
+    _externalName = name;
+    _index = index;
+  }
+
+  /**
+   * Return the string representation of this type
+   *
+   * @return String
+   */
+  public String externalName() {
+    return _externalName;
+  }
+
+  /**
+   * Return the numeric value of this type
+   *
+   * @return String
+   */
+  public int indexValue() {
+    return _index;
+  }
+
+  /**
+   * @param flags
+   * @return label
+   */
+  public static DNSResultCode resultCodeForFlags(int flags) {
+    int maskedIndex = flags & RCode_MASK;
+    for (DNSResultCode aCode : DNSResultCode.values()) {
+      if (aCode._index == maskedIndex) return aCode;
     }
+    return Unknown;
+  }
 
-    /**
-     * Return the string representation of this type
-     * 
-     * @return String
-     */
-    public String externalName() {
-        return _externalName;
+  public static DNSResultCode resultCodeForFlags(int flags, int extendedRCode) {
+    int maskedIndex = ((extendedRCode >> 28) & ExtendedRCode_MASK) | (flags & RCode_MASK);
+    for (DNSResultCode aCode : DNSResultCode.values()) {
+      if (aCode._index == maskedIndex) return aCode;
     }
+    return Unknown;
+  }
 
-    /**
-     * Return the numeric value of this type
-     * 
-     * @return String
-     */
-    public int indexValue() {
-        return _index;
-    }
-
-    /**
-     * @param flags
-     * @return label
-     */
-    public static DNSResultCode resultCodeForFlags(int flags) {
-        int maskedIndex = flags & RCode_MASK;
-        for (DNSResultCode aCode : DNSResultCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
-        }
-        return Unknown;
-    }
-
-    public static DNSResultCode resultCodeForFlags(int flags, int extendedRCode) {
-        int maskedIndex = ((extendedRCode >> 28) & ExtendedRCode_MASK) | (flags & RCode_MASK);
-        for (DNSResultCode aCode : DNSResultCode.values()) {
-            if (aCode._index == maskedIndex) return aCode;
-        }
-        return Unknown;
-    }
-
-    @Override
-    public String toString() {
-        return this.name() + " index " + this.indexValue();
-    }
-
+  @Override
+  public String toString() {
+    return this.name() + " index " + this.indexValue();
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSState.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/DNSState.java
@@ -11,205 +11,189 @@ package io.libp2p.discovery.mdns.impl.constants;
  */
 public enum DNSState {
 
-    /**
-     *
-     */
-    PROBING_1("probing 1", StateClass.probing),
-    /**
-    *
-    */
-    PROBING_2("probing 2", StateClass.probing),
-    /**
-    *
-    */
-    PROBING_3("probing 3", StateClass.probing),
-    /**
-    *
-    */
-    ANNOUNCING_1("announcing 1", StateClass.announcing),
-    /**
-    *
-    */
-    ANNOUNCING_2("announcing 2", StateClass.announcing),
-    /**
-    *
-    */
-    ANNOUNCED("announced", StateClass.announced),
-    /**
-    *
-    */
-    CANCELING_1("canceling 1", StateClass.canceling),
-    /**
-    *
-    */
-    CANCELING_2("canceling 2", StateClass.canceling),
-    /**
-    *
-    */
-    CANCELING_3("canceling 3", StateClass.canceling),
-    /**
-    *
-    */
-    CANCELED("canceled", StateClass.canceled),
-    /**
-     *
-     */
-    CLOSING("closing", StateClass.closing),
-    /**
-     *
-     */
-    CLOSED("closed", StateClass.closed);
+  /** */
+  PROBING_1("probing 1", StateClass.probing),
+  /** */
+  PROBING_2("probing 2", StateClass.probing),
+  /** */
+  PROBING_3("probing 3", StateClass.probing),
+  /** */
+  ANNOUNCING_1("announcing 1", StateClass.announcing),
+  /** */
+  ANNOUNCING_2("announcing 2", StateClass.announcing),
+  /** */
+  ANNOUNCED("announced", StateClass.announced),
+  /** */
+  CANCELING_1("canceling 1", StateClass.canceling),
+  /** */
+  CANCELING_2("canceling 2", StateClass.canceling),
+  /** */
+  CANCELING_3("canceling 3", StateClass.canceling),
+  /** */
+  CANCELED("canceled", StateClass.canceled),
+  /** */
+  CLOSING("closing", StateClass.closing),
+  /** */
+  CLOSED("closed", StateClass.closed);
 
-    private enum StateClass {
-        probing, announcing, announced, canceling, canceled, closing, closed
+  private enum StateClass {
+    probing,
+    announcing,
+    announced,
+    canceling,
+    canceled,
+    closing,
+    closed
+  }
+
+  // private static Logger logger = LoggerFactory.getLogger(DNSState.class.getName());
+
+  private final String _name;
+
+  private final StateClass _state;
+
+  private DNSState(String name, StateClass state) {
+    _name = name;
+    _state = state;
+  }
+
+  @Override
+  public final String toString() {
+    return _name;
+  }
+
+  /**
+   * Returns the next advanced state.<br>
+   * In general, this advances one step in the following sequence: PROBING_1, PROBING_2, PROBING_3,
+   * ANNOUNCING_1, ANNOUNCING_2, ANNOUNCED.<br>
+   * or CANCELING_1, CANCELING_2, CANCELING_3, CANCELED Does not advance for ANNOUNCED and CANCELED
+   * state.
+   *
+   * @return next state
+   */
+  public final DNSState advance() {
+    switch (this) {
+      case PROBING_1:
+        return PROBING_2;
+      case PROBING_2:
+        return PROBING_3;
+      case PROBING_3:
+        return ANNOUNCING_1;
+      case ANNOUNCING_1:
+        return ANNOUNCING_2;
+      case ANNOUNCING_2:
+        return ANNOUNCED;
+      case ANNOUNCED:
+        return ANNOUNCED;
+      case CANCELING_1:
+        return CANCELING_2;
+      case CANCELING_2:
+        return CANCELING_3;
+      case CANCELING_3:
+        return CANCELED;
+      case CANCELED:
+        return CANCELED;
+      case CLOSING:
+        return CLOSED;
+      case CLOSED:
+        return CLOSED;
+      default:
+        // This is just to keep the compiler happy as we have covered all cases before.
+        return this;
     }
+  }
 
-    // private static Logger logger = LoggerFactory.getLogger(DNSState.class.getName());
-
-    private final String     _name;
-
-    private final StateClass _state;
-
-    private DNSState(String name, StateClass state) {
-        _name = name;
-        _state = state;
+  /**
+   * Returns to the next reverted state. All states except CANCELED revert to PROBING_1. Status
+   * CANCELED does not revert.
+   *
+   * @return reverted state
+   */
+  public final DNSState revert() {
+    switch (this) {
+      case PROBING_1:
+      case PROBING_2:
+      case PROBING_3:
+      case ANNOUNCING_1:
+      case ANNOUNCING_2:
+      case ANNOUNCED:
+        return PROBING_1;
+      case CANCELING_1:
+      case CANCELING_2:
+      case CANCELING_3:
+        return CANCELING_1;
+      case CANCELED:
+        return CANCELED;
+      case CLOSING:
+        return CLOSING;
+      case CLOSED:
+        return CLOSED;
+      default:
+        // This is just to keep the compiler happy as we have covered all cases before.
+        return this;
     }
+  }
 
-    @Override
-    public final String toString() {
-        return _name;
-    }
+  /**
+   * Returns true, if this is a probing state.
+   *
+   * @return <code>true</code> if probing state, <code>false</code> otherwise
+   */
+  public final boolean isProbing() {
+    return _state == StateClass.probing;
+  }
 
-    /**
-     * Returns the next advanced state.<br/>
-     * In general, this advances one step in the following sequence: PROBING_1, PROBING_2, PROBING_3, ANNOUNCING_1, ANNOUNCING_2, ANNOUNCED.<br/>
-     * or CANCELING_1, CANCELING_2, CANCELING_3, CANCELED Does not advance for ANNOUNCED and CANCELED state.
-     *
-     * @return next state
-     */
-    public final DNSState advance() {
-        switch (this) {
-            case PROBING_1:
-                return PROBING_2;
-            case PROBING_2:
-                return PROBING_3;
-            case PROBING_3:
-                return ANNOUNCING_1;
-            case ANNOUNCING_1:
-                return ANNOUNCING_2;
-            case ANNOUNCING_2:
-                return ANNOUNCED;
-            case ANNOUNCED:
-                return ANNOUNCED;
-            case CANCELING_1:
-                return CANCELING_2;
-            case CANCELING_2:
-                return CANCELING_3;
-            case CANCELING_3:
-                return CANCELED;
-            case CANCELED:
-                return CANCELED;
-            case CLOSING:
-                return CLOSED;
-            case CLOSED:
-                return CLOSED;
-            default:
-                // This is just to keep the compiler happy as we have covered all cases before.
-                return this;
-        }
-    }
+  /**
+   * Returns true, if this is an announcing state.
+   *
+   * @return <code>true</code> if announcing state, <code>false</code> otherwise
+   */
+  public final boolean isAnnouncing() {
+    return _state == StateClass.announcing;
+  }
 
-    /**
-     * Returns to the next reverted state. All states except CANCELED revert to PROBING_1. Status CANCELED does not revert.
-     *
-     * @return reverted state
-     */
-    public final DNSState revert() {
-        switch (this) {
-            case PROBING_1:
-            case PROBING_2:
-            case PROBING_3:
-            case ANNOUNCING_1:
-            case ANNOUNCING_2:
-            case ANNOUNCED:
-                return PROBING_1;
-            case CANCELING_1:
-            case CANCELING_2:
-            case CANCELING_3:
-                return CANCELING_1;
-            case CANCELED:
-                return CANCELED;
-            case CLOSING:
-                return CLOSING;
-            case CLOSED:
-                return CLOSED;
-            default:
-                // This is just to keep the compiler happy as we have covered all cases before.
-                return this;
-        }
-    }
+  /**
+   * Returns true, if this is an announced state.
+   *
+   * @return <code>true</code> if announced state, <code>false</code> otherwise
+   */
+  public final boolean isAnnounced() {
+    return _state == StateClass.announced;
+  }
 
-    /**
-     * Returns true, if this is a probing state.
-     *
-     * @return <code>true</code> if probing state, <code>false</code> otherwise
-     */
-    public final boolean isProbing() {
-        return _state == StateClass.probing;
-    }
+  /**
+   * Returns true, if this is a canceling state.
+   *
+   * @return <code>true</code> if canceling state, <code>false</code> otherwise
+   */
+  public final boolean isCanceling() {
+    return _state == StateClass.canceling;
+  }
 
-    /**
-     * Returns true, if this is an announcing state.
-     *
-     * @return <code>true</code> if announcing state, <code>false</code> otherwise
-     */
-    public final boolean isAnnouncing() {
-        return _state == StateClass.announcing;
-    }
+  /**
+   * Returns true, if this is a canceled state.
+   *
+   * @return <code>true</code> if canceled state, <code>false</code> otherwise
+   */
+  public final boolean isCanceled() {
+    return _state == StateClass.canceled;
+  }
 
-    /**
-     * Returns true, if this is an announced state.
-     *
-     * @return <code>true</code> if announced state, <code>false</code> otherwise
-     */
-    public final boolean isAnnounced() {
-        return _state == StateClass.announced;
-    }
+  /**
+   * Returns true, if this is a closing state.
+   *
+   * @return <code>true</code> if closing state, <code>false</code> otherwise
+   */
+  public final boolean isClosing() {
+    return _state == StateClass.closing;
+  }
 
-    /**
-     * Returns true, if this is a canceling state.
-     *
-     * @return <code>true</code> if canceling state, <code>false</code> otherwise
-     */
-    public final boolean isCanceling() {
-        return _state == StateClass.canceling;
-    }
-
-    /**
-     * Returns true, if this is a canceled state.
-     *
-     * @return <code>true</code> if canceled state, <code>false</code> otherwise
-     */
-    public final boolean isCanceled() {
-        return _state == StateClass.canceled;
-    }
-
-    /**
-     * Returns true, if this is a closing state.
-     *
-     * @return <code>true</code> if closing state, <code>false</code> otherwise
-     */
-    public final boolean isClosing() {
-        return _state == StateClass.closing;
-    }
-
-    /**
-     * Returns true, if this is a closing state.
-     *
-     * @return <code>true</code> if closed state, <code>false</code> otherwise
-     */
-    public final boolean isClosed() {
-        return _state == StateClass.closed;
-    }
-
+  /**
+   * Returns true, if this is a closing state.
+   *
+   * @return <code>true</code> if closed state, <code>false</code> otherwise
+   */
+  public final boolean isClosed() {
+    return _state == StateClass.closed;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/package-info.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/constants/package-info.java
@@ -1,2 +1,1 @@
 package io.libp2p.discovery.mdns.impl.constants;
-

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/package-info.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/package-info.java
@@ -1,2 +1,1 @@
 package io.libp2p.discovery.mdns.impl;
-

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/DNSTask.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/DNSTask.java
@@ -4,53 +4,50 @@ package io.libp2p.discovery.mdns.impl.tasks;
 import io.libp2p.discovery.mdns.impl.DNSOutgoing;
 import io.libp2p.discovery.mdns.impl.DNSQuestion;
 import io.libp2p.discovery.mdns.impl.JmDNSImpl;
-
+import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
 import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
-
 public abstract class DNSTask implements Runnable {
-    private final JmDNSImpl _jmDNSImpl;
-    protected final ScheduledExecutorService _scheduler =
-            Executors.newScheduledThreadPool(1);
+  private final JmDNSImpl _jmDNSImpl;
+  protected final ScheduledExecutorService _scheduler = Executors.newScheduledThreadPool(1);
 
-    protected DNSTask(JmDNSImpl jmDNSImpl) {
-        super();
-        this._jmDNSImpl = jmDNSImpl;
+  protected DNSTask(JmDNSImpl jmDNSImpl) {
+    super();
+    this._jmDNSImpl = jmDNSImpl;
+  }
+
+  protected JmDNSImpl dns() {
+    return _jmDNSImpl;
+  }
+
+  public abstract void start();
+
+  protected abstract String getName();
+
+  @Override
+  public String toString() {
+    return this.getName();
+  }
+
+  protected DNSOutgoing addQuestion(DNSOutgoing out, DNSQuestion rec) throws IOException {
+    DNSOutgoing newOut = out;
+    try {
+      newOut.addQuestion(rec);
+    } catch (final IOException e) {
+      int flags = newOut.getFlags();
+      boolean multicast = newOut.isMulticast();
+      int maxUDPPayload = newOut.getMaxUDPPayload();
+      int id = newOut.getId();
+
+      newOut.setFlags(flags | DNSConstants.FLAGS_TC);
+      newOut.setId(id);
+      this._jmDNSImpl.send(newOut);
+
+      newOut = new DNSOutgoing(flags, multicast, maxUDPPayload);
+      newOut.addQuestion(rec);
     }
-
-    protected JmDNSImpl dns() {
-        return _jmDNSImpl;
-    }
-
-    public abstract void start();
-
-    protected abstract String getName();
-
-    @Override
-    public String toString() {
-        return this.getName();
-    }
-
-    protected DNSOutgoing addQuestion(DNSOutgoing out, DNSQuestion rec) throws IOException {
-        DNSOutgoing newOut = out;
-        try {
-            newOut.addQuestion(rec);
-        } catch (final IOException e) {
-            int flags = newOut.getFlags();
-            boolean multicast = newOut.isMulticast();
-            int maxUDPPayload = newOut.getMaxUDPPayload();
-            int id = newOut.getId();
-
-            newOut.setFlags(flags | DNSConstants.FLAGS_TC);
-            newOut.setId(id);
-            this._jmDNSImpl.send(newOut);
-
-            newOut = new DNSOutgoing(flags, multicast, maxUDPPayload);
-            newOut.addQuestion(rec);
-        }
-        return newOut;
-    }
+    return newOut;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/Responder.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/Responder.java
@@ -4,131 +4,131 @@
 
 package io.libp2p.discovery.mdns.impl.tasks;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.libp2p.discovery.mdns.impl.DNSIncoming;
 import io.libp2p.discovery.mdns.impl.DNSOutgoing;
 import io.libp2p.discovery.mdns.impl.DNSQuestion;
 import io.libp2p.discovery.mdns.impl.DNSRecord;
 import io.libp2p.discovery.mdns.impl.JmDNSImpl;
 import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * The Responder sends a single answer for the specified service infos and for the host name.
- */
+/** The Responder sends a single answer for the specified service infos and for the host name. */
 public class Responder extends DNSTask {
-    static Logger logger = LoggerFactory.getLogger(Responder.class.getName());
+  static Logger logger = LoggerFactory.getLogger(Responder.class.getName());
 
-    private final DNSIncoming _in;
+  private final DNSIncoming _in;
 
-    private final InetAddress _addr;
-    private final int         _port;
+  private final InetAddress _addr;
+  private final int _port;
 
-    private final boolean     _unicast;
+  private final boolean _unicast;
 
-    public Responder(JmDNSImpl jmDNSImpl, DNSIncoming in, InetAddress addr, int port) {
-        super(jmDNSImpl);
-        this._in = in;
-        this._addr = addr;
-        this._port = port;
-        this._unicast = (port != DNSConstants.MDNS_PORT);
+  public Responder(JmDNSImpl jmDNSImpl, DNSIncoming in, InetAddress addr, int port) {
+    super(jmDNSImpl);
+    this._in = in;
+    this._addr = addr;
+    this._port = port;
+    this._unicast = (port != DNSConstants.MDNS_PORT);
+  }
+
+  @Override
+  protected String getName() {
+    return "Responder(" + (this.dns() != null ? this.dns().getName() : "") + ")";
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + " incoming: " + _in;
+  }
+
+  @Override
+  public void start() {
+    int delay =
+        DNSConstants.RESPONSE_MIN_WAIT_INTERVAL
+            + JmDNSImpl.getRandom()
+                .nextInt(
+                    DNSConstants.RESPONSE_MAX_WAIT_INTERVAL
+                        - DNSConstants.RESPONSE_MIN_WAIT_INTERVAL
+                        + 1)
+            - _in.elapseSinceArrival();
+    if (delay < 0) {
+      delay = 0;
     }
+    logger.trace("{}.start() Responder chosen delay={}", this.getName(), delay);
 
-    @Override
-    protected String getName() {
-        return "Responder(" + (this.dns() != null ? this.dns().getName() : "") + ")";
-    }
+    _scheduler.schedule(this, delay, TimeUnit.MILLISECONDS);
+  }
 
-    @Override
-    public String toString() {
-        return super.toString() + " incoming: " + _in;
-    }
+  @Override
+  public void run() {
+    // We use these sets to prevent duplicate records
+    Set<DNSQuestion> questions = new HashSet<DNSQuestion>();
+    Set<DNSRecord> answers = new HashSet<DNSRecord>();
 
-    @Override
-    public void start() {
-        int delay =
-                DNSConstants.RESPONSE_MIN_WAIT_INTERVAL +
-                JmDNSImpl.getRandom().nextInt(
-                        DNSConstants.RESPONSE_MAX_WAIT_INTERVAL -
-                              DNSConstants.RESPONSE_MIN_WAIT_INTERVAL + 1
-                ) -
-                _in.elapseSinceArrival();
-        if (delay < 0) {
-            delay = 0;
+    try {
+      // Answer questions
+      for (DNSQuestion question : _in.getQuestions()) {
+        logger.debug("{}.run() JmDNS responding to: {}", this.getName(), question);
+
+        // for unicast responses the question must be included
+        if (_unicast) {
+          questions.add(question);
         }
-        logger.trace("{}.start() Responder chosen delay={}", this.getName(), delay);
 
-        _scheduler.schedule(this, delay, TimeUnit.MILLISECONDS);
-    }
+        question.addAnswers(this.dns(), answers);
+      }
 
-    @Override
-    public void run() {
-        // We use these sets to prevent duplicate records
-        Set<DNSQuestion> questions = new HashSet<DNSQuestion>();
-        Set<DNSRecord> answers = new HashSet<DNSRecord>();
+      // respond if we have answers
+      if (!answers.isEmpty()) {
+        logger.debug("{}.run() JmDNS responding", this.getName());
 
-        try {
-            // Answer questions
-            for (DNSQuestion question : _in.getQuestions()) {
-                logger.debug("{}.run() JmDNS responding to: {}", this.getName(), question);
-
-                // for unicast responses the question must be included
-                if (_unicast) {
-                    questions.add(question);
-                }
-
-                question.addAnswers(this.dns(), answers);
-            }
-
-            // respond if we have answers
-            if (!answers.isEmpty()) {
-                logger.debug("{}.run() JmDNS responding", this.getName());
-
-                DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA, !_unicast, _in.getSenderUDPPayload());
-                if (_unicast) {
-                    out.setDestination(new InetSocketAddress(_addr, _port));
-                }
-                out.setId(_in.getId());
-                for (DNSQuestion question : questions) {
-                    out = this.addQuestion(out, question);
-                }
-                for (DNSRecord answer : answers) {
-                    out = this.addAnswer(out, answer);
-                }
-                if (!out.isEmpty())
-                    this.dns().send(out);
-            }
-        } catch (Throwable e) {
-            logger.warn(this.getName() + "run() exception ", e);
+        DNSOutgoing out =
+            new DNSOutgoing(
+                DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA,
+                !_unicast,
+                _in.getSenderUDPPayload());
+        if (_unicast) {
+          out.setDestination(new InetSocketAddress(_addr, _port));
         }
-        _scheduler.shutdown();
-    }
-
-    private DNSOutgoing addAnswer(DNSOutgoing out, DNSRecord rec) throws IOException {
-        DNSOutgoing newOut = out;
-        try {
-            newOut.addAnswer(rec);
-        } catch (final IOException e) {
-            int flags = newOut.getFlags();
-            boolean multicast = newOut.isMulticast();
-            int maxUDPPayload = newOut.getMaxUDPPayload();
-            int id = newOut.getId();
-
-            newOut.setFlags(flags | DNSConstants.FLAGS_TC);
-            newOut.setId(id);
-            this.dns().send(newOut);
-
-            newOut = new DNSOutgoing(flags, multicast, maxUDPPayload);
-            newOut.addAnswer(rec);
+        out.setId(_in.getId());
+        for (DNSQuestion question : questions) {
+          out = this.addQuestion(out, question);
         }
-        return newOut;
+        for (DNSRecord answer : answers) {
+          out = this.addAnswer(out, answer);
+        }
+        if (!out.isEmpty()) this.dns().send(out);
+      }
+    } catch (Throwable e) {
+      logger.warn(this.getName() + "run() exception ", e);
     }
+    _scheduler.shutdown();
+  }
+
+  private DNSOutgoing addAnswer(DNSOutgoing out, DNSRecord rec) throws IOException {
+    DNSOutgoing newOut = out;
+    try {
+      newOut.addAnswer(rec);
+    } catch (final IOException e) {
+      int flags = newOut.getFlags();
+      boolean multicast = newOut.isMulticast();
+      int maxUDPPayload = newOut.getMaxUDPPayload();
+      int id = newOut.getId();
+
+      newOut.setFlags(flags | DNSConstants.FLAGS_TC);
+      newOut.setId(id);
+      this.dns().send(newOut);
+
+      newOut = new DNSOutgoing(flags, multicast, maxUDPPayload);
+      newOut.addAnswer(rec);
+    }
+    return newOut;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/ServiceResolver.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/ServiceResolver.java
@@ -10,72 +10,73 @@ import io.libp2p.discovery.mdns.impl.JmDNSImpl;
 import io.libp2p.discovery.mdns.impl.constants.DNSConstants;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordClass;
 import io.libp2p.discovery.mdns.impl.constants.DNSRecordType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * The ServiceResolver queries three times consecutively for services of a given type, and then removes itself from the timer.
+ * The ServiceResolver queries three times consecutively for services of a given type, and then
+ * removes itself from the timer.
  */
 public class ServiceResolver extends DNSTask {
-    private static Logger logger = LoggerFactory.getLogger(ServiceResolver.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ServiceResolver.class.getName());
 
-    private final String _type;
-    private final int _queryInterval;
-    private ScheduledFuture<?> _isShutdown;
+  private final String _type;
+  private final int _queryInterval;
+  private ScheduledFuture<?> _isShutdown;
 
-    public ServiceResolver(JmDNSImpl jmDNSImpl, String type, int queryInterval) {
-        super(jmDNSImpl);
-        this._type = type;
-        this._queryInterval = queryInterval;
+  public ServiceResolver(JmDNSImpl jmDNSImpl, String type, int queryInterval) {
+    super(jmDNSImpl);
+    this._type = type;
+    this._queryInterval = queryInterval;
+  }
+
+  @Override
+  protected String getName() {
+    return "ServiceResolver(" + (this.dns() != null ? this.dns().getName() : "") + ")";
+  }
+
+  @Override
+  public void start() {
+    _isShutdown =
+        _scheduler.scheduleAtFixedRate(
+            this, DNSConstants.QUERY_WAIT_INTERVAL, _queryInterval * 1000, TimeUnit.MILLISECONDS);
+  }
+
+  @SuppressWarnings("unchecked")
+  public Future<Void> stop() {
+    _scheduler.shutdown();
+    return (Future<Void>) _isShutdown;
+  }
+
+  @Override
+  public void run() {
+    try {
+      logger.debug("{}.run() JmDNS {}", this.getName(), this.description());
+      DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_QUERY);
+      out = this.addQuestions(out);
+      if (!out.isEmpty()) {
+        this.dns().send(out);
+      }
+    } catch (Throwable e) {
+      logger.warn(this.getName() + ".run() exception ", e);
     }
+  }
 
-    @Override
-    protected String getName() {
-        return "ServiceResolver(" + (this.dns() != null ? this.dns().getName() : "") + ")";
-    }
+  private DNSOutgoing addQuestions(DNSOutgoing out) throws IOException {
+    DNSOutgoing newOut = out;
+    newOut =
+        this.addQuestion(
+            newOut,
+            DNSQuestion.newQuestion(
+                _type, DNSRecordType.TYPE_PTR, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
+    return newOut;
+  }
 
-    @Override
-    public void start() {
-        _isShutdown = _scheduler.scheduleAtFixedRate(
-                this,
-                DNSConstants.QUERY_WAIT_INTERVAL,
-                _queryInterval * 1000,
-                TimeUnit.MILLISECONDS
-        );
-    }
-
-    @SuppressWarnings("unchecked")
-    public Future<Void> stop() {
-        _scheduler.shutdown();
-        return (Future<Void>)_isShutdown;
-    }
-
-    @Override
-    public void run() {
-        try {
-            logger.debug("{}.run() JmDNS {}",this.getName(), this.description());
-            DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_QUERY);
-            out = this.addQuestions(out);
-            if (!out.isEmpty()) {
-                this.dns().send(out);
-            }
-        } catch (Throwable e) {
-            logger.warn(this.getName() + ".run() exception ", e);
-        }
-    }
-
-    private DNSOutgoing addQuestions(DNSOutgoing out) throws IOException {
-        DNSOutgoing newOut = out;
-        newOut = this.addQuestion(newOut, DNSQuestion.newQuestion(_type, DNSRecordType.TYPE_PTR, DNSRecordClass.CLASS_IN, DNSRecordClass.NOT_UNIQUE));
-        return newOut;
-    }
-
-    private String description() {
-        return "querying service";
-    }
+  private String description() {
+    return "querying service";
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/package-info.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/tasks/package-info.java
@@ -1,2 +1,1 @@
 package io.libp2p.discovery.mdns.impl.tasks;
-

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/util/ByteWrangler.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/util/ByteWrangler.java
@@ -5,57 +5,48 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 /**
- * This class contains all the byte shifting 
- * 
- * @author Victor Toni
+ * This class contains all the byte shifting
  *
+ * @author Victor Toni
  */
 public class ByteWrangler {
-    /**
-     * Maximum number of bytes a value can consist of.
-     */
-    public static final int MAX_VALUE_LENGTH = 255;
+  /** Maximum number of bytes a value can consist of. */
+  public static final int MAX_VALUE_LENGTH = 255;
 
-    /**
-     * Maximum number of bytes record data can consist of.
-     * It is {@link #MAX_VALUE_LENGTH} + 1 because the first byte contains the number of the following bytes.
-     */
-    public static final int MAX_DATA_LENGTH = MAX_VALUE_LENGTH + 1;
+  /**
+   * Maximum number of bytes record data can consist of. It is {@link #MAX_VALUE_LENGTH} + 1 because
+   * the first byte contains the number of the following bytes.
+   */
+  public static final int MAX_DATA_LENGTH = MAX_VALUE_LENGTH + 1;
 
-    /**
-     * Representation of no value. A zero length array of bytes.
-     */
-    public static final byte[] NO_VALUE = new byte[0];
+  /** Representation of no value. A zero length array of bytes. */
+  public static final byte[] NO_VALUE = new byte[0];
 
-    /**
-     * Representation of empty text.
-     * The first byte denotes the length of the following character bytes (in this case zero.)
-     *
-     * FIXME: Should this be exported as a method since it could change externally???
-     */
-    public final static byte[] EMPTY_TXT = new byte[] { 0 };
+  /**
+   * Representation of empty text. The first byte denotes the length of the following character
+   * bytes (in this case zero.)
+   *
+   * <p>FIXME: Should this be exported as a method since it could change externally???
+   */
+  public static final byte[] EMPTY_TXT = new byte[] {0};
 
-    /**
-     * Name for charset used to convert Strings to/from wire bytes: {@value #CHARSET_NAME}.
-     */
-    public final static String CHARSET_NAME = "UTF-8";
+  /** Name for charset used to convert Strings to/from wire bytes: {@value #CHARSET_NAME}. */
+  public static final String CHARSET_NAME = "UTF-8";
 
-    /**
-     * Charset used to convert Strings to/from wire bytes: {@value #CHARSET_NAME}.
-     */
-    private final static Charset CHARSET_UTF_8 = Charset.forName(CHARSET_NAME);
+  /** Charset used to convert Strings to/from wire bytes: {@value #CHARSET_NAME}. */
+  private static final Charset CHARSET_UTF_8 = Charset.forName(CHARSET_NAME);
 
-    public static byte[] encodeText(final String text) throws IOException {
-        final byte data[] = text.getBytes(CHARSET_UTF_8);
-        if (data.length > MAX_VALUE_LENGTH) {
-            return EMPTY_TXT;
-        }
-
-        final ByteArrayOutputStream out = new ByteArrayOutputStream(MAX_DATA_LENGTH);
-        out.write((byte) data.length);
-        out.write(data, 0, data.length);
-
-        final byte[] encodedText = out.toByteArray();
-        return encodedText;
+  public static byte[] encodeText(final String text) throws IOException {
+    final byte data[] = text.getBytes(CHARSET_UTF_8);
+    if (data.length > MAX_VALUE_LENGTH) {
+      return EMPTY_TXT;
     }
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream(MAX_DATA_LENGTH);
+    out.write((byte) data.length);
+    out.write(data, 0, data.length);
+
+    final byte[] encodedText = out.toByteArray();
+    return encodedText;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/util/NamedThreadFactory.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/impl/util/NamedThreadFactory.java
@@ -8,28 +8,30 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 /**
- * Custom thread factory which sets the name to make it easier to identify where the pooled threads were created.
+ * Custom thread factory which sets the name to make it easier to identify where the pooled threads
+ * were created.
  *
  * @author Trejkaz, Pierre Frisch
  */
 public class NamedThreadFactory implements ThreadFactory {
-    private final ThreadFactory _delegate;
-    private final String _namePrefix;
+  private final ThreadFactory _delegate;
+  private final String _namePrefix;
 
-    /**
-     * Constructs the thread factory.
-     *
-     * @param namePrefix a prefix to append to thread names (will be separated from the default thread name by a space.)
-     */
-    public NamedThreadFactory(String namePrefix) {
-        this._namePrefix = namePrefix;
-        _delegate = Executors.defaultThreadFactory();
-    }
+  /**
+   * Constructs the thread factory.
+   *
+   * @param namePrefix a prefix to append to thread names (will be separated from the default thread
+   *     name by a space.)
+   */
+  public NamedThreadFactory(String namePrefix) {
+    this._namePrefix = namePrefix;
+    _delegate = Executors.defaultThreadFactory();
+  }
 
-    @Override
-    public Thread newThread(Runnable runnable) {
-        Thread thread = _delegate.newThread(runnable);
-        thread.setName(_namePrefix + ' ' + thread.getName());
-        return thread;
-    }
+  @Override
+  public Thread newThread(Runnable runnable) {
+    Thread thread = _delegate.newThread(runnable);
+    thread.setName(_namePrefix + ' ' + thread.getName());
+    return thread;
+  }
 }

--- a/libp2p/src/main/java/io/libp2p/discovery/mdns/package-info.java
+++ b/libp2p/src/main/java/io/libp2p/discovery/mdns/package-info.java
@@ -3,24 +3,19 @@ package io.libp2p.discovery.mdns;
 /**
  * Java code in this package is derived from the JmDNS project.
  *
- * JmDNS is a Java implementation of multi-cast DNS and can be used for
- * service registration and discovery in local area networks. JmDNS is
- * fully compatible with Apple's Bonjour. The project was originally
- * started in December 2002 by Arthur van Hoff at Strangeberry. In
- * November 2003 the project was moved to SourceForge, and the name
- * was changed from JRendezvous to JmDNS for legal reasons. Many
- * thanks to Stuart Cheshire for help and moral support. In 2014, it was
- * been moved from Sourceforge to Github by Kai Kreuzer with the kind
- * approval from Arthur and Rick.
- * <p>
- * <a href="https://github.com/jmdns/jmdns/">https://github.com/jmdns/jmdns/</a>
- * </p>
+ * <p>JmDNS is a Java implementation of multi-cast DNS and can be used for service registration and
+ * discovery in local area networks. JmDNS is fully compatible with Apple's Bonjour. The project was
+ * originally started in December 2002 by Arthur van Hoff at Strangeberry. In November 2003 the
+ * project was moved to SourceForge, and the name was changed from JRendezvous to JmDNS for legal
+ * reasons. Many thanks to Stuart Cheshire for help and moral support. In 2014, it was been moved
+ * from Sourceforge to Github by Kai Kreuzer with the kind approval from Arthur and Rick.
  *
- * JmDNS was originally licensed under the GNU Lesser General Public
- * License as jRendevous. It was re-released under the
- * Apache License, Version 2.0 in 2005. It is under those terms it is reused here.
- * <p>
- * <a href="https://github.com/jmdns/jmdns/blob/master/NOTICE.txt">JmDNS License Notice</a><br/>
- * <a href="https://github.com/jmdns/jmdns/blob/d15acaf8ad5f11fc6a1dfa597e3e36803a332dbd/CHANGELOG.txt#L214">JmDNS Changelog</a>
- * </p>
- **/
+ * <p><a href="https://github.com/jmdns/jmdns/">https://github.com/jmdns/jmdns/</a> JmDNS was
+ * originally licensed under the GNU Lesser General Public License as jRendevous. It was re-released
+ * under the Apache License, Version 2.0 in 2005. It is under those terms it is reused here.
+ *
+ * <p><a href="https://github.com/jmdns/jmdns/blob/master/NOTICE.txt">JmDNS License Notice</a><br>
+ * <a
+ * href="https://github.com/jmdns/jmdns/blob/d15acaf8ad5f11fc6a1dfa597e3e36803a332dbd/CHANGELOG.txt#L214">JmDNS
+ * Changelog</a>
+ */

--- a/libp2p/src/main/kotlin/io/libp2p/core/Connection.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/Connection.kt
@@ -27,6 +27,7 @@ interface Connection : P2PChannel {
      * Returns the local [Multiaddr] of this [Connection]
      */
     fun localAddress(): Multiaddr
+
     /**
      * Returns the remote [Multiaddr] of this [Connection]
      */

--- a/libp2p/src/main/kotlin/io/libp2p/core/Host.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/Host.kt
@@ -15,14 +15,17 @@ interface Host {
      * Our private key which can be used by different protocols to sign messages
      */
     val privKey: PrivKey
+
     /**
      * Our [PeerId] which is normally derived from [privKey]
      */
     val peerId: PeerId
+
     /**
      * [Network] implementation
      */
     val network: Network
+
     /**
      * [AddressBook] implementation
      */

--- a/libp2p/src/main/kotlin/io/libp2p/core/Libp2pException.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/Libp2pException.kt
@@ -50,6 +50,7 @@ open class NoSuchProtocolException(message: String) : Libp2pException(message)
  * Indicates that the protocol is not registered at local configuration
  */
 class NoSuchLocalProtocolException(message: String) : NoSuchProtocolException(message)
+
 /**
  * Indicates that the protocol is not known by the remote party
  */

--- a/libp2p/src/main/kotlin/io/libp2p/core/crypto/Key.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/crypto/Key.kt
@@ -31,7 +31,7 @@ import java.security.SecureRandom
 import crypto.pb.Crypto.PrivateKey as PbPrivateKey
 import crypto.pb.Crypto.PublicKey as PbPublicKey
 
-enum class KEY_TYPE {
+enum class KeyType {
 
     /**
      * RSA is an enum for the supported RSA key type
@@ -56,7 +56,7 @@ enum class KEY_TYPE {
 
 interface Key {
 
-    val keyType: crypto.pb.Crypto.KeyType
+    val keyType: Crypto.KeyType
 
     /**
      * Bytes returns a serialized, storeable representation of this key.
@@ -124,12 +124,12 @@ abstract class PubKey(override val keyType: Crypto.KeyType) : Key {
  * @param bits the number of bits desired for the key (only applicable for RSA).
  */
 @JvmOverloads
-fun generateKeyPair(type: KEY_TYPE, bits: Int = 2048, random: SecureRandom = SecureRandom()): Pair<PrivKey, PubKey> {
+fun generateKeyPair(type: KeyType, bits: Int = 2048, random: SecureRandom = SecureRandom()): Pair<PrivKey, PubKey> {
     return when (type) {
-        KEY_TYPE.RSA -> generateRsaKeyPair(bits, random)
-        KEY_TYPE.ED25519 -> generateEd25519KeyPair(random)
-        KEY_TYPE.SECP256K1 -> generateSecp256k1KeyPair(random)
-        KEY_TYPE.ECDSA -> generateEcdsaKeyPair(random)
+        KeyType.RSA -> generateRsaKeyPair(bits, random)
+        KeyType.ED25519 -> generateEd25519KeyPair(random)
+        KeyType.SECP256K1 -> generateSecp256k1KeyPair(random)
+        KeyType.ECDSA -> generateEcdsaKeyPair(random)
     }
 }
 

--- a/libp2p/src/main/kotlin/io/libp2p/core/dsl/Builders.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/dsl/Builders.kt
@@ -8,7 +8,7 @@ import io.libp2p.core.ConnectionHandler
 import io.libp2p.core.Host
 import io.libp2p.core.P2PChannel
 import io.libp2p.core.Stream
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.PrivKey
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multiformats.Multiaddr
@@ -219,8 +219,8 @@ class NetworkConfigBuilder {
 class IdentityBuilder {
     var factory: IdentityFactory? = null
 
-    fun random() = random(KEY_TYPE.ECDSA)
-    fun random(keyType: KEY_TYPE): IdentityBuilder = apply { factory = { generateKeyPair(keyType).first } }
+    fun random() = random(KeyType.ECDSA)
+    fun random(keyType: KeyType): IdentityBuilder = apply { factory = { generateKeyPair(keyType).first } }
 }
 
 class AddressBookBuilder {
@@ -241,11 +241,13 @@ class DebugBuilder {
      * Could be primarily useful for security handshake debugging/monitoring
      */
     val beforeSecureHandler = DebugHandlerBuilder<Connection>("wire.sec.before")
+
     /**
      * Injects the [ChannelHandler] right after the connection cipher
      * to handle plain wire messages
      */
     val afterSecureHandler = DebugHandlerBuilder<Connection>("wire.sec.after")
+
     /**
      * Injects the [ChannelHandler] right after the [StreamMuxer] pipeline handler
      * It intercepts [io.libp2p.mux.MuxFrame] instances

--- a/libp2p/src/main/kotlin/io/libp2p/core/multiformats/MultiaddrDns.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/multiformats/MultiaddrDns.kt
@@ -17,18 +17,20 @@ class MultiaddrDns {
         private val dnsProtocols = arrayOf(Protocol.DNS4, Protocol.DNS6, Protocol.DNSADDR)
 
         fun resolve(addr: Multiaddr, resolver: Resolver = DefaultResolver): List<Multiaddr> {
-            if (!addr.hasAny(*dnsProtocols))
+            if (!addr.hasAny(*dnsProtocols)) {
                 return listOf(addr)
+            }
 
             val addressesToResolve = addr.split { isDnsProtocol(it) }
 
             val resolvedAddresses = mutableListOf<List<Multiaddr>>()
             for (address in addressesToResolve) {
                 val toResolve = address.filterComponents(*dnsProtocols).firstOrNull()
-                val resolved = if (toResolve != null)
+                val resolved = if (toResolve != null) {
                     resolve(toResolve.protocol, toResolve.stringValue!!, address, resolver)
-                else
+                } else {
                     listOf(address)
+                }
                 resolvedAddresses.add(resolved)
             }
 
@@ -70,13 +72,14 @@ class MultiaddrDns {
         // * /ip4/1.1.1.2/p2p-circuit/ip4/2.1.1.1
         // * /ip4/1.1.1.2/p2p-circuit/ip4/2.1.1.2
         private fun crossProduct(addressMatrix: List<List<Multiaddr>>): List<Multiaddr> {
-            return if (addressMatrix.size == 1)
+            return if (addressMatrix.size == 1) {
                 addressMatrix[0]
-            else
+            } else {
                 addressMatrix[0].flatMap { parent ->
                     crossProduct(addressMatrix.subList(1, addressMatrix.size))
                         .map { child -> parent.concatenated(child) }
                 }
+            }
         }
 
         private fun isDnsProtocol(proto: Protocol): Boolean {

--- a/libp2p/src/main/kotlin/io/libp2p/core/multiformats/Multihash.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/multiformats/Multihash.kt
@@ -112,6 +112,7 @@ class Multihash(val bytes: ByteBuf, val desc: Descriptor, val lengthBits: Int, v
                 return Multihash(this, desc, lengthBits, digest)
             }
         }
+
         @JvmStatic
         fun digest(desc: Descriptor, content: ByteBuf, lengthBits: Int? = null): Multihash {
             val entry = REGISTRY[desc] ?: throw InvalidMultihashException("Unrecognised multihash descriptor")

--- a/libp2p/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/multiformats/Protocol.kt
@@ -115,8 +115,9 @@ enum class Protocol(
 private const val LENGTH_PREFIXED_VAR_SIZE = -1
 
 private val SIZE_VALIDATOR: (Protocol, ByteArray?) -> Unit = { protocol, bytes ->
-    if (!protocol.hasValue && bytes != null)
+    if (!protocol.hasValue && bytes != null) {
         throw IllegalArgumentException("No value expected for protocol $protocol, but got ${bytes.contentToString()}")
+    }
     if (protocol.hasValue) {
         requireNotNull(bytes) { "Non-null value expected for protocol $protocol" }
         if (protocol.sizeBits != LENGTH_PREFIXED_VAR_SIZE && bytes.size * 8 != protocol.sizeBits) {

--- a/libp2p/src/main/kotlin/io/libp2p/core/multistream/ProtocolMatcher.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/multistream/ProtocolMatcher.kt
@@ -15,10 +15,12 @@ interface ProtocolMatcher {
         fun strict(protocol: ProtocolId) = object : ProtocolMatcher {
             override fun matches(proposed: ProtocolId) = protocol == proposed
         }
+
         @JvmStatic
         fun prefix(protocolPrefix: String) = object : ProtocolMatcher {
             override fun matches(proposed: ProtocolId) = proposed.startsWith(protocolPrefix)
         }
+
         @JvmStatic
         fun list(protocols: Collection<String>) = object : ProtocolMatcher {
             override fun matches(proposed: ProtocolId) = proposed in protocols

--- a/libp2p/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
@@ -173,14 +173,17 @@ interface MessageApi {
      * Message body
      */
     val data: ByteBuf
+
     /**
      * Sender identity. Usually it a [PeerId] derived from the sender's public key
      */
     val from: ByteArray?
+
     /**
      * Sequence id for the sender. A pair [from]` + `[seqId] should be globally unique
      */
     val seqId: Long?
+
     /**
      * A set of message topics
      */

--- a/libp2p/src/main/kotlin/io/libp2p/discovery/MDnsDiscovery.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/discovery/MDnsDiscovery.kt
@@ -105,8 +105,9 @@ class MDnsDiscovery(
                 val aRecords = answers.filter { DNSRecordType.TYPE_A.equals(it.recordType) }
                 val aaaaRecords = answers.filter { DNSRecordType.TYPE_AAAA.equals(it.recordType) }
 
-                if (txtRecord == null || srvRecord == null || aRecords.isEmpty())
+                if (txtRecord == null || srvRecord == null || aRecords.isEmpty()) {
                     return // incomplete answers
+                }
 
                 txtRecord as DNSRecord.Text
                 srvRecord as DNSRecord.Service

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
@@ -61,16 +61,19 @@ fun <C> anyComplete(all: List<CompletableFuture<C>>): CompletableFuture<C> =
     anyComplete(*all.toTypedArray())
 
 fun <C> anyComplete(vararg all: CompletableFuture<C>): CompletableFuture<C> {
-    return if (all.isEmpty()) completedExceptionally(NothingToCompleteException())
-    else object : CompletableFuture<C>() {
-        init {
-            val counter = AtomicInteger(all.size)
-            all.forEach {
-                it.whenComplete { v, t ->
-                    if (t == null) {
-                        complete(v)
-                    } else if (counter.decrementAndGet() == 0) {
-                        completeExceptionally(NonCompleteException(t))
+    return if (all.isEmpty()) {
+        completedExceptionally(NothingToCompleteException())
+    } else {
+        object : CompletableFuture<C>() {
+            init {
+                val counter = AtomicInteger(all.size)
+                all.forEach {
+                    it.whenComplete { v, t ->
+                        if (t == null) {
+                            complete(v)
+                        } else if (counter.decrementAndGet() == 0) {
+                            completeExceptionally(NonCompleteException(t))
+                        }
                     }
                 }
             }

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/Delegates.kt
@@ -39,18 +39,20 @@ fun cappedDouble(
 
 // thanks to https://stackoverflow.com/a/47948047/9630725
 class LazyMutable<T>(val initializer: () -> T, val rejectSetAfterGet: Boolean = false) : ReadWriteProperty<Any?, T> {
-    private object UNINITIALIZED_VALUE
-    private var prop: Any? = UNINITIALIZED_VALUE
+    private object UninitializedValue
+    private var prop: Any? = UninitializedValue
     private var readAccessed = false
 
     @Suppress("UNCHECKED_CAST")
     override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        return if (prop == UNINITIALIZED_VALUE) {
+        return if (prop == UninitializedValue) {
             synchronized(this) {
                 readAccessed = true
-                return if (prop == UNINITIALIZED_VALUE) initializer().also { prop = it } else prop as T
+                return if (prop == UninitializedValue) initializer().also { prop = it } else prop as T
             }
-        } else prop as T
+        } else {
+            prop as T
+        }
     }
 
     override fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/MutableBiMultiMap.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/MutableBiMultiMap.kt
@@ -55,6 +55,7 @@ operator fun <K, V> MutableBiMultiMap<K, V>.minusAssign(key: K) = removeKey(key)
 internal class MutableBiMultiMapImpl<Key, Value> : MutableBiMultiMap<Key, Value> {
     @VisibleForTesting
     internal val keyToValue: MutableMap<Key, Value> = mutableMapOf()
+
     @VisibleForTesting
     internal val valueToKeys: MutableMap<Value, Set<Key>> = mutableMapOf()
 

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -34,6 +34,7 @@ abstract class P2PService(
 ) {
 
     private val peersMutable = mutableListOf<PeerHandler>()
+
     /**
      * List of connected peers.
      * Note that connected peer could not be ready for writing yet, so consider [activePeers]
@@ -42,6 +43,7 @@ abstract class P2PService(
     val peers: List<PeerHandler> = peersMutable
 
     private val activePeersMutable = mutableListOf<PeerHandler>()
+
     /**
      * List of active peers to which data could be written
      */
@@ -241,6 +243,7 @@ abstract class P2PService(
      * Executes the code on the service event thread
      */
     fun <C> submitOnEventThread(run: () -> C): CompletableFuture<C> = CompletableFuture.supplyAsync({ run() }, executor)
+
     /**
      * Executes the code on the service event thread
      */

--- a/libp2p/src/main/kotlin/io/libp2p/multistream/Negotiator.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/multistream/Negotiator.kt
@@ -94,8 +94,11 @@ object Negotiator {
 
         override fun channelRead0(ctx: ChannelHandlerContext, msg: String) {
             if (msg == MULTISTREAM_PROTO) {
-                if (!headerRead) headerRead = true else
+                if (!headerRead) {
+                    headerRead = true
+                } else {
                     throw ProtocolNegotiationException("Received multistream header more than once")
+                }
             } else {
                 processMsg(ctx, msg)?.also { completeEvent ->
                     // first fire event to setup a handler for selected protocol

--- a/libp2p/src/main/kotlin/io/libp2p/multistream/ProtocolSelect.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/multistream/ProtocolSelect.kt
@@ -48,7 +48,8 @@ class ProtocolSelect<TController>(val protocols: List<ProtocolBinding<TControlle
                     ?: throw NoSuchLocalProtocolException("Protocol negotiation failed: not supported protocol ${evt.proto}")
                 ctx.channel().attr(PROTOCOL).get()?.complete(evt.proto)
                 ctx.pipeline().addAfter(
-                    this, "ProtocolBindingInitializer",
+                    this,
+                    "ProtocolBindingInitializer",
                     nettyInitializer {
                         protocolBinding.initChannel(it.channel.getP2PChannel(), evt.proto).forward(selectedFuture)
                     }

--- a/libp2p/src/main/kotlin/io/libp2p/protocol/Ping.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/protocol/Ping.kt
@@ -103,7 +103,8 @@ open class PingProtocol(var pingSize: Int) : ProtocolHandler<PingController>(Lon
                     {
                         requests.remove(dataS)?.second?.completeExceptionally(PingTimeoutException())
                     },
-                    pingTimeout.toMillis(), TimeUnit.MILLISECONDS
+                    pingTimeout.toMillis(),
+                    TimeUnit.MILLISECONDS
                 )
             }
 

--- a/libp2p/src/main/kotlin/io/libp2p/protocol/ProtocolMessageHandlerAdapter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/protocol/ProtocolMessageHandlerAdapter.kt
@@ -54,10 +54,12 @@ class ProtocolMessageHandlerAdapter<TMessage>(
     }
 
     private fun checkedRelease(count: Int, obj: Any) {
-        if (count == -1)
+        if (count == -1) {
             return
+        }
         val rc = obj as ReferenceCounted
-        if (count == rc.refCnt())
+        if (count == rc.refCnt()) {
             rc.release()
+        }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubApiImpl.kt
@@ -81,8 +81,11 @@ open class PubsubApiImpl(val router: PubsubRouter) : PubsubApi {
             it.receiver.apply(rpc2Msg(msg))
         }
         return validationFuts.thenApplyAll {
-            if (it.isEmpty()) ValidationResult.Ignore
-            else it.reduce(validationResultReduce)
+            if (it.isEmpty()) {
+                ValidationResult.Ignore
+            } else {
+                it.reduce(validationResultReduce)
+            }
         }
     }
 
@@ -139,8 +142,10 @@ class MessageImpl(override val originalMessage: PubsubMessage) : MessageApi {
     private val msg = originalMessage.protobufMessage
     override val data = msg.data.toByteArray().toByteBuf()
     override val from = if (msg.hasFrom()) msg.from.toByteArray() else null
-    override val seqId = if (msg.hasSeqno() && msg.seqno.size() >= 8)
+    override val seqId = if (msg.hasSeqno() && msg.seqno.size() >= 8) {
         msg.seqno.toByteArray().copyOfRange(0, 8).toLongBigEndian()
-    else null
+    } else {
+        null
+    }
     override val topics = msg.topicIDsList.map { Topic(it) }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -30,13 +30,14 @@ class Gossip @JvmOverloads constructor(
     }
 
     override val protocolDescriptor =
-        if (router.protocol == PubsubProtocol.Gossip_V_1_1)
+        if (router.protocol == PubsubProtocol.Gossip_V_1_1) {
             ProtocolDescriptor(
                 PubsubProtocol.Gossip_V_1_1.announceStr,
                 PubsubProtocol.Gossip_V_1_0.announceStr
             )
-        else
+        } else {
             ProtocolDescriptor(PubsubProtocol.Gossip_V_1_0.announceStr)
+        }
 
     override fun handleConnection(conn: Connection) {
         conn.muxerSession().createStream(listOf(this))

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -485,7 +485,7 @@ data class GossipTopicScoreParams(
      * The penalty is only activated after [meshMessageDeliveriesActivation] time in the mesh.
      * The weight of the parameter MUST be negative (or zero to disable).
      */
-    val meshMessageDeliveriesWeight: Weight = 0.0 /*-1.0*/, // TODO temporarily exclude this parameter
+    val meshMessageDeliveriesWeight: Weight = 0.0, // TODO temporarily exclude this parameter
     /** @see meshMessageDeliveriesWeight */
     val meshMessageDeliveriesDecay: Double = 0.0,
     /** @see meshMessageDeliveriesWeight */

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -234,7 +234,6 @@ open class GossipRouter(
             curTime <= whitelistEntry.whitelistedTill &&
             whitelistEntry.messagesAccepted < acceptRequestsWhitelistMaxMessages
         ) {
-
             acceptRequestsWhitelist[peer] = whitelistEntry.incrementMessageCount()
             return true
         }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -21,6 +21,7 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
      * Gossip 1.0 variant
      */
     fun addPrune(topic: Topic)
+
     /**
      * Gossip 1.1 variant
      */
@@ -118,7 +119,6 @@ open class DefaultGossipRpcPartsQueue(
                 publishCount > 0 && subscriptionCount > 0 && iHaveCount > 0 &&
                 iWantCount > 0 && graftCount > 0 && pruneCount > 0
             ) {
-
                 val part = parts[partIdx++]
                 when (part) {
                     is PublishPart -> publishCount--

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -91,9 +91,11 @@ class DefaultGossipScore(
             inMesh() && ((curTimeMillis() - joinedMeshTimeMillis).millis > params.meshMessageDeliveriesActivation)
 
         private fun meshMessageDeliveriesDeficit() =
-            if (isMeshMessageDeliveriesActive())
+            if (isMeshMessageDeliveriesActive()) {
                 max(0.0, params.meshMessageDeliveriesThreshold - meshMessageDeliveries)
-            else 0.0
+            } else {
+                0.0
+            }
 
         fun meshMessageDeliveriesDeficitSqr() = meshMessageDeliveriesDeficit().pow(2)
 
@@ -142,8 +144,11 @@ class DefaultGossipScore(
         fun isConnected() = connectedTimeMillis > 0 && disconnectedTimeMillis == 0L
         fun isDisconnected() = disconnectedTimeMillis > 0
         fun getDisconnectDuration() =
-            if (isDisconnected()) (curTimeMillis() - disconnectedTimeMillis).millis
-            else throw IllegalStateException("Peer is not disconnected")
+            if (isDisconnected()) {
+                (curTimeMillis() - disconnectedTimeMillis).millis
+            } else {
+                throw IllegalStateException("Peer is not disconnected")
+            }
     }
 
     val peerParams = params.peerScoreParams
@@ -197,8 +202,11 @@ class DefaultGossipScore(
 
         val behaviorExcess = peerScore.behaviorPenalty - peerParams.behaviourPenaltyThreshold
         val routerPenalty =
-            if (behaviorExcess < 0) 0.0
-            else behaviorExcess.pow(2) * peerParams.behaviourPenaltyWeight
+            if (behaviorExcess < 0) {
+                0.0
+            } else {
+                behaviorExcess.pow(2) * peerParams.behaviourPenaltyWeight
+            }
 
         val computedScore = topicsScore + appScore + ipColocationPenalty + routerPenalty
         peerScore.cachedScore = computedScore

--- a/libp2p/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/noise/NoiseXXSecureChannel.kt
@@ -226,7 +226,6 @@ class NoiseIoHandshake(
     } // sendNoiseStaticKeyAsPayload
 
     private fun sendNoiseMessage(ctx: ChannelHandlerContext, msg: ByteArray? = null) {
-
         val lenMsg = if (!NoiseXXSecureChannel.rustInteroperability) {
             msg
         } else if (msg != null) {

--- a/libp2p/src/main/kotlin/io/libp2p/security/plaintext/PlaintextInsecureChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/plaintext/PlaintextInsecureChannel.kt
@@ -84,14 +84,16 @@ class PlaintextHandshakeHandler(
         val exchangeRecv = Plaintext.Exchange.parser().parseFrom(msg.nioBuffer())
             ?: throw InvalidInitialPacket()
 
-        if (!exchangeRecv.hasPubkey())
+        if (!exchangeRecv.hasPubkey()) {
             throw InvalidRemotePubKey()
+        }
 
         remotePeerId = PeerId(exchangeRecv.id.toByteArray())
         remotePubKey = unmarshalPublicKey(exchangeRecv.pubkey.toByteArray())
         val calculatedPeerId = PeerId.fromPubKey(remotePubKey)
-        if (remotePeerId != calculatedPeerId)
+        if (remotePeerId != calculatedPeerId) {
             throw InvalidRemotePubKey()
+        }
 
         handshakeCompleted(ctx)
     } // channelRead0

--- a/libp2p/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/secio/SecIoCodec.kt
@@ -58,8 +58,9 @@ class SecIoCodec(val local: SecioParams, val remote: SecioParams) : MessageToMes
 
             val macArr = updateMac(remote, cipherBytes)
 
-            if (!macBytes.contentEquals(macArr))
+            if (!macBytes.contentEquals(macArr)) {
                 throw InvalidMacException()
+            }
 
             val clearText = processBytes(remoteCipher, cipherBytes)
             out.add(clearText.toByteBuf())

--- a/libp2p/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/secio/SecIoNegotiator.kt
@@ -140,8 +140,9 @@ class SecIoNegotiator(
         val pubKey = unmarshalPublicKey(remotePubKeyBytes)
 
         val calcedPeerId = PeerId.fromPubKey(pubKey)
-        if (remotePeerId != null && calcedPeerId != remotePeerId)
+        if (remotePeerId != null && calcedPeerId != remotePeerId) {
             throw InvalidRemotePubKey()
+        }
 
         return pubKey
     } // validateRemoteKey
@@ -151,8 +152,9 @@ class SecIoNegotiator(
         val h2 = sha256(localPubKeyBytes + remoteNonce)
 
         val keyOrder = h1.compareTo(h2)
-        if (keyOrder == 0)
+        if (keyOrder == 0) {
             throw SelfConnecting()
+        }
 
         return keyOrder
     } // orderKeys
@@ -203,8 +205,9 @@ class SecIoNegotiator(
             exchangeMsg.signature.toByteArray()
         )
 
-        if (!signatureIsOk)
+        if (!signatureIsOk) {
             throw InvalidSignature()
+        }
     } // validateExchangeMessage
 
     private fun calcHMac(macKey: ByteArray): HMac {
@@ -241,8 +244,9 @@ class SecIoNegotiator(
     } // generateSharedSecret
 
     private fun verifyNonceResponse(buf: ByteBuf) {
-        if (!nonce.contentEquals(buf.toByteArray()))
+        if (!nonce.contentEquals(buf.toByteArray())) {
             throw InvalidInitialPacket()
+        }
 
         state = State.FinalValidated
     } // verifyNonceResponse

--- a/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/tls/TLSSecureChannel.kt
@@ -109,10 +109,11 @@ fun buildTlsHandler(
     val connectionKeys = if (certAlgorithm.equals("ECDSA")) generateEcdsaKeyPair() else generateEd25519KeyPair()
     val javaPrivateKey = getJavaKey(connectionKeys.first)
     val sslContext = (
-        if (ch.isInitiator)
+        if (ch.isInitiator) {
             SslContextBuilder.forClient().keyManager(javaPrivateKey, listOf(buildCert(localKey, connectionKeys.first)))
-        else
+        } else {
             SslContextBuilder.forServer(javaPrivateKey, listOf(buildCert(localKey, connectionKeys.first)))
+        }
         )
         .protocols(listOf("TLSv1.3"))
         .ciphers(listOf("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384", "TLS_CHACHA20_POLY1305_SHA256"))
@@ -133,10 +134,11 @@ fun buildTlsHandler(
     val handshake = handler.handshakeFuture()
     val engine = handler.engine()
     handshake.addListener { fut ->
-        if (! fut.isSuccess) {
+        if (!fut.isSuccess) {
             var cause = fut.cause()
-            if (cause != null && cause.cause != null)
+            if (cause != null && cause.cause != null) {
                 cause = cause.cause
+            }
             handshakeComplete.completeExceptionally(cause)
         } else {
             val nextProtocol = handler.applicationProtocol()
@@ -175,7 +177,7 @@ private class ChannelSetup(
     private var activated = false
 
     override fun channelActive(ctx: ChannelHandlerContext) {
-        if (! activated) {
+        if (!activated) {
             activated = true
             val expectedRemotePeerId = ctx.channel().attr(REMOTE_PEER_ID).get()
             ctx.channel().pipeline().addLast(
@@ -214,11 +216,13 @@ private class ChannelSetup(
 
 class Libp2pTrustManager(private val expectedRemotePeer: Optional<PeerId>) : X509TrustManager {
     override fun checkClientTrusted(certs: Array<out X509Certificate>?, authType: String?) {
-        if (certs?.size != 1)
+        if (certs?.size != 1) {
             throw CertificateException()
+        }
         val claimedPeerId = verifyAndExtractPeerId(arrayOf(certs.get(0)))
-        if (expectedRemotePeer.map { ex -> ! ex.equals(claimedPeerId) }.orElse(false))
+        if (expectedRemotePeer.map { ex -> !ex.equals(claimedPeerId) }.orElse(false)) {
             throw InvalidRemotePubKey()
+        }
     }
 
     override fun checkServerTrusted(certs: Array<out X509Certificate>?, authType: String?) {
@@ -268,14 +272,16 @@ fun getPubKey(pub: PublicKey): PubKey {
     if (pub.algorithm.equals("EC")) {
         return EcdsaPublicKey(pub as ECPublicKey)
     }
-    if (pub.algorithm.equals("RSA"))
+    if (pub.algorithm.equals("RSA")) {
         throw IllegalStateException("Unimplemented RSA public key support for TLS")
+    }
     throw IllegalStateException("Unsupported key type: " + pub.algorithm)
 }
 
 fun verifyAndExtractPeerId(chain: Array<Certificate>): PeerId {
-    if (chain.size != 1)
+    if (chain.size != 1) {
         throw java.lang.IllegalStateException("Cert chain must have exactly 1 element!")
+    }
     val cert = chain.get(0)
     // peerid is in the certificate extension
     val bcCert = org.bouncycastle.asn1.x509.Certificate
@@ -283,29 +289,34 @@ fun verifyAndExtractPeerId(chain: Array<Certificate>): PeerId {
     val bcX509Cert = X509CertificateHolder(bcCert)
     val libp2pOid = ASN1ObjectIdentifier("1.3.6.1.4.1.53594.1.1")
     val extension = bcX509Cert.extensions.getExtension(libp2pOid)
-    if (extension == null)
+    if (extension == null) {
         throw IllegalStateException("Certificate extension not present!")
+    }
     val input = ASN1InputStream(extension.extnValue.encoded)
     val wrapper = input.readObject() as DEROctetString
     val seq = ASN1InputStream(wrapper.octets).readObject() as DLSequence
     val pubKeyProto = (seq.getObjectAt(0) as DEROctetString).octets
     val signature = (seq.getObjectAt(1) as DEROctetString).octets
     val pubKey = unmarshalPublicKey(pubKeyProto)
-    if (! pubKey.verify(certificatePrefix.plus(cert.publicKey.encoded), signature))
+    if (!pubKey.verify(certificatePrefix.plus(cert.publicKey.encoded), signature)) {
         throw IllegalStateException("Invalid signature on TLS certificate extension!")
+    }
 
     cert.verify(cert.publicKey)
     val now = Date()
-    if (bcCert.endDate.date.before(now))
+    if (bcCert.endDate.date.before(now)) {
         throw IllegalStateException("TLS certificate has expired!")
-    if (bcCert.startDate.date.after(now))
+    }
+    if (bcCert.startDate.date.after(now)) {
         throw IllegalStateException("TLS certificate is not valid yet!")
+    }
     return PeerId.fromPubKey(pubKey)
 }
 
 fun getPublicKeyFromCert(chain: Array<Certificate>): PubKey {
-    if (chain.size != 1)
+    if (chain.size != 1) {
         throw java.lang.IllegalStateException("Cert chain must have exactly 1 element!")
+    }
     val cert = chain.get(0)
     return getPubKey(cert.publicKey)
 }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/implementation/ConnectionOverNetty.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/implementation/ConnectionOverNetty.kt
@@ -43,10 +43,11 @@ open class ConnectionOverNetty(
         toMultiaddr(nettyChannel.remoteAddress() as InetSocketAddress)
 
     private fun toMultiaddr(addr: InetSocketAddress): Multiaddr {
-        if (transport is NettyTransport)
+        if (transport is NettyTransport) {
             return transport.toMultiaddr(addr)
-        else
+        } else {
             return toMultiaddrDefault(addr)
+        }
     }
 
     fun toMultiaddrDefault(addr: InetSocketAddress): Multiaddr {

--- a/libp2p/src/main/kotlin/io/libp2p/transport/implementation/NettyTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/implementation/NettyTransport.kt
@@ -129,8 +129,7 @@ abstract class NettyTransport(
             ?: throw Libp2pException("No listeners on address $addr")
     } // unlisten
 
-    override fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?):
-        CompletableFuture<Connection> {
+    override fun dial(addr: Multiaddr, connHandler: ConnectionHandler, preHandler: ChannelVisitor<P2PChannel>?): CompletableFuture<Connection> {
         if (closed) throw Libp2pException("Transport is closed")
 
         val remotePeerId = addr.getPeerId()
@@ -186,8 +185,9 @@ abstract class NettyTransport(
 
     protected fun hostFromMultiaddr(addr: Multiaddr): String {
         val resolvedAddresses = MultiaddrDns.resolve(addr)
-        if (resolvedAddresses.isEmpty())
+        if (resolvedAddresses.isEmpty()) {
             throw Libp2pException("Could not resolve $addr to an IP address")
+        }
 
         return resolvedAddresses[0].components.find {
             it.protocol in arrayOf(Protocol.IP4, Protocol.IP6)

--- a/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
@@ -11,218 +11,214 @@ import io.libp2p.protocol.Ping;
 import io.libp2p.protocol.PingController;
 import io.libp2p.security.tls.*;
 import io.libp2p.transport.tcp.TcpTransport;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import kotlin.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
 public class HostTestJava {
-    @Test
-    void ping() throws Exception {
-/*        HostImpl clientHost = BuildersJKt.hostJ(b -> {
-            b.getIdentity().random();
-            b.getTransports().add(TcpTransport::new);
-            b.getSecureChannels().add(SecIoSecureChannel::new);
-            b.getMuxers().add(MplexStreamMuxer::new);
-            b.getProtocols().add(new Ping());
-            b.getDebug().getMuxFramesHandler().setLogger(LogLevel.ERROR, "host-1-MUX");
-            b.getDebug().getBeforeSecureHandler().setLogger(LogLevel.ERROR, "host-1-BS");
-            b.getDebug().getAfterSecureHandler().setLogger(LogLevel.ERROR, "host-1-AS");
-        });
-*/
-        String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
+  @Test
+  void ping() throws Exception {
+    /*        HostImpl clientHost = BuildersJKt.hostJ(b -> {
+                b.getIdentity().random();
+                b.getTransports().add(TcpTransport::new);
+                b.getSecureChannels().add(SecIoSecureChannel::new);
+                b.getMuxers().add(MplexStreamMuxer::new);
+                b.getProtocols().add(new Ping());
+                b.getDebug().getMuxFramesHandler().setLogger(LogLevel.ERROR, "host-1-MUX");
+                b.getDebug().getBeforeSecureHandler().setLogger(LogLevel.ERROR, "host-1-BS");
+                b.getDebug().getAfterSecureHandler().setLogger(LogLevel.ERROR, "host-1-AS");
+            });
+    */
+    String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
 
-        Host clientHost = new HostBuilder()
-                .transport(TcpTransport::new)
-                .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
-                .muxer(StreamMuxerProtocol::getYamux)
-                .build();
+    Host clientHost =
+        new HostBuilder()
+            .transport(TcpTransport::new)
+            .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
+            .muxer(StreamMuxerProtocol::getYamux)
+            .build();
 
-        Host serverHost = new HostBuilder()
-                .transport(TcpTransport::new)
-                .secureChannel(TlsSecureChannel::new)
-                .muxer(StreamMuxerProtocol::getYamux)
-                .protocol(new Ping())
-                .listen(localListenAddress)
-                .build();
+    Host serverHost =
+        new HostBuilder()
+            .transport(TcpTransport::new)
+            .secureChannel(TlsSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .protocol(new Ping())
+            .listen(localListenAddress)
+            .build();
 
-        CompletableFuture<Void> clientStarted = clientHost.start();
-        CompletableFuture<Void> serverStarted = serverHost.start();
-        clientStarted.get(5, TimeUnit.SECONDS);
-        System.out.println("Client started");
-        serverStarted.get(5, TimeUnit.SECONDS);
-        System.out.println("Server started");
+    CompletableFuture<Void> clientStarted = clientHost.start();
+    CompletableFuture<Void> serverStarted = serverHost.start();
+    clientStarted.get(5, TimeUnit.SECONDS);
+    System.out.println("Client started");
+    serverStarted.get(5, TimeUnit.SECONDS);
+    System.out.println("Server started");
 
-        Assertions.assertEquals(0, clientHost.listenAddresses().size());
-        Assertions.assertEquals(1, serverHost.listenAddresses().size());
-        Assertions.assertEquals(
-                localListenAddress + "/p2p/" + serverHost.getPeerId(),
-                serverHost.listenAddresses().get(0).toString()
-        );
+    Assertions.assertEquals(0, clientHost.listenAddresses().size());
+    Assertions.assertEquals(1, serverHost.listenAddresses().size());
+    Assertions.assertEquals(
+        localListenAddress + "/p2p/" + serverHost.getPeerId(),
+        serverHost.listenAddresses().get(0).toString());
 
-        StreamPromise<PingController> ping =
-                clientHost.getNetwork().connect(
-                        serverHost.getPeerId(),
-                        new Multiaddr(localListenAddress)
-                ).thenApply(
-                        it -> it.muxerSession().createStream(new Ping())
-                )
-                .get(5, TimeUnit.SECONDS);
+    StreamPromise<PingController> ping =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .thenApply(it -> it.muxerSession().createStream(new Ping()))
+            .get(5, TimeUnit.SECONDS);
 
-        Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping stream created");
-        PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping controller created");
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping stream created");
+    PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping controller created");
 
-        for (int i = 0; i < 10; i++) {
-            long latency = pingCtr.ping().get(1, TimeUnit.SECONDS);
-            System.out.println("Ping is " + latency);
-        }
-        pingStream.close().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping stream closed");
-
-        Assertions.assertThrows(ExecutionException.class, () ->
-                pingCtr.ping().get(5, TimeUnit.SECONDS));
-
-        clientHost.stop().get(5, TimeUnit.SECONDS);
-        System.out.println("Client stopped");
-        serverHost.stop().get(5, TimeUnit.SECONDS);
-        System.out.println("Server stopped");
+    for (int i = 0; i < 10; i++) {
+      long latency = pingCtr.ping().get(1, TimeUnit.SECONDS);
+      System.out.println("Ping is " + latency);
     }
+    pingStream.close().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping stream closed");
 
-    @Test
-    void largePing() throws Exception {
-        int pingSize = 200 * 1024;
-        String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
+    Assertions.assertThrows(
+        ExecutionException.class, () -> pingCtr.ping().get(5, TimeUnit.SECONDS));
 
-        Host clientHost = new HostBuilder()
-                .transport(TcpTransport::new)
-                .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
-                .muxer(StreamMuxerProtocol::getYamux)
-                .build();
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    System.out.println("Client stopped");
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+    System.out.println("Server stopped");
+  }
 
-        Host serverHost = new HostBuilder()
-                .transport(TcpTransport::new)
-                .secureChannel(TlsSecureChannel::new)
-                .muxer(StreamMuxerProtocol::getYamux)
-                .protocol(new Ping(pingSize))
-                .listen(localListenAddress)
-                .build();
+  @Test
+  void largePing() throws Exception {
+    int pingSize = 200 * 1024;
+    String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
 
-        CompletableFuture<Void> clientStarted = clientHost.start();
-        CompletableFuture<Void> serverStarted = serverHost.start();
-        clientStarted.get(5, TimeUnit.SECONDS);
-        System.out.println("Client started");
-        serverStarted.get(5, TimeUnit.SECONDS);
-        System.out.println("Server started");
+    Host clientHost =
+        new HostBuilder()
+            .transport(TcpTransport::new)
+            .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
+            .muxer(StreamMuxerProtocol::getYamux)
+            .build();
 
-        Assertions.assertEquals(0, clientHost.listenAddresses().size());
-        Assertions.assertEquals(1, serverHost.listenAddresses().size());
-        Assertions.assertEquals(
-                localListenAddress + "/p2p/" + serverHost.getPeerId(),
-                serverHost.listenAddresses().get(0).toString()
-        );
+    Host serverHost =
+        new HostBuilder()
+            .transport(TcpTransport::new)
+            .secureChannel(TlsSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .protocol(new Ping(pingSize))
+            .listen(localListenAddress)
+            .build();
 
-        StreamPromise<PingController> ping =
-                clientHost.getNetwork().connect(
-                                serverHost.getPeerId(),
-                                new Multiaddr(localListenAddress)
-                        ).thenApply(
-                                it -> it.muxerSession().createStream(new Ping(pingSize))
-                        )
-                        .join();
+    CompletableFuture<Void> clientStarted = clientHost.start();
+    CompletableFuture<Void> serverStarted = serverHost.start();
+    clientStarted.get(5, TimeUnit.SECONDS);
+    System.out.println("Client started");
+    serverStarted.get(5, TimeUnit.SECONDS);
+    System.out.println("Server started");
 
-        Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping stream created");
-        PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping controller created");
+    Assertions.assertEquals(0, clientHost.listenAddresses().size());
+    Assertions.assertEquals(1, serverHost.listenAddresses().size());
+    Assertions.assertEquals(
+        localListenAddress + "/p2p/" + serverHost.getPeerId(),
+        serverHost.listenAddresses().get(0).toString());
 
-        for (int i = 0; i < 10; i++) {
-            long latency = pingCtr.ping().join();//get(5, TimeUnit.SECONDS);
-            System.out.println("Ping is " + latency);
-        }
-        pingStream.close().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping stream closed");
+    StreamPromise<PingController> ping =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .thenApply(it -> it.muxerSession().createStream(new Ping(pingSize)))
+            .join();
 
-        Assertions.assertThrows(ExecutionException.class, () ->
-                pingCtr.ping().get(5, TimeUnit.SECONDS));
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping stream created");
+    PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping controller created");
 
-        clientHost.stop().get(5, TimeUnit.SECONDS);
-        System.out.println("Client stopped");
-        serverHost.stop().get(5, TimeUnit.SECONDS);
-        System.out.println("Server stopped");
+    for (int i = 0; i < 10; i++) {
+      long latency = pingCtr.ping().join(); // get(5, TimeUnit.SECONDS);
+      System.out.println("Ping is " + latency);
     }
+    pingStream.close().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping stream closed");
 
-    @Test
-    void addPingAfterHostStart() throws Exception {
-        String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
+    Assertions.assertThrows(
+        ExecutionException.class, () -> pingCtr.ping().get(5, TimeUnit.SECONDS));
 
-        Host clientHost = new HostBuilder()
-                .transport(TcpTransport::new)
-                .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
-                .muxer(StreamMuxerProtocol::getYamux)
-                .build();
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    System.out.println("Client stopped");
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+    System.out.println("Server stopped");
+  }
 
-        Host serverHost = new HostBuilder()
-                .transport(TcpTransport::new)
-                .secureChannel(TlsSecureChannel::new)
-                .muxer(StreamMuxerProtocol::getYamux)
-                .listen(localListenAddress)
-                .build();
+  @Test
+  void addPingAfterHostStart() throws Exception {
+    String localListenAddress = "/ip4/127.0.0.1/tcp/40002";
 
-        CompletableFuture<Void> clientStarted = clientHost.start();
-        CompletableFuture<Void> serverStarted = serverHost.start();
-        clientStarted.get(5, TimeUnit.SECONDS);
-        System.out.println("Client started");
-        serverStarted.get(5, TimeUnit.SECONDS);
-        System.out.println("Server started");
+    Host clientHost =
+        new HostBuilder()
+            .transport(TcpTransport::new)
+            .secureChannel((k, m) -> new TlsSecureChannel(k, m, "ECDSA"))
+            .muxer(StreamMuxerProtocol::getYamux)
+            .build();
 
-        Assertions.assertEquals(0, clientHost.listenAddresses().size());
-        Assertions.assertEquals(1, serverHost.listenAddresses().size());
-        Assertions.assertEquals(
-                localListenAddress + "/p2p/" + serverHost.getPeerId(),
-                serverHost.listenAddresses().get(0).toString()
-        );
+    Host serverHost =
+        new HostBuilder()
+            .transport(TcpTransport::new)
+            .secureChannel(TlsSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .listen(localListenAddress)
+            .build();
 
-        serverHost.addProtocolHandler(new Ping());
+    CompletableFuture<Void> clientStarted = clientHost.start();
+    CompletableFuture<Void> serverStarted = serverHost.start();
+    clientStarted.get(5, TimeUnit.SECONDS);
+    System.out.println("Client started");
+    serverStarted.get(5, TimeUnit.SECONDS);
+    System.out.println("Server started");
 
-        StreamPromise<PingController> ping =
-                clientHost.getNetwork().connect(
-                                serverHost.getPeerId(),
-                                new Multiaddr(localListenAddress)
-                        ).thenApply(
-                                it -> it.muxerSession().createStream(new Ping())
-                        )
-                        .get(5, TimeUnit.SECONDS);
+    Assertions.assertEquals(0, clientHost.listenAddresses().size());
+    Assertions.assertEquals(1, serverHost.listenAddresses().size());
+    Assertions.assertEquals(
+        localListenAddress + "/p2p/" + serverHost.getPeerId(),
+        serverHost.listenAddresses().get(0).toString());
 
-        Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping stream created");
-        PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping controller created");
+    serverHost.addProtocolHandler(new Ping());
 
-        for (int i = 0; i < 10; i++) {
-            long latency = pingCtr.ping().get(1, TimeUnit.SECONDS);
-            System.out.println("Ping is " + latency);
-        }
-        pingStream.close().get(5, TimeUnit.SECONDS);
-        System.out.println("Ping stream closed");
+    StreamPromise<PingController> ping =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .thenApply(it -> it.muxerSession().createStream(new Ping()))
+            .get(5, TimeUnit.SECONDS);
 
-        Assertions.assertThrows(ExecutionException.class, () ->
-                pingCtr.ping().get(5, TimeUnit.SECONDS));
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping stream created");
+    PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping controller created");
 
-        clientHost.stop().get(5, TimeUnit.SECONDS);
-        System.out.println("Client stopped");
-        serverHost.stop().get(5, TimeUnit.SECONDS);
-        System.out.println("Server stopped");
+    for (int i = 0; i < 10; i++) {
+      long latency = pingCtr.ping().get(1, TimeUnit.SECONDS);
+      System.out.println("Ping is " + latency);
     }
+    pingStream.close().get(5, TimeUnit.SECONDS);
+    System.out.println("Ping stream closed");
 
-    @Test
-    void keyPairGeneration() {
-        Pair<PrivKey, PubKey> pair = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1);
-        PeerId peerId = PeerId.fromPubKey(pair.component2());
-        System.out.println("PeerId: " + peerId.toHex());
-    }
+    Assertions.assertThrows(
+        ExecutionException.class, () -> pingCtr.ping().get(5, TimeUnit.SECONDS));
+
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    System.out.println("Client stopped");
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+    System.out.println("Server stopped");
+  }
+
+  @Test
+  void keyPairGeneration() {
+    Pair<PrivKey, PubKey> pair = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1);
+    PeerId peerId = PeerId.fromPubKey(pair.component2());
+    System.out.println("PeerId: " + peerId.toHex());
+  }
 }

--- a/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/HostTestJava.java
@@ -1,7 +1,7 @@
 package io.libp2p.core;
 
-import io.libp2p.core.crypto.KEY_TYPE;
 import io.libp2p.core.crypto.KeyKt;
+import io.libp2p.core.crypto.KeyType;
 import io.libp2p.core.crypto.PrivKey;
 import io.libp2p.core.crypto.PubKey;
 import io.libp2p.core.dsl.HostBuilder;
@@ -217,7 +217,7 @@ public class HostTestJava {
 
   @Test
   void keyPairGeneration() {
-    Pair<PrivKey, PubKey> pair = KeyKt.generateKeyPair(KEY_TYPE.SECP256K1);
+    Pair<PrivKey, PubKey> pair = KeyKt.generateKeyPair(KeyType.SECP256K1);
     PeerId peerId = PeerId.fromPubKey(pair.component2());
     System.out.println("PeerId: " + peerId.toHex());
   }

--- a/libp2p/src/test/java/io/libp2p/pubsub/GossipApiTest.java
+++ b/libp2p/src/test/java/io/libp2p/pubsub/GossipApiTest.java
@@ -1,5 +1,8 @@
 package io.libp2p.pubsub;
 
+import static io.libp2p.tools.StubsKt.peerHandlerStub;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.protobuf.ByteString;
 import io.libp2p.core.pubsub.ValidationResult;
 import io.libp2p.etc.types.WBytes;
@@ -8,123 +11,120 @@ import io.libp2p.pubsub.gossip.GossipParams;
 import io.libp2p.pubsub.gossip.GossipParamsKt;
 import io.libp2p.pubsub.gossip.GossipRouter;
 import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Test;
-import pubsub.pb.Rpc;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-
-import static io.libp2p.tools.StubsKt.peerHandlerStub;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import pubsub.pb.Rpc;
 
 public class GossipApiTest {
 
-    @Test
-    public void createGossipTest() {
-        GossipParams gossipParams = GossipParams.builder()
-                .D(10)
-                .DHigh(20)
-                .build();
-        GossipRouterBuilder routerBuilder = new GossipRouterBuilder();
-        routerBuilder.setParams(gossipParams);
-        GossipRouter router = routerBuilder.build();
-        assertThat(router.getParams().getD()).isEqualTo(10);
-        assertThat(router.getParams().getDHigh()).isEqualTo(20);
-        assertThat(router.getParams().getDScore()).isEqualTo(GossipParamsKt.defaultDScore(10));
-    }
+  @Test
+  public void createGossipTest() {
+    GossipParams gossipParams = GossipParams.builder().D(10).DHigh(20).build();
+    GossipRouterBuilder routerBuilder = new GossipRouterBuilder();
+    routerBuilder.setParams(gossipParams);
+    GossipRouter router = routerBuilder.build();
+    assertThat(router.getParams().getD()).isEqualTo(10);
+    assertThat(router.getParams().getDHigh()).isEqualTo(20);
+    assertThat(router.getParams().getDScore()).isEqualTo(GossipParamsKt.defaultDScore(10));
+  }
 
-    @Test
-    public void testFastMessageId() throws Exception {
-        List<TestPubsubMessage> createdMessages = new ArrayList<>();
+  @Test
+  public void testFastMessageId() throws Exception {
+    List<TestPubsubMessage> createdMessages = new ArrayList<>();
 
-        GossipRouterBuilder routerBuilder = new GossipRouterBuilder();
-        routerBuilder.setSeenCache(new FastIdSeenCache<>(msg -> msg.getProtobufMessage().getData()));
-        routerBuilder.setMessageFactory(m -> {
-            TestPubsubMessage message = new TestPubsubMessage(m);
-            createdMessages.add(message);
-            return message;
+    GossipRouterBuilder routerBuilder = new GossipRouterBuilder();
+    routerBuilder.setSeenCache(new FastIdSeenCache<>(msg -> msg.getProtobufMessage().getData()));
+    routerBuilder.setMessageFactory(
+        m -> {
+          TestPubsubMessage message = new TestPubsubMessage(m);
+          createdMessages.add(message);
+          return message;
         });
-        GossipRouter router = routerBuilder.build();
-        router.subscribe("topic");
+    GossipRouter router = routerBuilder.build();
+    router.subscribe("topic");
 
-        BlockingQueue<PubsubMessage> messages = new LinkedBlockingQueue<>();
-        router.initHandler(m -> {
-            messages.add(m);
-            return CompletableFuture.completedFuture(ValidationResult.Valid);
+    BlockingQueue<PubsubMessage> messages = new LinkedBlockingQueue<>();
+    router.initHandler(
+        m -> {
+          messages.add(m);
+          return CompletableFuture.completedFuture(ValidationResult.Valid);
         });
 
-        P2PService.PeerHandler peerHandler = peerHandlerStub(router);
+    P2PService.PeerHandler peerHandler = peerHandlerStub(router);
 
-        router.runOnEventThread(() -> router.onInbound(peerHandler, newMessage("Hello-1")));
-        TestPubsubMessage message1 = (TestPubsubMessage) messages.poll(1, TimeUnit.SECONDS);
+    router.runOnEventThread(() -> router.onInbound(peerHandler, newMessage("Hello-1")));
+    TestPubsubMessage message1 = (TestPubsubMessage) messages.poll(1, TimeUnit.SECONDS);
 
-        assertThat(message1).isNotNull();
-        assertThat(message1.canonicalId).isNotNull();
-        assertThat(createdMessages.size()).isEqualTo(1);
-        createdMessages.clear();
+    assertThat(message1).isNotNull();
+    assertThat(message1.canonicalId).isNotNull();
+    assertThat(createdMessages.size()).isEqualTo(1);
+    createdMessages.clear();
 
-        router.runOnEventThread(() -> router.onInbound(peerHandler, newMessage("Hello-1")));
-        TestPubsubMessage message2 = (TestPubsubMessage) messages.poll(100, TimeUnit.MILLISECONDS);
+    router.runOnEventThread(() -> router.onInbound(peerHandler, newMessage("Hello-1")));
+    TestPubsubMessage message2 = (TestPubsubMessage) messages.poll(100, TimeUnit.MILLISECONDS);
 
-        assertThat(message2).isNull();
-        assertThat(createdMessages.size()).isEqualTo(1);
-        // assert that 'slow' canonicalId was not calculated and the message was filtered as seen by fastId
-        assertThat(createdMessages.get(0).canonicalId).isNull();
-        createdMessages.clear();
+    assertThat(message2).isNull();
+    assertThat(createdMessages.size()).isEqualTo(1);
+    // assert that 'slow' canonicalId was not calculated and the message was filtered as seen by
+    // fastId
+    assertThat(createdMessages.get(0).canonicalId).isNull();
+    createdMessages.clear();
+  }
+
+  private static Rpc.RPC newMessage(String msg) {
+    return Rpc.RPC
+        .newBuilder()
+        .addPublish(
+            Rpc.Message.newBuilder()
+                .addTopicIDs("topic")
+                .setData(ByteString.copyFrom(msg, StandardCharsets.US_ASCII)))
+        .build();
+  }
+
+  private static class TestPubsubMessage implements PubsubMessage {
+    final Rpc.Message message;
+    Function<Rpc.Message, WBytes> canonicalIdCalculator =
+        m -> new WBytes(("canon-" + m.getData().toString()).getBytes());
+    WBytes canonicalId = null;
+
+    public TestPubsubMessage(Rpc.Message message) {
+      this.message = message;
     }
 
-    private static Rpc.RPC newMessage(String msg) {
-        return Rpc.RPC.newBuilder().addPublish(
-                Rpc.Message.newBuilder()
-                        .addTopicIDs("topic")
-                        .setData(ByteString.copyFrom(msg, StandardCharsets.US_ASCII))
-        ).build();
+    @NotNull
+    @Override
+    public Rpc.Message getProtobufMessage() {
+      return message;
     }
 
-    private static class TestPubsubMessage implements PubsubMessage {
-        final Rpc.Message message;
-        Function<Rpc.Message, WBytes> canonicalIdCalculator = m -> new WBytes(("canon-" + m.getData().toString()).getBytes());
-        WBytes canonicalId = null;
-
-        public TestPubsubMessage(Rpc.Message message) {
-            this.message = message;
-        }
-
-        @NotNull
-        @Override
-        public Rpc.Message getProtobufMessage() {
-            return message;
-        }
-
-        @NotNull
-        @Override
-        public WBytes getMessageId() {
-            if (canonicalId == null) {
-                canonicalId = canonicalIdCalculator.apply(getProtobufMessage());
-            }
-            return canonicalId;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            TestPubsubMessage that = (TestPubsubMessage) o;
-            return message.equals(that.message);
-        }
-
-        @Override
-        public int hashCode() {
-            return message.hashCode();
-        }
+    @NotNull
+    @Override
+    public WBytes getMessageId() {
+      if (canonicalId == null) {
+        canonicalId = canonicalIdCalculator.apply(getProtobufMessage());
+      }
+      return canonicalId;
     }
 
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      TestPubsubMessage that = (TestPubsubMessage) o;
+      return message.equals(that.message);
+    }
+
+    @Override
+    public int hashCode() {
+      return message.hashCode();
+    }
+  }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/core/HostTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/core/HostTest.kt
@@ -75,13 +75,17 @@ class HostTest {
             var interceptRead = false
             var interceptWrite = false
             override fun interceptRead(buf: ByteBuf) =
-                if (interceptRead)
+                if (interceptRead) {
                     Unpooled.wrappedBuffer("RRR".toByteArray(Charsets.UTF_8))
-                else buf
+                } else {
+                    buf
+                }
             override fun interceptWrite(buf: ByteBuf) =
-                if (interceptWrite)
+                if (interceptWrite) {
                     Unpooled.wrappedBuffer("WWW".toByteArray(Charsets.UTF_8))
-                else buf
+                } else {
+                    buf
+                }
         }
         val interceptor = TestInterceptor()
 

--- a/libp2p/src/test/kotlin/io/libp2p/core/HostTranportsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/core/HostTranportsTest.kt
@@ -32,17 +32,20 @@ import java.util.concurrent.TimeUnit
 
 @Tag("secure-channel")
 class PlaintextTcpTest : TcpTransportHostTest(::PlaintextInsecureChannel)
+
 @Tag("secure-channel")
 class PlaintextWsTest : WsTransportHostTest(::PlaintextInsecureChannel)
 
 @Tag("secure-channel")
 class SecioTcpTest : TcpTransportHostTest(::SecIoSecureChannel)
+
 @Tag("secure-channel")
 class SecioWsTest : WsTransportHostTest(::SecIoSecureChannel)
 
 @DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
 @Tag("secure-channel")
 class NoiseXXTcpTest : TcpTransportHostTest(::NoiseXXSecureChannel)
+
 @DisabledIfEnvironmentVariable(named = "TRAVIS", matches = "true")
 @Tag("secure-channel")
 class NoiseXXWsTest : WsTransportHostTest(::NoiseXXSecureChannel)
@@ -96,7 +99,7 @@ abstract class HostTransportsTest(
             add(secureChannelCtor)
         }
         muxers {
-            + StreamMuxerProtocol.Mplex
+            +StreamMuxerProtocol.Mplex
         }
         protocols {
             +Ping()
@@ -121,7 +124,7 @@ abstract class HostTransportsTest(
             add(secureChannelCtor)
         }
         muxers {
-            + StreamMuxerProtocol.Mplex
+            +StreamMuxerProtocol.Mplex
         }
         network {
             listen(listenAddress)

--- a/libp2p/src/test/kotlin/io/libp2p/core/RpcHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/core/RpcHandlerTest.kt
@@ -106,7 +106,7 @@ class RpcHandlerTest {
                 add(::SecIoSecureChannel)
             }
             muxers {
-                + StreamMuxerProtocol.Mplex
+                +StreamMuxerProtocol.Mplex
             }
             protocols {
                 +RpcProtocol()
@@ -127,7 +127,7 @@ class RpcHandlerTest {
                 add(::SecIoSecureChannel)
             }
             muxers {
-                + StreamMuxerProtocol.Mplex
+                +StreamMuxerProtocol.Mplex
             }
             protocols {
                 +RpcProtocol()
@@ -166,8 +166,11 @@ class RpcHandlerTest {
         Assertions.assertEquals(1, streamCounter2)
         Assertions.assertEquals(1, streamCounter1)
         for (i in 1..100) {
-            if (host1.streams.isNotEmpty() || host2.streams.isNotEmpty()) Thread.sleep(10)
-            else break
+            if (host1.streams.isNotEmpty() || host2.streams.isNotEmpty()) {
+                Thread.sleep(10)
+            } else {
+                break
+            }
         }
         Assertions.assertEquals(0, host1.streams.size)
         Assertions.assertEquals(0, host2.streams.size)
@@ -188,8 +191,11 @@ class RpcHandlerTest {
         Assertions.assertEquals(2, streamCounter1)
         Assertions.assertEquals(2, streamCounter2)
         for (i in 1..100) {
-            if (host1.streams.isNotEmpty() || host2.streams.isNotEmpty()) Thread.sleep(10)
-            else break
+            if (host1.streams.isNotEmpty() || host2.streams.isNotEmpty()) {
+                Thread.sleep(10)
+            } else {
+                break
+            }
         }
         Assertions.assertEquals(0, host1.streams.size)
         Assertions.assertEquals(0, host2.streams.size)

--- a/libp2p/src/test/kotlin/io/libp2p/core/dsl/BuilderDefaultsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/core/dsl/BuilderDefaultsTest.kt
@@ -57,7 +57,7 @@ class BuilderDefaultsTest {
             identity { random() }
             transports { +::TcpTransport }
             secureChannels { add(::SecIoSecureChannel) }
-            muxers { + StreamMuxerProtocol.Mplex }
+            muxers { +StreamMuxerProtocol.Mplex }
         }
 
         host.start().get(5, SECONDS)

--- a/libp2p/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrDnsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/core/multiformats/MultiaddrDnsTest.kt
@@ -164,12 +164,13 @@ class MultiaddrDnsTest {
 
         val TestResolver = object : MultiaddrDns.Resolver {
             override fun resolveDns4(hostname: String): List<Multiaddr> {
-                val address = if ("pig.com".equals(hostname))
+                val address = if ("pig.com".equals(hostname)) {
                     listOf("/ip4/1.1.1.1", "/ip4/1.1.1.2")
-                else if ("localhost".equals(hostname))
+                } else if ("localhost".equals(hostname)) {
                     listOf("/ip4/127.0.0.1")
-                else
+                } else {
                     listOf("/ip4/2.2.2.1", "/ip4/2.2.2.2")
+                }
 
                 return address.map { Multiaddr(it) }
             }

--- a/libp2p/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/core/multiformats/ProtocolTest.kt
@@ -21,6 +21,7 @@ class ProtocolTest {
             assertEquals(protocol, roundTrippedProtocol)
         }
     }
+
     @Test
     fun tcpProtocolProperties() {
         assertEquals(Protocol.TCP, Protocol.get("tcp"))

--- a/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexFrameCodecTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexFrameCodecTest.kt
@@ -36,7 +36,8 @@ class MplexFrameCodecTest {
     @Test
     fun `check max frame size limit`() {
         val mplexFrame = MplexFrame(
-            MuxId(dummyId, 777, true), MplexFlag.MessageInitiator,
+            MuxId(dummyId, 777, true),
+            MplexFlag.MessageInitiator,
             ByteArray(maxFrameDataLength).toByteBuf()
         )
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexHandlerTest.kt
@@ -17,7 +17,10 @@ class MplexHandlerTest : MuxHandlerAbstractTest() {
 
     override fun createMuxHandler(streamHandler: StreamHandler<*>): MuxHandler =
         object : MplexHandler(
-            MultistreamProtocolV1, maxFrameDataLength, null, streamHandler
+            MultistreamProtocolV1,
+            maxFrameDataLength,
+            null,
+            streamHandler
         ) {
             // MuxHandler consumes the exception. Override this behaviour for testing
             @Deprecated("Deprecated in Java")

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/MaxCountTopicSubscriptionFilterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/MaxCountTopicSubscriptionFilterTest.kt
@@ -134,7 +134,8 @@ internal class MaxCountTopicSubscriptionFilterTest {
             PubsubSubscription("allow_10", true),
         )
         val result = filter.filterIncomingSubscriptions(
-            subscriptions, listOf("allow_1", "allow_2", "allow_3", "allow_4", "allow_5", "allow_6", "allow_7")
+            subscriptions,
+            listOf("allow_1", "allow_2", "allow_3", "allow_4", "allow_5", "allow_6", "allow_7")
         )
         assertThat(result).isEqualTo(subscriptions)
     }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -296,7 +296,7 @@ abstract class PubsubRouterTest(val routerFactory: DeterministicFuzzRouterFactor
         }
         for (i in 0 until nodesCount) {
             for (j in 1..neighboursCount / 2)
-                allConnections += allRouters[i].connectSemiDuplex(allRouters[(i + j) % 21]/*, pubsubLogs = LogLevel.ERROR*/)
+                allConnections += allRouters[i].connectSemiDuplex(allRouters[(i + j) % 21])
                     .connections
         }
 
@@ -409,7 +409,10 @@ abstract class PubsubRouterTest(val routerFactory: DeterministicFuzzRouterFactor
 
         val subs2 = topics
             .map { it to RecordingSubscriber() }
-            .map { apis[2].subscribe(it.second, it.first); it.second }
+            .map {
+                apis[2].subscribe(it.second, it.first)
+                it.second
+            }
 
         val scheduler = fuzz.createControlledExecutor()
         val delayed = { result: ValidationResult, delayMs: Long ->

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/DefaultGossipScoreTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/DefaultGossipScoreTest.kt
@@ -732,7 +732,6 @@ class DefaultGossipScoreTest {
 
     @Test
     fun `test IP colocation penalty`() {
-
         val addr1 = Multiaddr.fromString("/ip4/0.0.0.1")
         val addr2 = Multiaddr.fromString("/ip4/0.0.0.2")
         val peer1 = PeerId.random()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:class-naming")
+
 package io.libp2p.pubsub.gossip
 
 import com.google.common.util.concurrent.AtomicDouble
@@ -74,8 +76,11 @@ class GossipV1_1Tests {
         fun connect(routerIndexes: IntRange, outbound: Boolean = true): List<SemiduplexConnection> {
             val list =
                 routers.slice(routerIndexes).map {
-                    if (outbound) router0.connectSemiDuplex(it, null, LogLevel.ERROR)
-                    else it.connectSemiDuplex(router0, null, LogLevel.ERROR)
+                    if (outbound) {
+                        router0.connectSemiDuplex(it, null, LogLevel.ERROR)
+                    } else {
+                        it.connectSemiDuplex(router0, null, LogLevel.ERROR)
+                    }
                 }
             connections += list
             return list
@@ -696,8 +701,12 @@ class GossipV1_1Tests {
     fun testAdaptiveGossip() {
         val appScore = mutableMapOf<PeerId, Double>().withDefault { 0.0 }
         val coreParams = GossipParams(
-            3, 3, 3, DLazy = 3,
-            floodPublish = false, gossipFactor = 0.5
+            3,
+            3,
+            3,
+            DLazy = 3,
+            floodPublish = false,
+            gossipFactor = 0.5
         )
         val peerScoreParams = GossipPeerScoreParams(
             appSpecificScore = { appScore.getValue(it) },
@@ -806,8 +815,13 @@ class GossipV1_1Tests {
     fun testOpportunisticGraft() {
         val appScore = mutableMapOf<PeerId, Double>().withDefault { 0.0 }
         val coreParams = GossipParams(
-            3, 3, 10, DLazy = 3, DOut = 1,
-            opportunisticGraftPeers = 2, opportunisticGraftTicks = 60
+            3,
+            3,
+            10,
+            DLazy = 3,
+            DOut = 1,
+            opportunisticGraftPeers = 2,
+            opportunisticGraftTicks = 60
         )
         val peerScoreParams = GossipPeerScoreParams(
             appSpecificScore = { appScore.getValue(it) },
@@ -970,7 +984,10 @@ class GossipV1_1Tests {
 
         val validationResult = CompletableFuture<ValidationResult>()
         val receivedMessages = LinkedBlockingQueue<MessageApi>()
-        val slowValidator = Validator { receivedMessages += it; validationResult }
+        val slowValidator = Validator {
+            receivedMessages += it
+            validationResult
+        }
         api.subscribe(slowValidator, io.libp2p.core.pubsub.Topic("topic1"))
         test.mockRouters.forEach { it.subscribe("topic1") }
 

--- a/libp2p/src/test/kotlin/io/libp2p/security/CipherSecureChannelTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/CipherSecureChannelTest.kt
@@ -1,7 +1,7 @@
 package io.libp2p.security
 
 import io.libp2p.core.PeerId
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.mux.StreamMuxer
 import io.libp2p.tools.TestChannel
@@ -18,9 +18,9 @@ abstract class CipherSecureChannelTest(secureChannelCtor: SecureChannelCtor, mux
 
     @Test
     fun `incorrect initiator remote PeerId should throw`() {
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (privKey2, _) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (_, wrongPubKey) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
+        val (privKey2, _) = generateKeyPair(KeyType.ECDSA)
+        val (_, wrongPubKey) = generateKeyPair(KeyType.ECDSA)
 
         val protocolSelect1 = makeSelector(privKey1, muxerIds)
         val protocolSelect2 = makeSelector(privKey2, muxerIds)
@@ -37,8 +37,8 @@ abstract class CipherSecureChannelTest(secureChannelCtor: SecureChannelCtor, mux
 
     @Test
     fun `test that on malformed message from remote the connection closes and no log noise`() {
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (privKey2, pubKey2) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
+        val (privKey2, pubKey2) = generateKeyPair(KeyType.ECDSA)
 
         val protocolSelect1 = makeSelector(privKey1, muxerIds)
         val protocolSelect2 = makeSelector(privKey2, muxerIds)

--- a/libp2p/src/test/kotlin/io/libp2p/security/SecureChannelTestBase.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/SecureChannelTestBase.kt
@@ -1,7 +1,7 @@
 package io.libp2p.security
 
 import io.libp2p.core.PeerId
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.PrivKey
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multistream.ProtocolMatcher
@@ -55,8 +55,8 @@ abstract class SecureChannelTestBase(
     @ParameterizedTest
     @MethodSource("plainDataSizes")
     fun secureInterconnect(dataSize: Int) {
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (privKey2, pubKey2) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
+        val (privKey2, pubKey2) = generateKeyPair(KeyType.ECDSA)
 
         val protocolSelect1 = makeSelector(privKey1, muxerIds)
         val protocolSelect2 = makeSelector(privKey2, muxerIds)

--- a/libp2p/src/test/kotlin/io/libp2p/security/noise/NoiseHandshakeTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/noise/NoiseHandshakeTest.kt
@@ -2,7 +2,7 @@ package io.libp2p.security.noise
 
 import com.google.protobuf.ByteString
 import com.southernstorm.noise.protocol.HandshakeState
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
@@ -120,7 +120,7 @@ class NoiseHandshakeTest {
         // generate a Peer Identity protobuf object
         // use it for encoding and decoding peer identities from the wire
         // this identity is intended to be sent as a Noise transport payload
-        val (privKey, pubKey) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey, pubKey) = generateKeyPair(KeyType.ECDSA)
         assert(pubKey.bytes().maxOrNull()?.compareTo(0) != 0)
 
         // sign the identity using the identity's private key
@@ -144,7 +144,7 @@ class NoiseHandshakeTest {
 
     @Test
     fun testAnnounceAndMatch() {
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
 
         val ch1 = NoiseXXSecureChannel(privKey1, listOf())
 
@@ -155,11 +155,11 @@ class NoiseHandshakeTest {
 
     @Test
     fun testStaticNoiseKeyPerProcess() {
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
         NoiseXXSecureChannel(privKey1, listOf())
         val b1 = NoiseXXSecureChannel.localStaticPrivateKey25519.copyOf()
 
-        val (privKey2, _) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey2, _) = generateKeyPair(KeyType.ECDSA)
         NoiseXXSecureChannel(privKey2, listOf())
         val b2 = NoiseXXSecureChannel.localStaticPrivateKey25519.copyOf()
 

--- a/libp2p/src/test/kotlin/io/libp2p/security/secio/EchoSampleTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/secio/EchoSampleTest.kt
@@ -4,7 +4,7 @@ import io.libp2p.core.ChannelVisitor
 import io.libp2p.core.Connection
 import io.libp2p.core.P2PChannel
 import io.libp2p.core.P2PChannelHandler
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.multistream.MultistreamProtocolV1
@@ -53,7 +53,7 @@ class EchoSampleTest {
     fun connect1() {
         val logger = LoggerFactory.getLogger("test")
 
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
         val applicationProtocols = listOf(createSimpleBinding("/echo/1.0.0") { EchoProtocol() })
         val muxer = StreamMuxerProtocol.Mplex.createMuxer(MultistreamProtocolV1, applicationProtocols).also {
             it as MplexStreamMuxer

--- a/libp2p/src/test/kotlin/io/libp2p/security/secio/SecIoNegotiatorTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/secio/SecIoNegotiatorTest.kt
@@ -1,7 +1,7 @@
 package io.libp2p.security.secio
 
 import io.libp2p.core.PeerId
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.crypto.unmarshalPrivateKey
 import io.libp2p.crypto.keys.secp256k1PublicKeyFromCoordinates
@@ -19,8 +19,8 @@ import java.math.BigInteger
 class SecIoNegotiatorTest {
     @Test
     fun handshake() {
-        val (privKey1, pubKey1) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (privKey2, pubKey2) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, pubKey1) = generateKeyPair(KeyType.ECDSA)
+        val (privKey2, pubKey2) = generateKeyPair(KeyType.ECDSA)
         var bb1: ByteBuf? = null
         var bb2: ByteBuf? = null
 

--- a/libp2p/src/test/kotlin/io/libp2p/security/tls/TlsSecureChannelTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/tls/TlsSecureChannelTest.kt
@@ -1,7 +1,7 @@
 package io.libp2p.security.tls
 
 import io.libp2p.core.PeerId
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multistream.MultistreamProtocolDebug
 import io.libp2p.core.mux.StreamMuxerProtocol
@@ -24,9 +24,9 @@ class TlsSecureChannelTest : SecureChannelTestBase(
 ) {
     @Test
     fun `incorrect initiator remote PeerId should throw`() {
-        val (privKey1, _) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (privKey2, _) = generateKeyPair(KEY_TYPE.ECDSA)
-        val (_, wrongPubKey) = generateKeyPair(KEY_TYPE.ECDSA)
+        val (privKey1, _) = generateKeyPair(KeyType.ECDSA)
+        val (privKey2, _) = generateKeyPair(KeyType.ECDSA)
+        val (_, wrongPubKey) = generateKeyPair(KeyType.ECDSA)
 
         val protocolSelect1 = makeSelector(privKey1, muxerIds)
         val protocolSelect2 = makeSelector(privKey2, muxerIds)

--- a/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -16,10 +16,11 @@ class TcpTransportTest : TransportTests() {
     }
 
     override fun localAddress(portNumber: Int): Multiaddr {
-        return if (ip4DnsAvailable && (portNumber % 2 == 0))
+        return if (ip4DnsAvailable && (portNumber % 2 == 0)) {
             Multiaddr("/dns4/localhost/tcp/$portNumber")
-        else
+        } else {
             Multiaddr("/ip4/127.0.0.1/tcp/$portNumber")
+        }
     }
 
     override fun badAddress(): Multiaddr =

--- a/libp2p/src/test/kotlin/io/libp2p/transport/ws/WsTransportTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/ws/WsTransportTest.kt
@@ -15,10 +15,11 @@ class WsTransportTest : TransportTests() {
     } // makeTransport
 
     override fun localAddress(portNumber: Int): Multiaddr {
-        return if (ip4DnsAvailable && (portNumber % 2 == 0))
+        return if (ip4DnsAvailable && (portNumber % 2 == 0)) {
             Multiaddr("/dns4/localhost/tcp/$portNumber/ws")
-        else
+        } else {
             Multiaddr("/ip4/127.0.0.1/tcp/$portNumber/ws")
+        }
     } // localAddress
 
     override fun badAddress(): Multiaddr =

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/AsyncDaemonExecutor.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/AsyncDaemonExecutor.java
@@ -1,50 +1,49 @@
 package io.libp2p.tools.p2pd;
 
 import io.netty.channel.unix.DomainSocketAddress;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-/**
- * Created by Anton Nashatyrev on 20.12.2018.
- */
+/** Created by Anton Nashatyrev on 20.12.2018. */
 public class AsyncDaemonExecutor {
-    private final SocketAddress address;
+  private final SocketAddress address;
 
-    public AsyncDaemonExecutor(SocketAddress address) {
-        this.address = address;
+  public AsyncDaemonExecutor(SocketAddress address) {
+    this.address = address;
+  }
+
+  public <TRet> CompletableFuture<TRet> executeWithDaemon(
+      Function<DaemonChannelHandler, CompletableFuture<TRet>> executor) {
+    CompletableFuture<DaemonChannelHandler> daemonFut = getDaemon();
+    return daemonFut
+        .thenCompose(executor)
+        .whenComplete(
+            (r, t) -> {
+              if (!daemonFut.isCompletedExceptionally()) {
+                try {
+                  daemonFut.get().close();
+                } catch (Exception e) {
+                }
+              }
+            });
+  }
+
+  public CompletableFuture<DaemonChannelHandler> getDaemon() {
+    ControlConnector connector;
+    if (address instanceof InetSocketAddress) {
+      connector = new TCPControlConnector();
+    } else if (address instanceof DomainSocketAddress) {
+      connector = new UnixSocketControlConnector();
+    } else {
+      throw new IllegalArgumentException();
     }
 
-    public <TRet> CompletableFuture<TRet> executeWithDaemon(
-            Function<DaemonChannelHandler, CompletableFuture<TRet>> executor) {
-        CompletableFuture<DaemonChannelHandler> daemonFut = getDaemon();
-        return daemonFut
-                .thenCompose(executor)
-                .whenComplete((r, t) -> {
-                    if (!daemonFut.isCompletedExceptionally()) {
-                        try {
-                            daemonFut.get().close();
-                        } catch (Exception e) {}
-                    }
-                });
-    }
+    return connector.connect(address);
+  }
 
-    public CompletableFuture<DaemonChannelHandler> getDaemon() {
-        ControlConnector connector;
-        if (address instanceof InetSocketAddress) {
-            connector = new TCPControlConnector();
-        } else if (address instanceof DomainSocketAddress) {
-            connector = new UnixSocketControlConnector();
-        } else {
-            throw new IllegalArgumentException();
-        }
-
-        return connector.connect(address);
-    }
-
-    public SocketAddress getAddress() {
-        return address;
-    }
+  public SocketAddress getAddress() {
+    return address;
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/ControlConnector.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/ControlConnector.java
@@ -6,50 +6,52 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
-
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-/**
- * Created by Anton Nashatyrev on 13.12.2018.
- */
+/** Created by Anton Nashatyrev on 13.12.2018. */
 public abstract class ControlConnector {
-    protected final int connectTimeoutSec = 5;
+  protected final int connectTimeoutSec = 5;
 
-    public abstract CompletableFuture<DaemonChannelHandler> connect(SocketAddress addr);
+  public abstract CompletableFuture<DaemonChannelHandler> connect(SocketAddress addr);
 
-    public abstract ChannelFuture listen(SocketAddress addr, Consumer<DaemonChannelHandler> handlersConsumer);
+  public abstract ChannelFuture listen(
+      SocketAddress addr, Consumer<DaemonChannelHandler> handlersConsumer);
 
-    protected static class ChannelInit extends ChannelInitializer<Channel> {
-        private final Consumer<DaemonChannelHandler> handlersConsumer;
-        private final boolean initiator;
+  protected static class ChannelInit extends ChannelInitializer<Channel> {
+    private final Consumer<DaemonChannelHandler> handlersConsumer;
+    private final boolean initiator;
 
-        public ChannelInit(Consumer<DaemonChannelHandler> handlersConsumer, boolean initiator) {
-            this.handlersConsumer = handlersConsumer;
-            this.initiator = initiator;
-        }
+    public ChannelInit(Consumer<DaemonChannelHandler> handlersConsumer, boolean initiator) {
+      this.handlersConsumer = handlersConsumer;
+      this.initiator = initiator;
+    }
 
-        @Override
-        protected void initChannel(Channel ch) throws Exception {
-            DaemonChannelHandler handler = new DaemonChannelHandler(ch, initiator);
-            ch.pipeline().addFirst(new SimpleChannelInboundHandler() {
+    @Override
+    protected void initChannel(Channel ch) throws Exception {
+      DaemonChannelHandler handler = new DaemonChannelHandler(ch, initiator);
+      ch.pipeline()
+          .addFirst(
+              new SimpleChannelInboundHandler() {
                 @Override
                 public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                    handlersConsumer.accept(handler);
-                    super.channelActive(ctx);
+                  handlersConsumer.accept(handler);
+                  super.channelActive(ctx);
                 }
 
                 @Override
-                protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
-                    handler.onData((ByteBuf) msg);
+                protected void channelRead0(ChannelHandlerContext ctx, Object msg)
+                    throws Exception {
+                  handler.onData((ByteBuf) msg);
                 }
 
                 @Override
-                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                    handler.onError(cause);
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+                    throws Exception {
+                  handler.onError(cause);
                 }
-            });
-        }
+              });
     }
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/DaemonChannelHandler.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/DaemonChannelHandler.java
@@ -12,8 +12,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import p2pd.pb.P2Pd;
-
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -27,276 +25,281 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
+import p2pd.pb.P2Pd;
 
-/**
- * Created by Anton Nashatyrev on 14.12.2018.
- */
+/** Created by Anton Nashatyrev on 14.12.2018. */
 public class DaemonChannelHandler implements Closeable, AutoCloseable {
 
-    private final Channel channel;
-    private final boolean isInitiator;
-    private Queue<ResponseBuilder> respBuildQueue = new ConcurrentLinkedQueue<>();
-    private StreamHandler<MuxerAdress> streamHandler;
-    private Stream<MuxerAdress> stream;
-    private ByteBuf prevDataTail = Unpooled.buffer(0);
+  private final Channel channel;
+  private final boolean isInitiator;
+  private Queue<ResponseBuilder> respBuildQueue = new ConcurrentLinkedQueue<>();
+  private StreamHandler<MuxerAdress> streamHandler;
+  private Stream<MuxerAdress> stream;
+  private ByteBuf prevDataTail = Unpooled.buffer(0);
 
-    public DaemonChannelHandler(Channel channel, boolean isInitiator) {
-        this.channel = channel;
-        this.isInitiator = isInitiator;
-    }
+  public DaemonChannelHandler(Channel channel, boolean isInitiator) {
+    this.channel = channel;
+    this.isInitiator = isInitiator;
+  }
 
-    public void setStreamHandler(StreamHandler<MuxerAdress> streamHandler) {
-        this.streamHandler = streamHandler;
-    }
+  public void setStreamHandler(StreamHandler<MuxerAdress> streamHandler) {
+    this.streamHandler = streamHandler;
+  }
 
-    void onData(ByteBuf msg) throws InvalidProtocolBufferException {
-        ByteBuf bytes = prevDataTail.isReadable() ? Unpooled.wrappedBuffer(prevDataTail, msg) : msg;
-        while (bytes.isReadable()) {
-            if (stream != null) {
-                streamHandler.onRead(bytes.nioBuffer());
-                bytes.clear();
-                break;
-            } else {
-                ResponseBuilder responseBuilder = respBuildQueue.peek();
-                if (responseBuilder == null) {
-                    throw new RuntimeException("Unexpected response message from p2pDaemon");
-                }
-
-                try {
-                    ByteBuf bbDup = bytes.duplicate();
-                    InputStream is = new ByteBufInputStream(bbDup);
-                    int msgLen = CodedInputStream.readRawVarint32(is.read(), is);
-                    if (msgLen > bbDup.readableBytes()) {
-                        break;
-                    }
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                Action action = responseBuilder.parseNextMessage(bytes);
-                if (action != Action.ContinueResponse) {
-                    respBuildQueue.poll();
-                }
-
-                if (action == Action.StartStream) {
-                    P2Pd.StreamInfo resp = responseBuilder.getStreamInfo();
-                    MuxerAdress remoteAddr = new MuxerAdress(new Peer(resp.getPeer().toByteArray()), resp.getProto());
-                    MuxerAdress localAddr = MuxerAdress.listenAddress(resp.getProto());
-
-                    stream = new NettyStream(channel, isInitiator, localAddr, remoteAddr);
-                    streamHandler.onCreate(stream);
-                    channel.closeFuture().addListener((ChannelFutureListener) future -> streamHandler.onClose());
-                }
-            }
+  void onData(ByteBuf msg) throws InvalidProtocolBufferException {
+    ByteBuf bytes = prevDataTail.isReadable() ? Unpooled.wrappedBuffer(prevDataTail, msg) : msg;
+    while (bytes.isReadable()) {
+      if (stream != null) {
+        streamHandler.onRead(bytes.nioBuffer());
+        bytes.clear();
+        break;
+      } else {
+        ResponseBuilder responseBuilder = respBuildQueue.peek();
+        if (responseBuilder == null) {
+          throw new RuntimeException("Unexpected response message from p2pDaemon");
         }
-        prevDataTail = Unpooled.wrappedBuffer(Util.byteBufToArray(bytes));
-    }
 
-    void onError(Throwable t) {
-        streamHandler.onError(t);
-    }
-
-    public <TResponse> CompletableFuture<TResponse> expectResponse(
-            ResponseBuilder<TResponse> responseBuilder) {
-        respBuildQueue.add(responseBuilder);
-        return responseBuilder.getResponse();
-    }
-
-    public <TResponse> CompletableFuture<TResponse> call(P2Pd.Request request,
-                                                         ResponseBuilder<TResponse> responseBuilder) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
-            request.writeDelimitedTo(baos);
+          ByteBuf bbDup = bytes.duplicate();
+          InputStream is = new ByteBufInputStream(bbDup);
+          int msgLen = CodedInputStream.readRawVarint32(is.read(), is);
+          if (msgLen > bbDup.readableBytes()) {
+            break;
+          }
         } catch (IOException e) {
-            throw new RuntimeException(e);
+          throw new RuntimeException(e);
         }
-        byte[] msgBytes = baos.toByteArray();
-        ByteBuf buffer = channel.alloc().buffer(msgBytes.length).writeBytes(msgBytes);
-        CompletableFuture<TResponse> ret = expectResponse(responseBuilder);
-        ChannelFuture channelFuture = channel.writeAndFlush(buffer);
-
-        try {
-            channelFuture.get();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
+        Action action = responseBuilder.parseNextMessage(bytes);
+        if (action != Action.ContinueResponse) {
+          respBuildQueue.poll();
         }
 
-        return ret;
+        if (action == Action.StartStream) {
+          P2Pd.StreamInfo resp = responseBuilder.getStreamInfo();
+          MuxerAdress remoteAddr =
+              new MuxerAdress(new Peer(resp.getPeer().toByteArray()), resp.getProto());
+          MuxerAdress localAddr = MuxerAdress.listenAddress(resp.getProto());
+
+          stream = new NettyStream(channel, isInitiator, localAddr, remoteAddr);
+          streamHandler.onCreate(stream);
+          channel
+              .closeFuture()
+              .addListener((ChannelFutureListener) future -> streamHandler.onClose());
+        }
+      }
+    }
+    prevDataTail = Unpooled.wrappedBuffer(Util.byteBufToArray(bytes));
+  }
+
+  void onError(Throwable t) {
+    streamHandler.onError(t);
+  }
+
+  public <TResponse> CompletableFuture<TResponse> expectResponse(
+      ResponseBuilder<TResponse> responseBuilder) {
+    respBuildQueue.add(responseBuilder);
+    return responseBuilder.getResponse();
+  }
+
+  public <TResponse> CompletableFuture<TResponse> call(
+      P2Pd.Request request, ResponseBuilder<TResponse> responseBuilder) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try {
+      request.writeDelimitedTo(baos);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    byte[] msgBytes = baos.toByteArray();
+    ByteBuf buffer = channel.alloc().buffer(msgBytes.length).writeBytes(msgBytes);
+    CompletableFuture<TResponse> ret = expectResponse(responseBuilder);
+    ChannelFuture channelFuture = channel.writeAndFlush(buffer);
+
+    try {
+      channelFuture.get();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      throw new RuntimeException(e);
     }
 
-    public void close() {
-        channel.close();
+    return ret;
+  }
+
+  public void close() {
+    channel.close();
+  }
+
+  @FunctionalInterface
+  public interface FunctionThrowable<A, B> {
+    B apply(A arg) throws Exception;
+  }
+
+  private enum Action {
+    EndResponse,
+    ContinueResponse,
+    StartStream
+  }
+
+  public abstract static class ResponseBuilder<TResponse> {
+    protected boolean throwOnResponseError = true;
+    protected CompletableFuture<TResponse> respFuture = new CompletableFuture<>();
+
+    protected Action parseNextMessage(ByteBuf bytes) {
+      ByteBuf buf = bytes.duplicate();
+      try {
+        return parseNextMessage(new ByteBufInputStream(bytes));
+      } catch (Exception e) {
+        respFuture.completeExceptionally(
+            new RuntimeException("Error parsing message: " + (Util.byteBufToArray(buf)), e));
+        return Action.EndResponse;
+      }
     }
 
-    @FunctionalInterface
-    public interface FunctionThrowable<A, B> {
-        B apply(A arg) throws Exception;
+    abstract Action parseNextMessage(InputStream is) throws Exception;
+
+    CompletableFuture<TResponse> getResponse() {
+      return respFuture;
     }
 
-    private enum Action {
-        EndResponse,
-        ContinueResponse,
-        StartStream
+    P2Pd.StreamInfo getStreamInfo() {
+      try {
+        TResponse resp = respFuture.get();
+        if (resp instanceof P2Pd.Response) {
+          return ((P2Pd.Response) resp).getStreamInfo();
+        } else {
+          return (P2Pd.StreamInfo) resp;
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static class SingleMsgResponseBuilder<TResponse> extends ResponseBuilder<TResponse> {
+    FunctionThrowable<InputStream, TResponse> parser;
+
+    public SingleMsgResponseBuilder(FunctionThrowable<InputStream, TResponse> parser) {
+      this.parser = parser;
     }
 
-    public static abstract class ResponseBuilder<TResponse> {
-        protected boolean throwOnResponseError = true;
-        protected CompletableFuture<TResponse> respFuture = new CompletableFuture<>();
-
-        protected Action parseNextMessage(ByteBuf bytes) {
-            ByteBuf buf = bytes.duplicate();
-            try {
-                return parseNextMessage(new ByteBufInputStream(bytes));
-            } catch (Exception e) {
-                respFuture.completeExceptionally(new RuntimeException("Error parsing message: "
-                        + (Util.byteBufToArray(buf)), e));
-                return Action.EndResponse;
-            }
+    @Override
+    Action parseNextMessage(InputStream is) {
+      try {
+        TResponse response = parser.apply(is);
+        if (throwOnResponseError
+            && response instanceof P2Pd.Response
+            && ((P2Pd.Response) response).getType() == P2Pd.Response.Type.ERROR) {
+          throw new P2PDError(((P2Pd.Response) response).getError().toString());
+        } else {
+          respFuture.complete(response);
         }
-
-        abstract Action parseNextMessage(InputStream is) throws Exception;
-
-        CompletableFuture<TResponse> getResponse() {
-            return respFuture;
-        }
-
-        P2Pd.StreamInfo getStreamInfo() {
-            try {
-                TResponse resp = respFuture.get();
-                if (resp instanceof P2Pd.Response) {
-                    return ((P2Pd.Response) resp).getStreamInfo();
-                } else {
-                    return (P2Pd.StreamInfo) resp;
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
+      } catch (Exception e) {
+        respFuture.completeExceptionally(e);
+      }
+      return Action.EndResponse;
     }
 
-    public static class SingleMsgResponseBuilder<TResponse> extends ResponseBuilder<TResponse>{
-        FunctionThrowable<InputStream, TResponse> parser;
+    CompletableFuture<TResponse> getResponse() {
+      return respFuture;
+    }
+  }
 
-        public SingleMsgResponseBuilder(FunctionThrowable<InputStream, TResponse> parser) {
-            this.parser = parser;
-        }
+  public static class SimpleResponseBuilder extends SingleMsgResponseBuilder<P2Pd.Response> {
+    public SimpleResponseBuilder() {
+      super(P2Pd.Response::parseDelimitedFrom);
+    }
+  }
 
-        @Override
-        Action parseNextMessage(InputStream is) {
-            try {
-                TResponse response = parser.apply(is);
-                if (throwOnResponseError && response instanceof P2Pd.Response &&
-                        ((P2Pd.Response) response).getType() == P2Pd.Response.Type.ERROR) {
-                    throw new P2PDError(((P2Pd.Response) response).getError().toString());
-                } else {
-                    respFuture.complete(response);
-                }
-            } catch (Exception e) {
-                respFuture.completeExceptionally(e);
-            }
-            return Action.EndResponse;
-        }
-
-        CompletableFuture<TResponse> getResponse() {
-            return respFuture;
-        }
+  public static class ListenerStreamBuilder extends SingleMsgResponseBuilder<P2Pd.StreamInfo> {
+    public ListenerStreamBuilder() {
+      super(P2Pd.StreamInfo::parseDelimitedFrom);
     }
 
-    public static class SimpleResponseBuilder extends SingleMsgResponseBuilder<P2Pd.Response> {
-        public SimpleResponseBuilder() {
-            super(P2Pd.Response::parseDelimitedFrom);
-        }
+    @Override
+    protected Action parseNextMessage(ByteBuf bytes) {
+      super.parseNextMessage(bytes);
+      return Action.StartStream;
+    }
+  }
+
+  public static class SimpleResponseStreamBuilder extends SingleMsgResponseBuilder<P2Pd.Response> {
+    public SimpleResponseStreamBuilder() {
+      super(P2Pd.Response::parseDelimitedFrom);
     }
 
-    public static class ListenerStreamBuilder extends SingleMsgResponseBuilder<P2Pd.StreamInfo> {
-        public ListenerStreamBuilder() {
-            super(P2Pd.StreamInfo::parseDelimitedFrom);
+    @Override
+    protected Action parseNextMessage(ByteBuf bytes) {
+      super.parseNextMessage(bytes);
+      try {
+        if (getResponse().get().getType() == P2Pd.Response.Type.OK) {
+          return Action.StartStream;
+        } else {
+          return Action.EndResponse;
         }
-        @Override
-        protected Action parseNextMessage(ByteBuf bytes) {
-            super.parseNextMessage(bytes);
-            return Action.StartStream;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public static class DHTListResponse extends ResponseBuilder<List<P2Pd.DHTResponse>> {
+    private final List<P2Pd.DHTResponse> items = new ArrayList<>();
+    private boolean started;
+
+    @Override
+    Action parseNextMessage(InputStream is) throws Exception {
+      if (!started) {
+        P2Pd.Response response = P2Pd.Response.parseDelimitedFrom(is);
+        if (response.getType() == P2Pd.Response.Type.ERROR) {
+          throw new P2PDError("" + response.getError());
+        } else {
+          if (!response.hasDht() || response.getDht().getType() != P2Pd.DHTResponse.Type.BEGIN) {
+            throw new RuntimeException("Invalid DHT list start message: " + response);
+          }
+          started = true;
+          return Action.ContinueResponse;
         }
+      } else {
+        P2Pd.DHTResponse response = P2Pd.DHTResponse.parseDelimitedFrom(is);
+        if (response.getType() == P2Pd.DHTResponse.Type.END) {
+          respFuture.complete(items);
+          return Action.EndResponse;
+        } else if (response.getType() == P2Pd.DHTResponse.Type.VALUE) {
+          items.add(response);
+          return Action.ContinueResponse;
+        } else {
+          throw new RuntimeException("Invalid DHT list message: " + response);
+        }
+      }
+    }
+  }
+
+  public static class UnboundMessagesResponse<MessageT>
+      extends ResponseBuilder<BlockingQueue<MessageT>> {
+    private final BlockingQueue<MessageT> items = new LinkedBlockingQueue<>();
+    private final Function<InputStream, MessageT> decoder;
+    private boolean started;
+
+    public UnboundMessagesResponse(Function<InputStream, MessageT> decoder) {
+      this.decoder = decoder;
     }
 
-    public static class SimpleResponseStreamBuilder extends SingleMsgResponseBuilder<P2Pd.Response> {
-        public SimpleResponseStreamBuilder() {
-            super(P2Pd.Response::parseDelimitedFrom);
+    @Override
+    Action parseNextMessage(InputStream is) throws Exception {
+      if (!started) {
+        P2Pd.Response response = P2Pd.Response.parseDelimitedFrom(is);
+        if (response.getType() == P2Pd.Response.Type.ERROR) {
+          throw new P2PDError("" + response.getError());
+        } else {
+          respFuture.complete(items);
+          started = true;
+          return Action.ContinueResponse;
         }
-
-        @Override
-        protected Action parseNextMessage(ByteBuf bytes) {
-            super.parseNextMessage(bytes);
-            try {
-                if (getResponse().get().getType() == P2Pd.Response.Type.OK) {
-                    return Action.StartStream;
-                } else {
-                    return Action.EndResponse;
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
+      } else {
+        MessageT message = decoder.apply(is);
+        items.add(message);
+        return Action.ContinueResponse;
+      }
     }
-
-    public static class DHTListResponse extends ResponseBuilder<List<P2Pd.DHTResponse>> {
-        private final List<P2Pd.DHTResponse> items = new ArrayList<>();
-        private boolean started;
-        @Override
-        Action parseNextMessage(InputStream is) throws Exception {
-            if (!started) {
-                P2Pd.Response response = P2Pd.Response.parseDelimitedFrom(is);
-                if (response.getType() == P2Pd.Response.Type.ERROR) {
-                    throw new P2PDError("" + response.getError());
-                } else {
-                    if (!response.hasDht() || response.getDht().getType() != P2Pd.DHTResponse.Type.BEGIN) {
-                        throw new RuntimeException("Invalid DHT list start message: " + response);
-                    }
-                    started = true;
-                    return Action.ContinueResponse;
-                }
-            } else {
-                P2Pd.DHTResponse response = P2Pd.DHTResponse.parseDelimitedFrom(is);
-                if (response.getType() == P2Pd.DHTResponse.Type.END) {
-                    respFuture.complete(items);
-                    return Action.EndResponse;
-                } else if (response.getType() == P2Pd.DHTResponse.Type.VALUE) {
-                    items.add(response);
-                    return Action.ContinueResponse;
-                } else {
-                    throw new RuntimeException("Invalid DHT list message: " + response);
-                }
-            }
-        }
-    }
-
-    public static class UnboundMessagesResponse<MessageT> extends ResponseBuilder<BlockingQueue<MessageT>> {
-        private final BlockingQueue<MessageT> items = new LinkedBlockingQueue<>();
-        private final Function<InputStream, MessageT> decoder;
-        private boolean started;
-
-        public UnboundMessagesResponse(Function<InputStream, MessageT> decoder) {
-            this.decoder = decoder;
-        }
-
-        @Override
-        Action parseNextMessage(InputStream is) throws Exception {
-            if (!started) {
-                P2Pd.Response response = P2Pd.Response.parseDelimitedFrom(is);
-                if (response.getType() == P2Pd.Response.Type.ERROR) {
-                    throw new P2PDError("" + response.getError());
-                } else {
-                    respFuture.complete(items);
-                    started = true;
-                    return Action.ContinueResponse;
-                }
-            } else {
-                MessageT message = decoder.apply(is);
-                items.add(message);
-                return Action.ContinueResponse;
-            }
-        }
-    }
-
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/DaemonLauncher.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/DaemonLauncher.java
@@ -7,41 +7,41 @@ import java.util.Arrays;
 
 public class DaemonLauncher {
 
-    public static class Daemon {
-        public final P2PDHost host;
-        private final Process process;
+  public static class Daemon {
+    public final P2PDHost host;
+    private final Process process;
 
-        public Daemon(P2PDHost host, Process process) {
-            this.host = host;
-            this.process = process;
-        }
-
-        public void kill() {
-            process.destroyForcibly();
-        }
+    public Daemon(P2PDHost host, Process process) {
+      this.host = host;
+      this.process = process;
     }
 
-    private final String daemonPath;
-    private int commandPort = 11111;
-
-    public DaemonLauncher(String daemonPath) {
-        this.daemonPath = daemonPath;
+    public void kill() {
+      process.destroyForcibly();
     }
+  }
 
-    public Daemon launch(int nodePort, String ... commandLineArgs) {
-        ArrayList<String> args = new ArrayList<>();
-        int cmdPort = commandPort++;
-        args.add(daemonPath);
-        args.add("-listen");
-        args.add("/ip4/127.0.0.1/tcp/" + cmdPort);
-        args.add("-hostAddrs");
-        args.add("/ip4/127.0.0.1/tcp/" + nodePort);
-        args.addAll(Arrays.asList(commandLineArgs));
-        try {
-            Process process = new ProcessBuilder(args).inheritIO().start();
-            return new Daemon(new P2PDHost(new InetSocketAddress("127.0.0.1", cmdPort)), process);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+  private final String daemonPath;
+  private int commandPort = 11111;
+
+  public DaemonLauncher(String daemonPath) {
+    this.daemonPath = daemonPath;
+  }
+
+  public Daemon launch(int nodePort, String... commandLineArgs) {
+    ArrayList<String> args = new ArrayList<>();
+    int cmdPort = commandPort++;
+    args.add(daemonPath);
+    args.add("-listen");
+    args.add("/ip4/127.0.0.1/tcp/" + cmdPort);
+    args.add("-hostAddrs");
+    args.add("/ip4/127.0.0.1/tcp/" + nodePort);
+    args.addAll(Arrays.asList(commandLineArgs));
+    try {
+      Process process = new ProcessBuilder(args).inheritIO().start();
+      return new Daemon(new P2PDHost(new InetSocketAddress("127.0.0.1", cmdPort)), process);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/NettyStream.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/NettyStream.java
@@ -4,64 +4,66 @@ import io.libp2p.tools.p2pd.libp2pj.Muxer;
 import io.libp2p.tools.p2pd.libp2pj.Stream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-
 import java.nio.ByteBuffer;
 
-/**
- * Created by Anton Nashatyrev on 14.12.2018.
- */
+/** Created by Anton Nashatyrev on 14.12.2018. */
 public class NettyStream implements Stream<Muxer.MuxerAdress> {
 
-    private final Channel channel;
-    private final boolean initiator;
-    private final Muxer.MuxerAdress localAddress;
-    private final Muxer.MuxerAdress remoteAddress;
+  private final Channel channel;
+  private final boolean initiator;
+  private final Muxer.MuxerAdress localAddress;
+  private final Muxer.MuxerAdress remoteAddress;
 
-    public NettyStream(Channel channel, boolean initiator,
-                       Muxer.MuxerAdress localAddress,
-                       Muxer.MuxerAdress remoteAddress) {
-        this.channel = channel;
-        this.initiator = initiator;
-        this.localAddress = localAddress;
-        this.remoteAddress = remoteAddress;
-    }
+  public NettyStream(
+      Channel channel,
+      boolean initiator,
+      Muxer.MuxerAdress localAddress,
+      Muxer.MuxerAdress remoteAddress) {
+    this.channel = channel;
+    this.initiator = initiator;
+    this.localAddress = localAddress;
+    this.remoteAddress = remoteAddress;
+  }
 
-    public NettyStream(Channel channel, boolean initiator) {
-        this(channel, initiator, null, null);
-    }
+  public NettyStream(Channel channel, boolean initiator) {
+    this(channel, initiator, null, null);
+  }
 
-    @Override
-    public void write(ByteBuffer data) {
-        channel.write(Unpooled.wrappedBuffer(data));
-    }
+  @Override
+  public void write(ByteBuffer data) {
+    channel.write(Unpooled.wrappedBuffer(data));
+  }
 
-    @Override
-    public void flush() {
-        channel.flush();
-    }
+  @Override
+  public void flush() {
+    channel.flush();
+  }
 
-    @Override
-    public boolean isInitiator() {
-        return initiator;
-    }
+  @Override
+  public boolean isInitiator() {
+    return initiator;
+  }
 
-    @Override
-    public void close() {
-        channel.close();
-    }
+  @Override
+  public void close() {
+    channel.close();
+  }
 
-    @Override
-    public Muxer.MuxerAdress getRemoteAddress() {
-        return remoteAddress;
-    }
+  @Override
+  public Muxer.MuxerAdress getRemoteAddress() {
+    return remoteAddress;
+  }
 
-    @Override
-    public Muxer.MuxerAdress getLocalAddress() {
-        return localAddress;
-    }
+  @Override
+  public Muxer.MuxerAdress getLocalAddress() {
+    return localAddress;
+  }
 
-    @Override
-    public String toString() {
-        return "NettyStream{" + getLocalAddress() + (isInitiator() ? " -> " : " <- ") + getRemoteAddress();
-    }
+  @Override
+  public String toString() {
+    return "NettyStream{"
+        + getLocalAddress()
+        + (isInitiator() ? " -> " : " <- ")
+        + getRemoteAddress();
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDDht.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDDht.java
@@ -6,150 +6,175 @@ import io.libp2p.tools.p2pd.libp2pj.DHT;
 import io.libp2p.tools.p2pd.libp2pj.Peer;
 import io.libp2p.tools.p2pd.libp2pj.PeerInfo;
 import io.libp2p.tools.p2pd.libp2pj.util.Cid;
-import p2pd.pb.P2Pd;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import p2pd.pb.P2Pd;
 
-/**
- * Created by Anton Nashatyrev on 20.12.2018.
- */
+/** Created by Anton Nashatyrev on 20.12.2018. */
 public class P2PDDht implements DHT {
-    private final AsyncDaemonExecutor daemonExecutor;
+  private final AsyncDaemonExecutor daemonExecutor;
 
-    public P2PDDht(AsyncDaemonExecutor daemonExecutor) {
-        this.daemonExecutor = daemonExecutor;
-    }
+  public P2PDDht(AsyncDaemonExecutor daemonExecutor) {
+    this.daemonExecutor = daemonExecutor;
+  }
 
-    @Override
-    public CompletableFuture<PeerInfo> findPeer(Peer peerId) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<P2Pd.Response> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                        .setType(P2Pd.DHTRequest.Type.FIND_PEER)
-                        .setPeer(ByteString.copyFrom(peerId.getIdBytes())))
-                    , new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> fromResp(r.getDht().getPeer()));
+  @Override
+  public CompletableFuture<PeerInfo> findPeer(Peer peerId) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<P2Pd.Response> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.FIND_PEER)
+                          .setPeer(ByteString.copyFrom(peerId.getIdBytes()))),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> fromResp(r.getDht().getPeer()));
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<List<PeerInfo>> findPeersConnectedToPeer(Peer peerId) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<List<P2Pd.DHTResponse>> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.FIND_PEERS_CONNECTED_TO_PEER)
-                            .setPeer(ByteString.copyFrom(peerId.getIdBytes())))
-                    , new DaemonChannelHandler.DHTListResponse());
+  @Override
+  public CompletableFuture<List<PeerInfo>> findPeersConnectedToPeer(Peer peerId) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<List<P2Pd.DHTResponse>> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.FIND_PEERS_CONNECTED_TO_PEER)
+                          .setPeer(ByteString.copyFrom(peerId.getIdBytes()))),
+                  new DaemonChannelHandler.DHTListResponse());
 
-            return resp.thenApply(list ->
-                list.stream().map(pi -> fromResp(pi.getPeer())).collect(Collectors.toList()));
+          return resp.thenApply(
+              list -> list.stream().map(pi -> fromResp(pi.getPeer())).collect(Collectors.toList()));
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<List<PeerInfo>> findProviders(Cid cid, int maxRetCount) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<List<P2Pd.DHTResponse>> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.FIND_PROVIDERS)
-                            .setCid(ByteString.copyFrom(cid.toBytes())))
-                    , new DaemonChannelHandler.DHTListResponse());
+  @Override
+  public CompletableFuture<List<PeerInfo>> findProviders(Cid cid, int maxRetCount) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<List<P2Pd.DHTResponse>> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.FIND_PROVIDERS)
+                          .setCid(ByteString.copyFrom(cid.toBytes()))),
+                  new DaemonChannelHandler.DHTListResponse());
 
-            return resp.thenApply(list ->list.stream()
-                            .map(pi -> fromResp(pi.getPeer())).collect(Collectors.toList()));
+          return resp.thenApply(
+              list -> list.stream().map(pi -> fromResp(pi.getPeer())).collect(Collectors.toList()));
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<List<PeerInfo>> getClosestPeers(byte[] key) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<List<P2Pd.DHTResponse>> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.GET_CLOSEST_PEERS)
-                            .setKey(ByteString.copyFrom(key)))
-                    , new DaemonChannelHandler.DHTListResponse());
+  @Override
+  public CompletableFuture<List<PeerInfo>> getClosestPeers(byte[] key) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<List<P2Pd.DHTResponse>> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.GET_CLOSEST_PEERS)
+                          .setKey(ByteString.copyFrom(key))),
+                  new DaemonChannelHandler.DHTListResponse());
 
-            return resp.thenApply(list ->list.stream()
-                            .map(pi -> fromResp(pi.getPeer())).collect(Collectors.toList()));
+          return resp.thenApply(
+              list -> list.stream().map(pi -> fromResp(pi.getPeer())).collect(Collectors.toList()));
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<byte[]> getPublicKey(Peer peerId) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<P2Pd.Response> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.GET_PUBLIC_KEY)
-                            .setPeer(ByteString.copyFrom(peerId.getIdBytes())))
-                    , new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> r.getDht().getValue().toByteArray());
+  @Override
+  public CompletableFuture<byte[]> getPublicKey(Peer peerId) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<P2Pd.Response> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.GET_PUBLIC_KEY)
+                          .setPeer(ByteString.copyFrom(peerId.getIdBytes()))),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> r.getDht().getValue().toByteArray());
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<byte[]> getValue(byte[] key) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<P2Pd.Response> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.GET_VALUE)
-                            .setKey(ByteString.copyFrom(key)))
-                    , new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> r.getDht().getValue().toByteArray());
+  @Override
+  public CompletableFuture<byte[]> getValue(byte[] key) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<P2Pd.Response> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.GET_VALUE)
+                          .setKey(ByteString.copyFrom(key))),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> r.getDht().getValue().toByteArray());
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<List<byte[]>> searchValue(byte[] key) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<List<P2Pd.DHTResponse>> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.SEARCH_VALUE)
-                            .setKey(ByteString.copyFrom(key)))
-                    , new DaemonChannelHandler.DHTListResponse());
+  @Override
+  public CompletableFuture<List<byte[]>> searchValue(byte[] key) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<List<P2Pd.DHTResponse>> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.SEARCH_VALUE)
+                          .setKey(ByteString.copyFrom(key))),
+                  new DaemonChannelHandler.DHTListResponse());
 
-            return resp.thenApply(list ->list.stream()
-                    .map(val -> val.getValue().toByteArray()).collect(Collectors.toList()));
+          return resp.thenApply(
+              list ->
+                  list.stream()
+                      .map(val -> val.getValue().toByteArray())
+                      .collect(Collectors.toList()));
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<Void> putValue(byte[] key, byte[] value) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<P2Pd.Response> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.PUT_VALUE)
-                            .setKey(ByteString.copyFrom(key))
-                            .setValue(ByteString.copyFrom(value)))
-                    , new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> null);
+  @Override
+  public CompletableFuture<Void> putValue(byte[] key, byte[] value) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<P2Pd.Response> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.PUT_VALUE)
+                          .setKey(ByteString.copyFrom(key))
+                          .setValue(ByteString.copyFrom(value))),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> null);
         });
-    }
+  }
 
-    @Override
-    public CompletableFuture<Void> provide(Cid cid) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<P2Pd.Response> resp = h.call(
-                    newDhtRequest(P2Pd.DHTRequest.newBuilder()
-                            .setType(P2Pd.DHTRequest.Type.PROVIDE)
-                            .setCid(ByteString.copyFrom(cid.toBytes())))
-                    , new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> null);
+  @Override
+  public CompletableFuture<Void> provide(Cid cid) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<P2Pd.Response> resp =
+              h.call(
+                  newDhtRequest(
+                      P2Pd.DHTRequest.newBuilder()
+                          .setType(P2Pd.DHTRequest.Type.PROVIDE)
+                          .setCid(ByteString.copyFrom(cid.toBytes()))),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> null);
         });
-    }
+  }
 
-    private static PeerInfo fromResp(P2Pd.PeerInfo pi) {
-        return new PeerInfo(new Peer(pi.getId().toByteArray()),
-                pi.getAddrsList().stream()
-                        .map(addr -> Multiaddr.deserialize(addr.toByteArray()))
-                        .collect(Collectors.toList()));
-    }
+  private static PeerInfo fromResp(P2Pd.PeerInfo pi) {
+    return new PeerInfo(
+        new Peer(pi.getId().toByteArray()),
+        pi.getAddrsList().stream()
+            .map(addr -> Multiaddr.deserialize(addr.toByteArray()))
+            .collect(Collectors.toList()));
+  }
 
-    private static P2Pd.Request newDhtRequest(P2Pd.DHTRequest.Builder dht) {
-        return P2Pd.Request.newBuilder()
-                .setType(P2Pd.Request.Type.DHT)
-                .setDht(dht)
-                .build();
-    }
+  private static P2Pd.Request newDhtRequest(P2Pd.DHTRequest.Builder dht) {
+    return P2Pd.Request.newBuilder().setType(P2Pd.Request.Type.DHT).setDht(dht).build();
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDError.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDError.java
@@ -1,10 +1,8 @@
 package io.libp2p.tools.p2pd;
 
-/**
- * Created by Anton Nashatyrev on 14.12.2018.
- */
+/** Created by Anton Nashatyrev on 14.12.2018. */
 public class P2PDError extends RuntimeException {
-    public P2PDError(String message) {
-        super(message);
-    }
+  public P2PDError(String message) {
+    super(message);
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDHost.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDHost.java
@@ -10,8 +10,6 @@ import io.libp2p.tools.p2pd.libp2pj.StreamHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.unix.DomainSocketAddress;
-import p2pd.pb.P2Pd;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -22,174 +20,203 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import p2pd.pb.P2Pd;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public class P2PDHost implements Host {
-    private AsyncDaemonExecutor daemonExecutor;
+  private AsyncDaemonExecutor daemonExecutor;
 
-    private final int requestTimeoutSec = 5;
+  private final int requestTimeoutSec = 5;
 
-    public static P2PDHost createDefaultDomainSocket() {
-        return new P2PDHost(new DomainSocketAddress("/tmp/p2pd.sock"));
+  public static P2PDHost createDefaultDomainSocket() {
+    return new P2PDHost(new DomainSocketAddress("/tmp/p2pd.sock"));
+  }
+
+  public P2PDHost(SocketAddress addr) {
+    daemonExecutor = new AsyncDaemonExecutor(addr);
+  }
+
+  @Override
+  public DHT getDht() {
+    return new P2PDDht(daemonExecutor);
+  }
+
+  public P2PDPubsub getPubsub() {
+    return new P2PDPubsub(daemonExecutor);
+  }
+
+  @Override
+  public Peer getMyId() {
+    try {
+      return new Peer(identify().get().getId().toByteArray());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    public P2PDHost(SocketAddress addr) {
-        daemonExecutor = new AsyncDaemonExecutor(addr);
+  @Override
+  public List<Multiaddr> getListenAddresses() {
+    try {
+      return identify().get().getAddrsList().stream()
+          .map(bs -> Multiaddr.deserialize(bs.toByteArray()))
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    @Override
-    public DHT getDht() {
-        return new P2PDDht(daemonExecutor);
-    }
+  private CompletableFuture<P2Pd.IdentifyResponse> identify() {
+    return daemonExecutor.executeWithDaemon(
+        h ->
+            h.call(
+                    P2Pd.Request.newBuilder().setType(P2Pd.Request.Type.IDENTIFY).build(),
+                    new DaemonChannelHandler.SimpleResponseBuilder())
+                .thenApply(P2Pd.Response::getIdentify));
+  }
 
-    public P2PDPubsub getPubsub() {
-        return new P2PDPubsub(daemonExecutor);
-    }
-
-    @Override
-    public Peer getMyId() {
-        try {
-            return new Peer(identify().get().getId().toByteArray());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Override
-    public List<Multiaddr> getListenAddresses() {
-        try {
-            return identify().get().getAddrsList().stream()
-                    .map(bs -> Multiaddr.deserialize(bs.toByteArray()))
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private CompletableFuture<P2Pd.IdentifyResponse> identify() {
-        return daemonExecutor.executeWithDaemon(h ->
-            h.call(P2Pd.Request.newBuilder()
-                    .setType(P2Pd.Request.Type.IDENTIFY)
-                    .build(), new DaemonChannelHandler.SimpleResponseBuilder())
-                    .thenApply(P2Pd.Response::getIdentify)
-        );
-    }
-
-    @Override
-    public CompletableFuture<Void> connect(List<Multiaddr> peerAddresses, Peer peerId) {
-        return daemonExecutor.executeWithDaemon(handler -> {
-            CompletableFuture<P2Pd.Response> resp = handler.call(P2Pd.Request.newBuilder()
-                            .setType(P2Pd.Request.Type.CONNECT)
-                            .setConnect(P2Pd.ConnectRequest.newBuilder()
-                                    .setPeer(ByteString.copyFrom(peerId.getIdBytes()))
-                                    .addAllAddrs(peerAddresses.stream()
-                                                    .map(addr -> ByteString.copyFrom(addr.serialize()))
-                                                    .collect(Collectors.toList()))
-                                    .setTimeout(requestTimeoutSec)
-                                    .build()
-                            ).build(),
-                    new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> null);
+  @Override
+  public CompletableFuture<Void> connect(List<Multiaddr> peerAddresses, Peer peerId) {
+    return daemonExecutor.executeWithDaemon(
+        handler -> {
+          CompletableFuture<P2Pd.Response> resp =
+              handler.call(
+                  P2Pd.Request.newBuilder()
+                      .setType(P2Pd.Request.Type.CONNECT)
+                      .setConnect(
+                          P2Pd.ConnectRequest.newBuilder()
+                              .setPeer(ByteString.copyFrom(peerId.getIdBytes()))
+                              .addAllAddrs(
+                                  peerAddresses.stream()
+                                      .map(addr -> ByteString.copyFrom(addr.serialize()))
+                                      .collect(Collectors.toList()))
+                              .setTimeout(requestTimeoutSec)
+                              .build())
+                      .build(),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> null);
         });
-    }
+  }
 
-    private final List<Closeable> activeChannels = new Vector<>();
-    private final AtomicInteger counter = new AtomicInteger();
+  private final List<Closeable> activeChannels = new Vector<>();
+  private final AtomicInteger counter = new AtomicInteger();
 
-    @Override
-    public CompletableFuture<Void> dial(MuxerAdress muxerAdress, StreamHandler<MuxerAdress> streamHandler) {
-        try {
-            return daemonExecutor.getDaemon().thenCompose(handler -> {
+  @Override
+  public CompletableFuture<Void> dial(
+      MuxerAdress muxerAdress, StreamHandler<MuxerAdress> streamHandler) {
+    try {
+      return daemonExecutor
+          .getDaemon()
+          .thenCompose(
+              handler -> {
                 try {
-                    handler.setStreamHandler(new StreamHandlerWrapper<>(streamHandler)
-                            .onCreate(s -> activeChannels.add(handler))
-                            .onClose(() -> activeChannels.remove(handler))
-                    );
-                    CompletableFuture<P2Pd.Response> resp = handler.call(P2Pd.Request.newBuilder()
-                                    .setType(P2Pd.Request.Type.STREAM_OPEN)
-                                    .setStreamOpen(P2Pd.StreamOpenRequest.newBuilder()
-                                            .setPeer(ByteString.copyFrom(muxerAdress.getPeer().getIdBytes()))
-                                            .addAllProto(muxerAdress.getProtocols().stream()
-                                                    .map(Protocol::getName).collect(Collectors.toList()))
-                                            .setTimeout(requestTimeoutSec)
-                                            .build()
-                                    ).build(),
-                            new DaemonChannelHandler.SimpleResponseStreamBuilder());
-                    return resp.whenComplete((r, t) -> {
-                        if (t != null) {
-                            streamHandler.onError(t);
-                            handler.close();
-                        }
-                    }).thenApply(r -> null);
+                  handler.setStreamHandler(
+                      new StreamHandlerWrapper<>(streamHandler)
+                          .onCreate(s -> activeChannels.add(handler))
+                          .onClose(() -> activeChannels.remove(handler)));
+                  CompletableFuture<P2Pd.Response> resp =
+                      handler.call(
+                          P2Pd.Request.newBuilder()
+                              .setType(P2Pd.Request.Type.STREAM_OPEN)
+                              .setStreamOpen(
+                                  P2Pd.StreamOpenRequest.newBuilder()
+                                      .setPeer(
+                                          ByteString.copyFrom(muxerAdress.getPeer().getIdBytes()))
+                                      .addAllProto(
+                                          muxerAdress.getProtocols().stream()
+                                              .map(Protocol::getName)
+                                              .collect(Collectors.toList()))
+                                      .setTimeout(requestTimeoutSec)
+                                      .build())
+                              .build(),
+                          new DaemonChannelHandler.SimpleResponseStreamBuilder());
+                  return resp.whenComplete(
+                          (r, t) -> {
+                            if (t != null) {
+                              streamHandler.onError(t);
+                              handler.close();
+                            }
+                          })
+                      .thenApply(r -> null);
                 } catch (Exception e) {
-                    handler.close();
-                    throw new RuntimeException(e);
+                  handler.close();
+                  throw new RuntimeException(e);
                 }
+              });
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Closeable> listen(
+      MuxerAdress muxerAdress, Supplier<StreamHandler<MuxerAdress>> handlerFactory) {
+    Multiaddr listenMultiaddr;
+    SocketAddress listenAddr;
+    ControlConnector connector;
+    if (daemonExecutor.getAddress() instanceof InetSocketAddress) {
+      connector = new TCPControlConnector();
+      int port = 46666 + counter.incrementAndGet();
+      listenAddr = new InetSocketAddress("127.0.0.1", port);
+      listenMultiaddr = new Multiaddr("/ip4/127.0.0.1/tcp/46666");
+    } else if (daemonExecutor.getAddress() instanceof DomainSocketAddress) {
+      connector = new UnixSocketControlConnector();
+      String path = "/tmp/p2pd.client." + counter.incrementAndGet();
+      listenAddr = new DomainSocketAddress(path);
+      listenMultiaddr = new Multiaddr("/unix" + path);
+    } else {
+      throw new IllegalStateException();
+    }
+
+    ChannelFuture channelFuture =
+        connector.listen(
+            listenAddr,
+            h -> {
+              StreamHandler<MuxerAdress> streamHandler = handlerFactory.get();
+              h.setStreamHandler(streamHandler);
+              CompletableFuture<P2Pd.StreamInfo> response =
+                  h.expectResponse(new DaemonChannelHandler.ListenerStreamBuilder());
+              response.whenComplete(
+                  (r, t) -> {
+                    if (t != null) {
+                      streamHandler.onError(t);
+                    }
+                  });
             });
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 
-    @Override
-    public CompletableFuture<Closeable> listen(MuxerAdress muxerAdress, Supplier<StreamHandler<MuxerAdress>> handlerFactory) {
-        Multiaddr listenMultiaddr;
-        SocketAddress listenAddr;
-        ControlConnector connector;
-        if (daemonExecutor.getAddress() instanceof InetSocketAddress) {
-            connector = new TCPControlConnector();
-            int port = 46666 + counter.incrementAndGet();
-            listenAddr = new InetSocketAddress("127.0.0.1", port);
-            listenMultiaddr = new Multiaddr("/ip4/127.0.0.1/tcp/46666");
-        } else if (daemonExecutor.getAddress() instanceof DomainSocketAddress) {
-            connector = new UnixSocketControlConnector();
-            String path = "/tmp/p2pd.client." + counter.incrementAndGet();
-            listenAddr = new DomainSocketAddress(path);
-            listenMultiaddr = new Multiaddr("/unix" + path);
-        } else {
-            throw new IllegalStateException();
-        }
+    channelFuture.addListener(
+        (ChannelFutureListener) future -> activeChannels.add(() -> future.channel().close()));
 
-        ChannelFuture channelFuture = connector.listen(listenAddr, h -> {
-            StreamHandler<MuxerAdress> streamHandler = handlerFactory.get();
-            h.setStreamHandler(streamHandler);
-            CompletableFuture<P2Pd.StreamInfo> response = h.expectResponse(new DaemonChannelHandler.ListenerStreamBuilder());
-            response.whenComplete((r, t) -> {
-                if (t != null) {
-                    streamHandler.onError(t);
-                }
-            });
+    Closeable ret = () -> channelFuture.channel().close();
+    return Util.channelFutureToJava(channelFuture)
+        .thenCompose(
+            channel ->
+                daemonExecutor.executeWithDaemon(
+                    handler ->
+                        handler.call(
+                            P2Pd.Request.newBuilder()
+                                .setType(P2Pd.Request.Type.STREAM_HANDLER)
+                                .setStreamHandler(
+                                    P2Pd.StreamHandlerRequest.newBuilder()
+                                        .setAddr(ByteString.copyFrom(listenMultiaddr.serialize()))
+                                        .addAllProto(
+                                            muxerAdress.getProtocols().stream()
+                                                .map(Protocol::getName)
+                                                .collect(Collectors.toList()))
+                                        .build())
+                                .build(),
+                            new DaemonChannelHandler.SimpleResponseBuilder())))
+        .thenApply(resp1 -> ret);
+  }
+
+  @Override
+  public void close() {
+    activeChannels.forEach(
+        ch -> {
+          try {
+            ch.close();
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
         });
-
-        channelFuture.addListener((ChannelFutureListener)
-                future -> activeChannels.add(() -> future.channel().close()));
-
-        Closeable ret = () -> channelFuture.channel().close();
-        return Util.channelFutureToJava(channelFuture)
-                .thenCompose(channel ->
-                        daemonExecutor.executeWithDaemon(handler ->
-                            handler.call(P2Pd.Request.newBuilder()
-                                        .setType(P2Pd.Request.Type.STREAM_HANDLER)
-                                        .setStreamHandler(P2Pd.StreamHandlerRequest.newBuilder()
-                                            .setAddr(ByteString.copyFrom(listenMultiaddr.serialize()))
-                                            .addAllProto(muxerAdress.getProtocols().stream()
-                                                .map(Protocol::getName).collect(Collectors.toList()))
-                                            .build()
-                                        ).build(),
-                                    new DaemonChannelHandler.SimpleResponseBuilder())))
-                .thenApply(resp1 -> ret);
-    }
-
-    @Override
-    public void close() {
-        activeChannels.forEach(ch -> {
-            try {
-                ch.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        });
-    }
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDPubsub.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/P2PDPubsub.java
@@ -1,56 +1,56 @@
 package io.libp2p.tools.p2pd;
 
 import com.google.protobuf.ByteString;
-import p2pd.pb.P2Pd;
-
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import p2pd.pb.P2Pd;
 
-/**
- * Created by Anton Nashatyrev on 20.12.2018.
- */
+/** Created by Anton Nashatyrev on 20.12.2018. */
 public class P2PDPubsub {
-    private final AsyncDaemonExecutor daemonExecutor;
+  private final AsyncDaemonExecutor daemonExecutor;
 
-    public P2PDPubsub(AsyncDaemonExecutor daemonExecutor) {
-        this.daemonExecutor = daemonExecutor;
-    }
+  public P2PDPubsub(AsyncDaemonExecutor daemonExecutor) {
+    this.daemonExecutor = daemonExecutor;
+  }
 
-    public CompletableFuture<BlockingQueue<P2Pd.PSMessage>> subscribe(String topic) {
-        return daemonExecutor.getDaemon().thenCompose(h -> {
-            return h.call(
-                    newPubsubRequest(P2Pd.PSRequest.newBuilder()
-                            .setType(P2Pd.PSRequest.Type.SUBSCRIBE)
-                            .setTopic(topic))
-                    , new DaemonChannelHandler.UnboundMessagesResponse<>(
-                            is -> {
-                                try {
-                                    return P2Pd.PSMessage.parseDelimitedFrom(is);
-                                } catch (IOException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
-                    ));
+  public CompletableFuture<BlockingQueue<P2Pd.PSMessage>> subscribe(String topic) {
+    return daemonExecutor
+        .getDaemon()
+        .thenCompose(
+            h -> {
+              return h.call(
+                  newPubsubRequest(
+                      P2Pd.PSRequest.newBuilder()
+                          .setType(P2Pd.PSRequest.Type.SUBSCRIBE)
+                          .setTopic(topic)),
+                  new DaemonChannelHandler.UnboundMessagesResponse<>(
+                      is -> {
+                        try {
+                          return P2Pd.PSMessage.parseDelimitedFrom(is);
+                        } catch (IOException e) {
+                          throw new RuntimeException(e);
+                        }
+                      }));
+            });
+  }
+
+  public CompletableFuture<Void> publish(String topic, byte[] data) {
+    return daemonExecutor.executeWithDaemon(
+        h -> {
+          CompletableFuture<P2Pd.Response> resp =
+              h.call(
+                  newPubsubRequest(
+                      P2Pd.PSRequest.newBuilder()
+                          .setType(P2Pd.PSRequest.Type.PUBLISH)
+                          .setTopic(topic)
+                          .setData(ByteString.copyFrom(data))),
+                  new DaemonChannelHandler.SimpleResponseBuilder());
+          return resp.thenApply(r -> null);
         });
-    }
+  }
 
-    public CompletableFuture<Void> publish(String topic, byte[] data) {
-        return daemonExecutor.executeWithDaemon(h -> {
-            CompletableFuture<P2Pd.Response> resp = h.call(
-                    newPubsubRequest(P2Pd.PSRequest.newBuilder()
-                            .setType(P2Pd.PSRequest.Type.PUBLISH)
-                            .setTopic(topic)
-                            .setData(ByteString.copyFrom(data)))
-                    , new DaemonChannelHandler.SimpleResponseBuilder());
-            return resp.thenApply(r -> null);
-        });
-    }
-
-    private static P2Pd.Request newPubsubRequest(P2Pd.PSRequest.Builder pubsub) {
-        return P2Pd.Request.newBuilder()
-                .setType(P2Pd.Request.Type.PUBSUB)
-                .setPubsub(pubsub)
-                .build();
-    }
+  private static P2Pd.Request newPubsubRequest(P2Pd.PSRequest.Builder pubsub) {
+    return P2Pd.Request.newBuilder().setType(P2Pd.Request.Type.PUBSUB).setPubsub(pubsub).build();
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/StreamHandlerWrapper.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/StreamHandlerWrapper.java
@@ -2,55 +2,52 @@ package io.libp2p.tools.p2pd;
 
 import io.libp2p.tools.p2pd.libp2pj.Stream;
 import io.libp2p.tools.p2pd.libp2pj.StreamHandler;
-
 import java.nio.ByteBuffer;
 import java.util.function.Consumer;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public class StreamHandlerWrapper<TEndpoint> implements StreamHandler<TEndpoint> {
-    private final StreamHandler<TEndpoint> delegate;
-    private Consumer<Stream<TEndpoint>> onCreateListener;
-    private Runnable onCloseListener;
+  private final StreamHandler<TEndpoint> delegate;
+  private Consumer<Stream<TEndpoint>> onCreateListener;
+  private Runnable onCloseListener;
 
-    public StreamHandlerWrapper(StreamHandler<TEndpoint> delegate) {
-        this.delegate = delegate;
-    }
+  public StreamHandlerWrapper(StreamHandler<TEndpoint> delegate) {
+    this.delegate = delegate;
+  }
 
-    public StreamHandlerWrapper<TEndpoint> onCreate(Consumer<Stream<TEndpoint>> listener) {
-        this.onCreateListener = listener;
-        return this;
-    }
+  public StreamHandlerWrapper<TEndpoint> onCreate(Consumer<Stream<TEndpoint>> listener) {
+    this.onCreateListener = listener;
+    return this;
+  }
 
-    public StreamHandlerWrapper<TEndpoint> onClose(Runnable listener) {
-        this.onCloseListener = listener;
-        return this;
-    }
+  public StreamHandlerWrapper<TEndpoint> onClose(Runnable listener) {
+    this.onCloseListener = listener;
+    return this;
+  }
 
-    @Override
-    public void onCreate(Stream<TEndpoint> stream) {
-        delegate.onCreate(stream);
-        if (onCreateListener != null) {
-            onCreateListener.accept(stream);
-        }
+  @Override
+  public void onCreate(Stream<TEndpoint> stream) {
+    delegate.onCreate(stream);
+    if (onCreateListener != null) {
+      onCreateListener.accept(stream);
     }
+  }
 
-    @Override
-    public void onRead(ByteBuffer data) {
-        delegate.onRead(data);
-    }
+  @Override
+  public void onRead(ByteBuffer data) {
+    delegate.onRead(data);
+  }
 
-    @Override
-    public void onClose() {
-        delegate.onClose();
-        if (onCloseListener != null) {
-            onCloseListener.run();
-        }
+  @Override
+  public void onClose() {
+    delegate.onClose();
+    if (onCloseListener != null) {
+      onCloseListener.run();
     }
+  }
 
-    @Override
-    public void onError(Throwable error) {
-        delegate.onError(error);
-    }
+  @Override
+  public void onError(Throwable error) {
+    delegate.onError(error);
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/TCPControlConnector.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/TCPControlConnector.java
@@ -8,47 +8,48 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-/**
- * Created by Anton Nashatyrev on 06.08.2019.
- */
+/** Created by Anton Nashatyrev on 06.08.2019. */
 public class TCPControlConnector extends ControlConnector {
-    static NioEventLoopGroup group = new NioEventLoopGroup();
+  static NioEventLoopGroup group = new NioEventLoopGroup();
 
-    public CompletableFuture<DaemonChannelHandler> connect(String host, int port) {
-        return connect(new InetSocketAddress(host, port));
-    }
-    public CompletableFuture<DaemonChannelHandler> connect(SocketAddress addr) {
-        CompletableFuture<DaemonChannelHandler> ret = new CompletableFuture<>();
+  public CompletableFuture<DaemonChannelHandler> connect(String host, int port) {
+    return connect(new InetSocketAddress(host, port));
+  }
 
-        ChannelFuture channelFuture = new Bootstrap()
-                .group(group)
-                .channel(NioSocketChannel.class)
-                .handler(new ChannelInit(ret::complete, true))
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
-                .connect(addr);
+  public CompletableFuture<DaemonChannelHandler> connect(SocketAddress addr) {
+    CompletableFuture<DaemonChannelHandler> ret = new CompletableFuture<>();
 
-        channelFuture.addListener((ChannelFutureListener) future -> {
-            try {
+    ChannelFuture channelFuture =
+        new Bootstrap()
+            .group(group)
+            .channel(NioSocketChannel.class)
+            .handler(new ChannelInit(ret::complete, true))
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
+            .connect(addr);
+
+    channelFuture.addListener(
+        (ChannelFutureListener)
+            future -> {
+              try {
                 future.get();
-            } catch (Exception e) {
+              } catch (Exception e) {
                 ret.completeExceptionally(e);
-            }
-        });
-        return ret;
-    }
+              }
+            });
+    return ret;
+  }
 
-    public ChannelFuture listen(SocketAddress addr, Consumer<DaemonChannelHandler> handlersConsumer) {
-        return new ServerBootstrap()
-                .group(group)
-                .channel(NioServerSocketChannel.class)
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
-                .childHandler(new ChannelInit(handlersConsumer, false))
-                .bind(addr);
-    }
+  public ChannelFuture listen(SocketAddress addr, Consumer<DaemonChannelHandler> handlersConsumer) {
+    return new ServerBootstrap()
+        .group(group)
+        .channel(NioServerSocketChannel.class)
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
+        .childHandler(new ChannelInit(handlersConsumer, false))
+        .bind(addr);
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/UnixSocketControlConnector.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/UnixSocketControlConnector.java
@@ -10,55 +10,56 @@ import io.netty.channel.epoll.EpollDomainSocketChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerDomainSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
-
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-/**
- * Created by Anton Nashatyrev on 06.08.2019.
- */
+/** Created by Anton Nashatyrev on 06.08.2019. */
 public class UnixSocketControlConnector extends ControlConnector {
-    protected static final EventLoopGroup group = new EpollEventLoopGroup();
+  protected static final EventLoopGroup group = new EpollEventLoopGroup();
 
-    public CompletableFuture<DaemonChannelHandler> connect() {
-        return connect("/tmp/p2pd.sock");
-    }
+  public CompletableFuture<DaemonChannelHandler> connect() {
+    return connect("/tmp/p2pd.sock");
+  }
 
-    public CompletableFuture<DaemonChannelHandler> connect(String socketPath) {
-        return connect(new DomainSocketAddress(socketPath));
-    }
-    public CompletableFuture<DaemonChannelHandler> connect(SocketAddress addr) {
-        CompletableFuture<DaemonChannelHandler> ret = new CompletableFuture<>();
+  public CompletableFuture<DaemonChannelHandler> connect(String socketPath) {
+    return connect(new DomainSocketAddress(socketPath));
+  }
 
-        ChannelFuture channelFuture = new Bootstrap()
-                .group(group)
-                .channel(EpollDomainSocketChannel.class)
-                .handler(new ChannelInit(ret::complete, true))
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
-                .connect(addr);
+  public CompletableFuture<DaemonChannelHandler> connect(SocketAddress addr) {
+    CompletableFuture<DaemonChannelHandler> ret = new CompletableFuture<>();
 
-        channelFuture.addListener((ChannelFutureListener) future -> {
-            try {
+    ChannelFuture channelFuture =
+        new Bootstrap()
+            .group(group)
+            .channel(EpollDomainSocketChannel.class)
+            .handler(new ChannelInit(ret::complete, true))
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
+            .connect(addr);
+
+    channelFuture.addListener(
+        (ChannelFutureListener)
+            future -> {
+              try {
                 future.get();
-            } catch (Exception e) {
+              } catch (Exception e) {
                 ret.completeExceptionally(e);
-            }
-        });
-        return ret;
-    }
+              }
+            });
+    return ret;
+  }
 
-    public ChannelFuture listen(String socketPath, Consumer<DaemonChannelHandler> handlersConsumer) {
-        return listen(new DomainSocketAddress(socketPath), handlersConsumer);
-    }
+  public ChannelFuture listen(String socketPath, Consumer<DaemonChannelHandler> handlersConsumer) {
+    return listen(new DomainSocketAddress(socketPath), handlersConsumer);
+  }
 
-    public ChannelFuture listen(SocketAddress addr, Consumer<DaemonChannelHandler> handlersConsumer) {
+  public ChannelFuture listen(SocketAddress addr, Consumer<DaemonChannelHandler> handlersConsumer) {
 
-        return new ServerBootstrap()
-                .group(group)
-                .channel(EpollServerDomainSocketChannel.class)
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
-                .childHandler(new ChannelInit(handlersConsumer, false))
-                .bind(addr);
-    }
+    return new ServerBootstrap()
+        .group(group)
+        .channel(EpollServerDomainSocketChannel.class)
+        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutSec * 1000)
+        .childHandler(new ChannelInit(handlersConsumer, false))
+        .bind(addr);
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/Util.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/Util.java
@@ -8,70 +8,73 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
-
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public class Util {
-    public static <V> Future<V> futureFromJavaToNetty(CompletableFuture<V> javaFut) {
-        Promise<V> ret = ImmediateEventExecutor.INSTANCE.newPromise();
-        javaFut.handle((v, t) -> {
-            if (t != null) ret.setFailure(t);
-            else ret.setSuccess(v);
-            return null;
+  public static <V> Future<V> futureFromJavaToNetty(CompletableFuture<V> javaFut) {
+    Promise<V> ret = ImmediateEventExecutor.INSTANCE.newPromise();
+    javaFut.handle(
+        (v, t) -> {
+          if (t != null) ret.setFailure(t);
+          else ret.setSuccess(v);
+          return null;
         });
-        return ret;
-    }
+    return ret;
+  }
 
-    public static CompletableFuture<Channel> channelFutureToJava(ChannelFuture channelFuture) {
-        CompletableFuture<Channel> ret = new CompletableFuture<>();
-        channelFuture.addListener((ChannelFutureListener) future -> {
-            try {
+  public static CompletableFuture<Channel> channelFutureToJava(ChannelFuture channelFuture) {
+    CompletableFuture<Channel> ret = new CompletableFuture<>();
+    channelFuture.addListener(
+        (ChannelFutureListener)
+            future -> {
+              try {
                 future.get();
                 ret.complete(future.channel());
-            } catch (Exception e) {
+              } catch (Exception e) {
                 ret.completeExceptionally(e);
-            }
-        });
-        return ret;
-    }
+              }
+            });
+    return ret;
+  }
 
-    public static <V> CompletableFuture<V> futureFromNettyToJava(Future<V> nettyFut) {
-        CompletableFuture<V> ret = new CompletableFuture<>();
-        addListener(nettyFut, ret::complete, ret::completeExceptionally);
-        return ret;
-    }
+  public static <V> CompletableFuture<V> futureFromNettyToJava(Future<V> nettyFut) {
+    CompletableFuture<V> ret = new CompletableFuture<>();
+    addListener(nettyFut, ret::complete, ret::completeExceptionally);
+    return ret;
+  }
 
-    private static <V> void addListener(Future<V> future, Consumer<V> success, Consumer<Throwable> error) {
-        if (future == null) return;
+  private static <V> void addListener(
+      Future<V> future, Consumer<V> success, Consumer<Throwable> error) {
+    if (future == null) return;
 
-        future.addListener((GenericFutureListener<Future<V>>) f -> {
-            try {
+    future.addListener(
+        (GenericFutureListener<Future<V>>)
+            f -> {
+              try {
                 V v = f.get();
                 if (success != null) success.accept(v);
-            } catch (Throwable e) {
+              } catch (Throwable e) {
                 if (error != null) error.accept(e);
-            }
-        });
-    }
+              }
+            });
+  }
 
-    private static <V> Promise<V> newPromise() {
-        return ImmediateEventExecutor.INSTANCE.newPromise();
-    }
+  private static <V> Promise<V> newPromise() {
+    return ImmediateEventExecutor.INSTANCE.newPromise();
+  }
 
-    public static byte[] byteBufToArray(ByteBuf bb) {
-        byte[] ret = new byte[bb.readableBytes()];
-        bb.readBytes(ret);
-        return ret;
-    }
+  public static byte[] byteBufToArray(ByteBuf bb) {
+    byte[] ret = new byte[bb.readableBytes()];
+    bb.readBytes(ret);
+    return ret;
+  }
 
-    public static byte[] byteBufferToArray(ByteBuffer bb) {
-        byte[] ret = new byte[bb.remaining()];
-        bb.get(ret);
-        return ret;
-    }
+  public static byte[] byteBufferToArray(ByteBuffer bb) {
+    byte[] ret = new byte[bb.remaining()];
+    bb.get(ret);
+    return ret;
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Connector.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Connector.java
@@ -4,14 +4,11 @@ import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public interface Connector<TListener extends Closeable, TEndpoint> {
 
-    CompletableFuture<Void> dial(TEndpoint address,
-                                 StreamHandler<TEndpoint> handler);
+  CompletableFuture<Void> dial(TEndpoint address, StreamHandler<TEndpoint> handler);
 
-    CompletableFuture<TListener> listen(TEndpoint listenAddress,
-                                        Supplier<StreamHandler<TEndpoint>> handlerFactory);
+  CompletableFuture<TListener> listen(
+      TEndpoint listenAddress, Supplier<StreamHandler<TEndpoint>> handlerFactory);
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/DHT.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/DHT.java
@@ -1,29 +1,26 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
 import io.libp2p.tools.p2pd.libp2pj.util.Cid;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-/**
- * Created by Anton Nashatyrev on 21.12.2018.
- */
+/** Created by Anton Nashatyrev on 21.12.2018. */
 public interface DHT {
-    CompletableFuture<PeerInfo> findPeer(Peer peerId);
+  CompletableFuture<PeerInfo> findPeer(Peer peerId);
 
-    CompletableFuture<List<PeerInfo>> findPeersConnectedToPeer(Peer peerId);
+  CompletableFuture<List<PeerInfo>> findPeersConnectedToPeer(Peer peerId);
 
-    CompletableFuture<List<PeerInfo>> findProviders(Cid cid, int maxRetCount);
+  CompletableFuture<List<PeerInfo>> findProviders(Cid cid, int maxRetCount);
 
-    CompletableFuture<List<PeerInfo>> getClosestPeers(byte[] key);
+  CompletableFuture<List<PeerInfo>> getClosestPeers(byte[] key);
 
-    CompletableFuture<byte[]> getPublicKey(Peer peerId);
+  CompletableFuture<byte[]> getPublicKey(Peer peerId);
 
-    CompletableFuture<byte[]> getValue(byte[] key);
+  CompletableFuture<byte[]> getValue(byte[] key);
 
-    CompletableFuture<List<byte[]>> searchValue(byte[] key);
+  CompletableFuture<List<byte[]>> searchValue(byte[] key);
 
-    CompletableFuture<Void> putValue(byte[] key, byte[] value);
+  CompletableFuture<Void> putValue(byte[] key, byte[] value);
 
-    CompletableFuture<Void> provide(Cid cid);
+  CompletableFuture<Void> provide(Cid cid);
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Host.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Host.java
@@ -1,37 +1,34 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
 import io.libp2p.core.multiformats.Multiaddr;
-
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public interface Host extends Muxer {
 
-    Peer getMyId();
+  Peer getMyId();
 
-    List<Multiaddr> getListenAddresses();
+  List<Multiaddr> getListenAddresses();
 
-    CompletableFuture<Void> connect(List<Multiaddr> peerAddresses, Peer peerId);
+  CompletableFuture<Void> connect(List<Multiaddr> peerAddresses, Peer peerId);
 
-    @Override
-    CompletableFuture<Void> dial(MuxerAdress muxerAdress, StreamHandler<MuxerAdress> handler);
+  @Override
+  CompletableFuture<Void> dial(MuxerAdress muxerAdress, StreamHandler<MuxerAdress> handler);
 
-    @Override
-    CompletableFuture<Closeable> listen(MuxerAdress muxerAdress,
-                                        Supplier<StreamHandler<MuxerAdress>> handlerFactory);
+  @Override
+  CompletableFuture<Closeable> listen(
+      MuxerAdress muxerAdress, Supplier<StreamHandler<MuxerAdress>> handlerFactory);
 
-    void close();
+  void close();
 
-    DHT getDht();
+  DHT getDht();
 
-//    Peerstore getPeerStore();
+  //    Peerstore getPeerStore();
 
-//    Network getNetwork();
+  //    Network getNetwork();
 
-//    ConnectionManager getConnectionManager();
+  //    ConnectionManager getConnectionManager();
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Muxer.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Muxer.java
@@ -8,55 +8,52 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-/**
- * Created by Anton Nashatyrev on 10.12.2018.
- */
+/** Created by Anton Nashatyrev on 10.12.2018. */
 public interface Muxer extends Connector<Closeable, Muxer.MuxerAdress> {
 
-    @Override
-    CompletableFuture<Void> dial(MuxerAdress muxerAdress, StreamHandler<MuxerAdress> handler);
+  @Override
+  CompletableFuture<Void> dial(MuxerAdress muxerAdress, StreamHandler<MuxerAdress> handler);
 
-    @Override
-    CompletableFuture<Closeable> listen(MuxerAdress muxerAdress,
-                                        Supplier<StreamHandler<MuxerAdress>> handlerFactory);
+  @Override
+  CompletableFuture<Closeable> listen(
+      MuxerAdress muxerAdress, Supplier<StreamHandler<MuxerAdress>> handlerFactory);
 
-    public class MuxerAdress {
-        public static MuxerAdress listenAddress(String... protocolNames) {
-            return new MuxerAdress(null, protocolNames);
-        }
-
-        private final List<Protocol> protocols = new ArrayList<>();
-        private final Peer peer;
-
-        public MuxerAdress(Peer peer, String... protocolNames) {
-            this(Arrays.stream(protocolNames)
-                    .map(Protocol::new)
-                    .collect(Collectors.toList()), peer);
-        }
-
-        public MuxerAdress(List<Protocol> protocols, Peer peer) {
-            this.protocols.addAll(protocols);
-            this.peer = peer;
-        }
-
-        public MuxerAdress(Protocol protocol, Peer peer) {
-            this.protocols.add(protocol);
-            this.peer = peer;
-        }
-
-        public List<Protocol> getProtocols() {
-            return protocols;
-        }
-
-        public Peer getPeer() {
-            return peer;
-        }
-
-        @Override
-        public String toString() {
-            return peer + "[" +
-                    protocols.stream().map(Protocol::toString).collect(Collectors.joining(","))
-                    + "]";
-        }
+  public class MuxerAdress {
+    public static MuxerAdress listenAddress(String... protocolNames) {
+      return new MuxerAdress(null, protocolNames);
     }
+
+    private final List<Protocol> protocols = new ArrayList<>();
+    private final Peer peer;
+
+    public MuxerAdress(Peer peer, String... protocolNames) {
+      this(Arrays.stream(protocolNames).map(Protocol::new).collect(Collectors.toList()), peer);
+    }
+
+    public MuxerAdress(List<Protocol> protocols, Peer peer) {
+      this.protocols.addAll(protocols);
+      this.peer = peer;
+    }
+
+    public MuxerAdress(Protocol protocol, Peer peer) {
+      this.protocols.add(protocol);
+      this.peer = peer;
+    }
+
+    public List<Protocol> getProtocols() {
+      return protocols;
+    }
+
+    public Peer getPeer() {
+      return peer;
+    }
+
+    @Override
+    public String toString() {
+      return peer
+          + "["
+          + protocols.stream().map(Protocol::toString).collect(Collectors.joining(","))
+          + "]";
+    }
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Peer.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Peer.java
@@ -1,29 +1,27 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public class Peer {
-    private final byte[] id;
+  private final byte[] id;
 
-    public Peer(byte[] id) {
-        this.id = id;
-    }
+  public Peer(byte[] id) {
+    this.id = id;
+  }
 
-    public byte[] getIdBytes() {
-        return id;
-    }
+  public byte[] getIdBytes() {
+    return id;
+  }
 
-//    public String getIdBase58() {
-//        return Base58.encode(getIdBytes());
-//    }
-//
-//    public String getIdHexString() {
-//        return Hex.encodeHexString(getIdBytes());
-//    }
+  //    public String getIdBase58() {
+  //        return Base58.encode(getIdBytes());
+  //    }
+  //
+  //    public String getIdHexString() {
+  //        return Hex.encodeHexString(getIdBytes());
+  //    }
 
-//    @Override
-//    public String toString() {
-//        return "Peer{" + "id=" + getIdBase58() + "}";
-//    }
+  //    @Override
+  //    public String toString() {
+  //        return "Peer{" + "id=" + getIdBase58() + "}";
+  //    }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/PeerInfo.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/PeerInfo.java
@@ -1,34 +1,28 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
 import io.libp2p.core.multiformats.Multiaddr;
-
 import java.util.List;
 
-/**
- * Created by Anton Nashatyrev on 20.12.2018.
- */
+/** Created by Anton Nashatyrev on 20.12.2018. */
 public class PeerInfo {
-    private final Peer id;
-    private final List<Multiaddr> addresses;
+  private final Peer id;
+  private final List<Multiaddr> addresses;
 
-    public PeerInfo(Peer id, List<Multiaddr> addresses) {
-        this.id = id;
-        this.addresses = addresses;
-    }
+  public PeerInfo(Peer id, List<Multiaddr> addresses) {
+    this.id = id;
+    this.addresses = addresses;
+  }
 
-    public Peer getId() {
-        return id;
-    }
+  public Peer getId() {
+    return id;
+  }
 
-    public List<Multiaddr> getAddresses() {
-        return addresses;
-    }
+  public List<Multiaddr> getAddresses() {
+    return addresses;
+  }
 
-    @Override
-    public String toString() {
-        return "PeerInfo{" +
-                "id=" + id +
-                ", adresses=" + addresses +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "PeerInfo{" + "id=" + id + ", adresses=" + addresses + '}';
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Protocol.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Protocol.java
@@ -1,21 +1,19 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public class Protocol {
-    private final String name;
+  private final String name;
 
-    public Protocol(String name) {
-        this.name = name;
-    }
+  public Protocol(String name) {
+    this.name = name;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public String getName() {
+    return name;
+  }
 
-    @Override
-    public String toString() {
-        return getName();
-    }
+  @Override
+  public String toString() {
+    return getName();
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Stream.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Stream.java
@@ -2,20 +2,18 @@ package io.libp2p.tools.p2pd.libp2pj;
 
 import java.nio.ByteBuffer;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public interface Stream<TEndpoint> {
 
-    boolean isInitiator();
+  boolean isInitiator();
 
-    void write(ByteBuffer data);
+  void write(ByteBuffer data);
 
-    void flush();
+  void flush();
 
-    void close();
+  void close();
 
-    TEndpoint getRemoteAddress();
+  TEndpoint getRemoteAddress();
 
-    TEndpoint getLocalAddress();
+  TEndpoint getLocalAddress();
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/StreamHandler.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/StreamHandler.java
@@ -2,16 +2,14 @@ package io.libp2p.tools.p2pd.libp2pj;
 
 import java.nio.ByteBuffer;
 
-/**
- * Created by Anton Nashatyrev on 18.12.2018.
- */
+/** Created by Anton Nashatyrev on 18.12.2018. */
 public interface StreamHandler<TEndpoint> {
 
-    void onCreate(Stream<TEndpoint> stream);
+  void onCreate(Stream<TEndpoint> stream);
 
-    void onRead(ByteBuffer data);
+  void onRead(ByteBuffer data);
 
-    void onClose();
+  void onClose();
 
-    void onError(Throwable error);
+  void onError(Throwable error);
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Transport.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/Transport.java
@@ -1,34 +1,29 @@
 package io.libp2p.tools.p2pd.libp2pj;
 
 import io.libp2p.core.multiformats.Multiaddr;
-
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-/**
- * Created by Anton Nashatyrev on 10.12.2018.
- */
+/** Created by Anton Nashatyrev on 10.12.2018. */
 public interface Transport extends Connector<Transport.Listener, Multiaddr> {
 
+  @Override
+  CompletableFuture<Void> dial(Multiaddr multiaddress, StreamHandler<Multiaddr> dialHandler);
+
+  @Override
+  CompletableFuture<Listener> listen(
+      Multiaddr multiaddress, Supplier<StreamHandler<Multiaddr>> handlerFactory);
+
+  interface Listener extends Closeable {
 
     @Override
-    CompletableFuture<Void> dial(Multiaddr multiaddress,
-                                 StreamHandler<Multiaddr> dialHandler);
+    void close();
 
-    @Override
-    CompletableFuture<Listener> listen(Multiaddr multiaddress,
-                                       Supplier<StreamHandler<Multiaddr>> handlerFactory);
+    Multiaddr getLocalMultiaddress();
 
-    interface Listener extends Closeable {
-
-        @Override
-        void close();
-
-        Multiaddr getLocalMultiaddress();
-
-        default CompletableFuture<Multiaddr> getPublicMultiaddress() {
-            return CompletableFuture.completedFuture(getLocalMultiaddress());
-        }
+    default CompletableFuture<Multiaddr> getPublicMultiaddress() {
+      return CompletableFuture.completedFuture(getLocalMultiaddress());
     }
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/exceptions/MalformedMultiaddressException.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/exceptions/MalformedMultiaddressException.java
@@ -1,10 +1,8 @@
 package io.libp2p.tools.p2pd.libp2pj.exceptions;
 
-/**
- * Created by Anton Nashatyrev on 11.12.2018.
- */
+/** Created by Anton Nashatyrev on 11.12.2018. */
 public class MalformedMultiaddressException extends RuntimeException {
-    public MalformedMultiaddressException(String message) {
-        super(message);
-    }
+  public MalformedMultiaddressException(String message) {
+    super(message);
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/exceptions/UnsupportedTransportException.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/exceptions/UnsupportedTransportException.java
@@ -1,10 +1,8 @@
 package io.libp2p.tools.p2pd.libp2pj.exceptions;
 
-/**
- * Created by Anton Nashatyrev on 11.12.2018.
- */
+/** Created by Anton Nashatyrev on 11.12.2018. */
 public class UnsupportedTransportException extends RuntimeException {
-    public UnsupportedTransportException(String message) {
-        super(message);
-    }
+  public UnsupportedTransportException(String message) {
+    super(message);
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/util/Base58.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/util/Base58.java
@@ -4,170 +4,170 @@ import java.util.Arrays;
 
 public class Base58 {
 
-    private static final char[] ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-            .toCharArray();
-    private static final int BASE_58 = ALPHABET.length;
-    private static final int BASE_256 = 256;
+  private static final char[] ALPHABET =
+      "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".toCharArray();
+  private static final int BASE_58 = ALPHABET.length;
+  private static final int BASE_256 = 256;
 
-    private static final int[] INDEXES = new int[128];
-    static {
-        for (int i = 0; i < INDEXES.length; i++) {
-            INDEXES[i] = -1;
-        }
-        for (int i = 0; i < ALPHABET.length; i++) {
-            INDEXES[ALPHABET[i]] = i;
-        }
+  private static final int[] INDEXES = new int[128];
+
+  static {
+    for (int i = 0; i < INDEXES.length; i++) {
+      INDEXES[i] = -1;
+    }
+    for (int i = 0; i < ALPHABET.length; i++) {
+      INDEXES[ALPHABET[i]] = i;
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    byte[] ret = Base58.decode("QmWaWjD7Sfs7Lw7ZgMgbRN47e2iakSMuZHqPRkctHyhFzf");
+    System.out.println(Arrays.toString(ret));
+  }
+
+  public static String encode(byte[] input) {
+    if (input.length == 0) {
+      // paying with the same coin
+      return "";
     }
 
+    //
+    // Make a copy of the input since we are going to modify it.
+    //
+    input = copyOfRange(input, 0, input.length);
 
-    public static void main(String[] args) throws Exception {
-        byte[] ret = Base58.decode("QmWaWjD7Sfs7Lw7ZgMgbRN47e2iakSMuZHqPRkctHyhFzf");
-        System.out.println(Arrays.toString(ret));
+    //
+    // Count leading zeroes
+    //
+    int zeroCount = 0;
+    while (zeroCount < input.length && input[zeroCount] == 0) {
+      ++zeroCount;
     }
 
-    public static String encode(byte[] input) {
-        if (input.length == 0) {
-            // paying with the same coin
-            return "";
-        }
+    //
+    // The actual encoding
+    //
+    byte[] temp = new byte[input.length * 2];
+    int j = temp.length;
 
-        //
-        // Make a copy of the input since we are going to modify it.
-        //
-        input = copyOfRange(input, 0, input.length);
+    int startAt = zeroCount;
+    while (startAt < input.length) {
+      byte mod = divmod58(input, startAt);
+      if (input[startAt] == 0) {
+        ++startAt;
+      }
 
-        //
-        // Count leading zeroes
-        //
-        int zeroCount = 0;
-        while (zeroCount < input.length && input[zeroCount] == 0) {
-            ++zeroCount;
-        }
-
-        //
-        // The actual encoding
-        //
-        byte[] temp = new byte[input.length * 2];
-        int j = temp.length;
-
-        int startAt = zeroCount;
-        while (startAt < input.length) {
-            byte mod = divmod58(input, startAt);
-            if (input[startAt] == 0) {
-                ++startAt;
-            }
-
-            temp[--j] = (byte) ALPHABET[mod];
-        }
-
-        //
-        // Strip extra '1' if any
-        //
-        while (j < temp.length && temp[j] == ALPHABET[0]) {
-            ++j;
-        }
-
-        //
-        // Add as many leading '1' as there were leading zeros.
-        //
-        while (--zeroCount >= 0) {
-            temp[--j] = (byte) ALPHABET[0];
-        }
-
-        byte[] output = copyOfRange(temp, j, temp.length);
-        return new String(output);
+      temp[--j] = (byte) ALPHABET[mod];
     }
 
-    public static byte[] decode(String input) {
-        if (input.length() == 0) {
-            // paying with the same coin
-            return new byte[0];
-        }
-
-        byte[] input58 = new byte[input.length()];
-        //
-        // Transform the String to a base58 byte sequence
-        //
-        for (int i = 0; i < input.length(); ++i) {
-            char c = input.charAt(i);
-
-            int digit58 = -1;
-            if (c >= 0 && c < 128) {
-                digit58 = INDEXES[c];
-            }
-            if (digit58 < 0) {
-                throw new RuntimeException("Not a Base58 input: " + input);
-            }
-
-            input58[i] = (byte) digit58;
-        }
-
-        //
-        // Count leading zeroes
-        //
-        int zeroCount = 0;
-        while (zeroCount < input58.length && input58[zeroCount] == 0) {
-            ++zeroCount;
-        }
-
-        //
-        // The encoding
-        //
-        byte[] temp = new byte[input.length()];
-        int j = temp.length;
-
-        int startAt = zeroCount;
-        while (startAt < input58.length) {
-            byte mod = divmod256(input58, startAt);
-            if (input58[startAt] == 0) {
-                ++startAt;
-            }
-
-            temp[--j] = mod;
-        }
-
-        //
-        // Do no add extra leading zeroes, move j to first non null byte.
-        //
-        while (j < temp.length && temp[j] == 0) {
-            ++j;
-        }
-
-        return copyOfRange(temp, j - zeroCount, temp.length);
+    //
+    // Strip extra '1' if any
+    //
+    while (j < temp.length && temp[j] == ALPHABET[0]) {
+      ++j;
     }
 
-    private static byte divmod58(byte[] number, int startAt) {
-        int remainder = 0;
-        for (int i = startAt; i < number.length; i++) {
-            int digit256 = (int) number[i] & 0xFF;
-            int temp = remainder * BASE_256 + digit256;
-
-            number[i] = (byte) (temp / BASE_58);
-
-            remainder = temp % BASE_58;
-        }
-
-        return (byte) remainder;
+    //
+    // Add as many leading '1' as there were leading zeros.
+    //
+    while (--zeroCount >= 0) {
+      temp[--j] = (byte) ALPHABET[0];
     }
 
-    private static byte divmod256(byte[] number58, int startAt) {
-        int remainder = 0;
-        for (int i = startAt; i < number58.length; i++) {
-            int digit58 = (int) number58[i] & 0xFF;
-            int temp = remainder * BASE_58 + digit58;
+    byte[] output = copyOfRange(temp, j, temp.length);
+    return new String(output);
+  }
 
-            number58[i] = (byte) (temp / BASE_256);
-
-            remainder = temp % BASE_256;
-        }
-
-        return (byte) remainder;
+  public static byte[] decode(String input) {
+    if (input.length() == 0) {
+      // paying with the same coin
+      return new byte[0];
     }
 
-    private static byte[] copyOfRange(byte[] source, int from, int to) {
-        byte[] range = new byte[to - from];
-        System.arraycopy(source, from, range, 0, range.length);
+    byte[] input58 = new byte[input.length()];
+    //
+    // Transform the String to a base58 byte sequence
+    //
+    for (int i = 0; i < input.length(); ++i) {
+      char c = input.charAt(i);
 
-        return range;
+      int digit58 = -1;
+      if (c >= 0 && c < 128) {
+        digit58 = INDEXES[c];
+      }
+      if (digit58 < 0) {
+        throw new RuntimeException("Not a Base58 input: " + input);
+      }
+
+      input58[i] = (byte) digit58;
     }
+
+    //
+    // Count leading zeroes
+    //
+    int zeroCount = 0;
+    while (zeroCount < input58.length && input58[zeroCount] == 0) {
+      ++zeroCount;
+    }
+
+    //
+    // The encoding
+    //
+    byte[] temp = new byte[input.length()];
+    int j = temp.length;
+
+    int startAt = zeroCount;
+    while (startAt < input58.length) {
+      byte mod = divmod256(input58, startAt);
+      if (input58[startAt] == 0) {
+        ++startAt;
+      }
+
+      temp[--j] = mod;
+    }
+
+    //
+    // Do no add extra leading zeroes, move j to first non null byte.
+    //
+    while (j < temp.length && temp[j] == 0) {
+      ++j;
+    }
+
+    return copyOfRange(temp, j - zeroCount, temp.length);
+  }
+
+  private static byte divmod58(byte[] number, int startAt) {
+    int remainder = 0;
+    for (int i = startAt; i < number.length; i++) {
+      int digit256 = (int) number[i] & 0xFF;
+      int temp = remainder * BASE_256 + digit256;
+
+      number[i] = (byte) (temp / BASE_58);
+
+      remainder = temp % BASE_58;
+    }
+
+    return (byte) remainder;
+  }
+
+  private static byte divmod256(byte[] number58, int startAt) {
+    int remainder = 0;
+    for (int i = startAt; i < number58.length; i++) {
+      int digit58 = (int) number58[i] & 0xFF;
+      int temp = remainder * BASE_58 + digit58;
+
+      number58[i] = (byte) (temp / BASE_256);
+
+      remainder = temp % BASE_256;
+    }
+
+    return (byte) remainder;
+  }
+
+  private static byte[] copyOfRange(byte[] source, int from, int to) {
+    byte[] range = new byte[to - from];
+    System.arraycopy(source, from, range, 0, range.length);
+
+    return range;
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/util/Cid.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/util/Cid.java
@@ -2,7 +2,7 @@ package io.libp2p.tools.p2pd.libp2pj.util;
 
 public class Cid {
 
-    public byte[] toBytes() {
-        throw new UnsupportedOperationException();
-    }
+  public byte[] toBytes() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/util/Util.java
+++ b/libp2p/src/testFixtures/java/io/libp2p/tools/p2pd/libp2pj/util/Util.java
@@ -3,32 +3,28 @@ package io.libp2p.tools.p2pd.libp2pj.util;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Created by Anton Nashatyrev on 17.12.2018.
- */
+/** Created by Anton Nashatyrev on 17.12.2018. */
 public class Util {
 
-    public static byte[] concat(List<byte[]> arrays) {
-        byte[] ret = new byte[arrays.stream().mapToInt(arr -> arr.length).sum()];
-        int off = 0;
-        for (byte[] bb : arrays) {
-            System.arraycopy(bb, 0, ret, off, bb.length);
-            off += bb.length;
-        }
-        return ret;
+  public static byte[] concat(List<byte[]> arrays) {
+    byte[] ret = new byte[arrays.stream().mapToInt(arr -> arr.length).sum()];
+    int off = 0;
+    for (byte[] bb : arrays) {
+      System.arraycopy(bb, 0, ret, off, bb.length);
+      off += bb.length;
     }
+    return ret;
+  }
 
-    /**
-     * https://developers.google.com/protocol-buffers/docs/encoding
-     */
-    public static byte[] encodeUVariant(long n) {
-        int size = 0;
-        byte[] ret = new byte[10];
-        while(n > 0) {
-            if (size > 0) ret[size - 1] |= 0b10000000;
-            ret[size++] = (byte) (n & 0b01111111);
-            n >>>= 7;
-        }
-        return Arrays.copyOfRange(ret, 0, size);
+  /** https://developers.google.com/protocol-buffers/docs/encoding */
+  public static byte[] encodeUVariant(long n) {
+    int size = 0;
+    byte[] ret = new byte[10];
+    while (n > 0) {
+      if (size > 0) ret[size - 1] |= 0b10000000;
+      ret[size++] = (byte) (n & 0b01111111);
+      n >>>= 7;
     }
+    return Arrays.copyOfRange(ret, 0, size);
+  }
 }

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/DeterministicFuzz.kt
@@ -1,6 +1,6 @@
 package io.libp2p.pubsub
 
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.etc.types.lazyVar
 import io.libp2p.pubsub.flood.FloodRouter
@@ -37,7 +37,7 @@ class DeterministicFuzz {
         return TestRouter("" + (cnt++), router).apply {
             val randomBytes = ByteArray(8)
             random.nextBytes(randomBytes)
-            keyPair = generateKeyPair(KEY_TYPE.ECDSA, random = SecureRandom(randomBytes))
+            keyPair = generateKeyPair(KeyType.ECDSA, random = SecureRandom(randomBytes))
             testExecutor = deterministicExecutor
         }
     }

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/TestRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/TestRouter.kt
@@ -1,7 +1,7 @@
 package io.libp2p.pubsub
 
 import io.libp2p.core.PeerId
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.pubsub.RESULT_VALID
 import io.libp2p.core.pubsub.ValidationResult
@@ -47,7 +47,7 @@ class TestRouter(
 
     var testExecutor: ScheduledExecutorService by lazyVar { Executors.newSingleThreadScheduledExecutor() }
 
-    var keyPair = generateKeyPair(KEY_TYPE.ECDSA)
+    var keyPair = generateKeyPair(KeyType.ECDSA)
     val peerId by lazy { PeerId.fromPubKey(keyPair.second) }
     val protocol = router.protocol.announceStr
 
@@ -62,13 +62,15 @@ class TestRouter(
         pubsubLogs: LogLevel? = null,
         initiator: Boolean
     ): TestChannel {
-
         val parentChannel = TestChannel("dummy-parent-channel", false)
         val connection =
             ConnectionOverNetty(parentChannel, NullTransport(), initiator)
         connection.setSecureSession(
             SecureChannel.Session(
-                peerId, remoteRouter.peerId, remoteRouter.keyPair.second, null
+                peerId,
+                remoteRouter.peerId,
+                remoteRouter.keyPair.second,
+                null
             )
         )
 
@@ -90,7 +92,6 @@ class TestRouter(
         wireLogs: LogLevel? = null,
         pubsubLogs: LogLevel? = null
     ): TestConnection {
-
         val thisChannel = newChannel("[${idCnt.incrementAndGet()}]$name=>${another.name}", another, wireLogs, pubsubLogs, true)
         val anotherChannel = another.newChannel("[${idCnt.incrementAndGet()}]${another.name}=>$name", this, wireLogs, pubsubLogs, false)
         listOf(thisChannel, anotherChannel).forEach {

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/tools/HostFactory.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/tools/HostFactory.kt
@@ -2,7 +2,7 @@ package io.libp2p.tools
 
 import io.libp2p.core.Host
 import io.libp2p.core.PeerId
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.PrivKey
 import io.libp2p.core.crypto.PubKey
 import io.libp2p.core.crypto.generateKeyPair
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 
 class HostFactory {
 
-    var keyType = KEY_TYPE.ECDSA
+    var keyType = KeyType.ECDSA
     var tcpPort = 5000
     var transportCtor = ::TcpTransport
     var secureCtor: SecureChannelCtor = ::NoiseXXSecureChannel

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TCPProxy.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TCPProxy.kt
@@ -26,7 +26,6 @@ class TCPProxy {
                     it.addLastLocal(object : ChannelInboundHandlerAdapter() {
                         val client = CompletableFuture<ChannelHandlerContext>()
                         override fun channelActive(serverCtx: ChannelHandlerContext) {
-
                             serverCtx.channel().pipeline().addFirst(LoggingHandler("server", LogLevel.INFO))
 
                             Bootstrap().apply {

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/transport/NullConnectionUpgrader.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/transport/NullConnectionUpgrader.kt
@@ -3,7 +3,7 @@ package io.libp2p.transport
 import io.libp2p.core.Connection
 import io.libp2p.core.PeerId
 import io.libp2p.core.StreamPromise
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.multistream.ProtocolBinding
@@ -20,19 +20,17 @@ class NullMultistreamProtocol : MultistreamProtocol {
 class NullConnectionUpgrader :
     ConnectionUpgrader(NullMultistreamProtocol(), emptyList(), NullMultistreamProtocol(), emptyList()) {
 
-    override fun establishSecureChannel(connection: Connection):
-        CompletableFuture<SecureChannel.Session> {
+    override fun establishSecureChannel(connection: Connection): CompletableFuture<SecureChannel.Session> {
         val nonsenseSession = SecureChannel.Session(
             PeerId.random(),
             PeerId.random(),
-            generateKeyPair(KEY_TYPE.RSA).second,
+            generateKeyPair(KeyType.RSA).second,
             null
         )
         return CompletableFuture.completedFuture(nonsenseSession)
     } // establishSecureChannel
 
-    override fun establishMuxer(connection: Connection):
-        CompletableFuture<StreamMuxer.Session> {
+    override fun establishMuxer(connection: Connection): CompletableFuture<StreamMuxer.Session> {
         return CompletableFuture.completedFuture(DoNothingMuxerSession())
     } // establishMuxer
 

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/AbstractSchedulers.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/AbstractSchedulers.java
@@ -5,8 +5,8 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * The collection of standard Schedulers, Scheduler factory and system time supplier
  *
- * For debugging and testing the default <code>Schedulers</code> instance can be replaced
- * with appropriate one
+ * <p>For debugging and testing the default <code>Schedulers</code> instance can be replaced with
+ * appropriate one
  */
 public abstract class AbstractSchedulers implements Schedulers {
   private static final int BLOCKING_THREAD_COUNT = 128;

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ControlledExecutorService.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ControlledExecutorService.java
@@ -3,15 +3,14 @@ package io.libp2p.tools.schedulers;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * The <code>ScheduledExecutorService</code> which functions based on the
- * current system time supplied by {@link TimeController#getTime()} instead of
- * <code>System.currentTimeMillis()</code>
+ * The <code>ScheduledExecutorService</code> which functions based on the current system time
+ * supplied by {@link TimeController#getTime()} instead of <code>System.currentTimeMillis()</code>
  */
 public interface ControlledExecutorService extends ScheduledExecutorService {
 
   /**
-   * Sets up the {@link TimeController} instance which manages ordered tasks execution
-   * and provides current time
+   * Sets up the {@link TimeController} instance which manages ordered tasks execution and provides
+   * current time
    */
   void setTimeController(TimeController timeController);
 }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ControlledSchedulers.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ControlledSchedulers.java
@@ -3,40 +3,35 @@ package io.libp2p.tools.schedulers;
 import java.time.Duration;
 
 /**
- * Special Schedulers implementation which is mostly suitable for testing and simulation.
- * The system time is controlled manually and all the schedulers execute tasks according
- * to this time.
- * Initial system time is equal to 0
+ * Special Schedulers implementation which is mostly suitable for testing and simulation. The system
+ * time is controlled manually and all the schedulers execute tasks according to this time. Initial
+ * system time is equal to 0
  */
 public interface ControlledSchedulers extends Schedulers {
 
   /**
    * Sets current time.
-   * @throws IllegalStateException if this instance is dependent on a parent
-   * {@link TimeController}
+   *
+   * @throws IllegalStateException if this instance is dependent on a parent {@link TimeController}
    * @see TimeController#setTime(long)
    */
   default void setCurrentTime(long newTime) {
     getTimeController().setTime(newTime);
   }
 
-  /**
-   * Just a handy helper method for {@link #setCurrentTime(long)}
-   */
+  /** Just a handy helper method for {@link #setCurrentTime(long)} */
   default void addTime(Duration duration) {
     addTime(duration.toMillis());
   }
 
-  /**
-   * Just a handy helper method for {@link #setCurrentTime(long)}
-   */
+  /** Just a handy helper method for {@link #setCurrentTime(long)} */
   default void addTime(long millis) {
     setCurrentTime(getCurrentTime() + millis);
   }
 
   /**
-   * Returns {@link TimeController} which manages tasks ordered execution and
-   * supplies current time for this instance
+   * Returns {@link TimeController} which manages tasks ordered execution and supplies current time
+   * for this instance
    */
   TimeController getTimeController();
 }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ControlledSchedulersImpl.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ControlledSchedulersImpl.java
@@ -25,7 +25,8 @@ public class ControlledSchedulersImpl extends AbstractSchedulers implements Cont
 
   @Override
   protected ScheduledExecutorService createExecutor(String namePattern, int threads) {
-    ControlledExecutorServiceImpl service = new ControlledExecutorServiceImpl(createDelegateExecutor());
+    ControlledExecutorServiceImpl service =
+        new ControlledExecutorServiceImpl(createDelegateExecutor());
     service.setTimeController(timeController);
     return service;
   }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/DefaultSchedulers.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/DefaultSchedulers.java
@@ -1,13 +1,12 @@
 package io.libp2p.tools.schedulers;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DefaultSchedulers extends AbstractSchedulers {
 

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ErrorHandlingScheduler.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/ErrorHandlingScheduler.java
@@ -5,16 +5,17 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-//import reactor.core.Disposable;
+
+// import reactor.core.Disposable;
 
 public class ErrorHandlingScheduler implements Scheduler {
 
   private final Scheduler delegate;
   private final Consumer<Throwable> errorHandler;
-//  private reactor.core.scheduler.Scheduler cachedReactor;
 
-  public ErrorHandlingScheduler(Scheduler delegate,
-      Consumer<Throwable> errorHandler) {
+  //  private reactor.core.scheduler.Scheduler cachedReactor;
+
+  public ErrorHandlingScheduler(Scheduler delegate, Consumer<Throwable> errorHandler) {
     this.delegate = delegate;
     this.errorHandler = errorHandler;
   }
@@ -31,20 +32,17 @@ public class ErrorHandlingScheduler implements Scheduler {
 
   @Override
   public CompletableFuture<Void> executeAtFixedRate(
-      Duration initialDelay, Duration period,
-      RunnableEx task) {
+      Duration initialDelay, Duration period, RunnableEx task) {
     return delegate.executeAtFixedRate(initialDelay, period, () -> runAndHandleError(task));
   }
 
   @Override
-  public CompletableFuture<Void> execute(
-      RunnableEx task) {
+  public CompletableFuture<Void> execute(RunnableEx task) {
     return delegate.execute(() -> runAndHandleError(task));
   }
 
   @Override
-  public CompletableFuture<Void> executeWithDelay(Duration delay,
-      RunnableEx task) {
+  public CompletableFuture<Void> executeWithDelay(Duration delay, RunnableEx task) {
     return delegate.executeWithDelay(delay, () -> runAndHandleError(task));
   }
 
@@ -53,14 +51,14 @@ public class ErrorHandlingScheduler implements Scheduler {
     return delegate.getCurrentTime();
   }
 
-//  @Override
-//  public reactor.core.scheduler.Scheduler toReactor() {
-//    if (cachedReactor == null) {
-//      cachedReactor = new ErrorHandlingReactorScheduler(delegate.toReactor(),
-//          delegate::getCurrentTime);
-//    }
-//    return cachedReactor;
-//  }
+  //  @Override
+  //  public reactor.core.scheduler.Scheduler toReactor() {
+  //    if (cachedReactor == null) {
+  //      cachedReactor = new ErrorHandlingReactorScheduler(delegate.toReactor(),
+  //          delegate::getCurrentTime);
+  //    }
+  //    return cachedReactor;
+  //  }
 
   private void runAndHandleError(RunnableEx runnable) throws Exception {
     try {
@@ -74,64 +72,66 @@ public class ErrorHandlingScheduler implements Scheduler {
     }
   }
 
-//  private class ErrorHandlingReactorScheduler extends DelegatingReactorScheduler {
-//
-//    public ErrorHandlingReactorScheduler(reactor.core.scheduler.Scheduler delegate,
-//        Supplier<Long> timeSupplier) {
-//      super(delegate, timeSupplier);
-//    }
-//
-//    @Nonnull
-//    @Override
-//    public Disposable schedule(@Nonnull Runnable task) {
-//      return super.schedule(() -> runAndHandleError(task));
-//    }
-//
-//    @Nonnull
-//    @Override
-//    public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-//      return super.schedule(() -> runAndHandleError(task), delay, unit);
-//    }
-//
-//    @Nonnull
-//    @Override
-//    public Disposable schedulePeriodically(Runnable task, long initialDelay, long period,
-//        TimeUnit unit) {
-//      return super.schedulePeriodically(() -> runAndHandleError(task), initialDelay, period, unit);
-//    }
-//
-//    @Nonnull
-//    @Override
-//    public Worker createWorker() {
-//      return new DelegateWorker(super.createWorker()) {
-//        @Nonnull
-//        @Override
-//        public Disposable schedule(@Nonnull Runnable task) {
-//          return super.schedule(() -> runAndHandleError(task));
-//        }
-//
-//        @Nonnull
-//        @Override
-//        public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
-//          return super.schedule(() -> runAndHandleError(task), delay, unit);
-//        }
-//
-//        @Nonnull
-//        @Override
-//        public Disposable schedulePeriodically(Runnable task, long initialDelay, long period,
-//            TimeUnit unit) {
-//          return super.schedulePeriodically(() -> runAndHandleError(task), initialDelay, period, unit);
-//        }
-//      };
-//    }
-//
-//    private void runAndHandleError(Runnable runnable) {
-//      try {
-//        runnable.run();
-//      } catch (Throwable t) {
-//        errorHandler.accept(t);
-//        throw new RuntimeException(t);
-//      }
-//    }
-//  }
+  //  private class ErrorHandlingReactorScheduler extends DelegatingReactorScheduler {
+  //
+  //    public ErrorHandlingReactorScheduler(reactor.core.scheduler.Scheduler delegate,
+  //        Supplier<Long> timeSupplier) {
+  //      super(delegate, timeSupplier);
+  //    }
+  //
+  //    @Nonnull
+  //    @Override
+  //    public Disposable schedule(@Nonnull Runnable task) {
+  //      return super.schedule(() -> runAndHandleError(task));
+  //    }
+  //
+  //    @Nonnull
+  //    @Override
+  //    public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+  //      return super.schedule(() -> runAndHandleError(task), delay, unit);
+  //    }
+  //
+  //    @Nonnull
+  //    @Override
+  //    public Disposable schedulePeriodically(Runnable task, long initialDelay, long period,
+  //        TimeUnit unit) {
+  //      return super.schedulePeriodically(() -> runAndHandleError(task), initialDelay, period,
+  // unit);
+  //    }
+  //
+  //    @Nonnull
+  //    @Override
+  //    public Worker createWorker() {
+  //      return new DelegateWorker(super.createWorker()) {
+  //        @Nonnull
+  //        @Override
+  //        public Disposable schedule(@Nonnull Runnable task) {
+  //          return super.schedule(() -> runAndHandleError(task));
+  //        }
+  //
+  //        @Nonnull
+  //        @Override
+  //        public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+  //          return super.schedule(() -> runAndHandleError(task), delay, unit);
+  //        }
+  //
+  //        @Nonnull
+  //        @Override
+  //        public Disposable schedulePeriodically(Runnable task, long initialDelay, long period,
+  //            TimeUnit unit) {
+  //          return super.schedulePeriodically(() -> runAndHandleError(task), initialDelay, period,
+  // unit);
+  //        }
+  //      };
+  //    }
+  //
+  //    private void runAndHandleError(Runnable runnable) {
+  //      try {
+  //        runnable.run();
+  //      } catch (Throwable t) {
+  //        errorHandler.accept(t);
+  //        throw new RuntimeException(t);
+  //      }
+  //    }
+  //  }
 }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/LatestExecutor.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/LatestExecutor.java
@@ -3,15 +3,14 @@ package io.libp2p.tools.schedulers;
 import java.util.function.Consumer;
 
 /**
- * Processes events submitted via {@link #newEvent(T)} with the specified
- * <code>eventProcessor</code> on the specified <code>scheduler</code>.
+ * Processes events submitted via {@link #newEvent(T)} with the specified <code>eventProcessor
+ * </code> on the specified <code>scheduler</code>.
  *
- * Guarantees that the latest event would be processed, though other
- * intermediate events could be skipped.
+ * <p>Guarantees that the latest event would be processed, though other intermediate events could be
+ * skipped.
  *
- * Skips subsequent events if any previous is still processing.
- * Avoids creating scheduling a task for each event thus allowing frequent
- * events submitting.
+ * <p>Skips subsequent events if any previous is still processing. Avoids creating scheduling a task
+ * for each event thus allowing frequent events submitting.
  */
 public class LatestExecutor<T> {
   private final Scheduler scheduler;
@@ -25,9 +24,8 @@ public class LatestExecutor<T> {
   }
 
   /**
-   * Submits a new event for processing.
-   * This particular event may not be processed if a subsequent event submitted
-   * shortly
+   * Submits a new event for processing. This particular event may not be processed if a subsequent
+   * event submitted shortly
    */
   public synchronized void newEvent(T event) {
     latestEvent = event;

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/LoggerMDCExecutor.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/LoggerMDCExecutor.java
@@ -1,11 +1,10 @@
 package io.libp2p.tools.schedulers;
 
-import org.slf4j.MDC;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
+import org.slf4j.MDC;
 
 public class LoggerMDCExecutor implements Executor {
 

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/RunnableEx.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/RunnableEx.java
@@ -1,8 +1,6 @@
 package io.libp2p.tools.schedulers;
 
-/**
- * The same as standard <code>Runnable</code> which can throw unchecked exception
- */
+/** The same as standard <code>Runnable</code> which can throw unchecked exception */
 public interface RunnableEx {
   void run() throws Exception;
 }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/Scheduler.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/Scheduler.java
@@ -5,30 +5,32 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
-/**
- * Analog for standard <code>ScheduledExecutorService</code>
- */
+/** Analog for standard <code>ScheduledExecutorService</code> */
 public interface Scheduler {
 
   <T> CompletableFuture<T> execute(Callable<T> task);
 
   <T> CompletableFuture<T> executeWithDelay(Duration delay, Callable<T> task);
 
-  CompletableFuture<Void> executeAtFixedRate(Duration initialDelay, Duration period,
-                                             RunnableEx task);
+  CompletableFuture<Void> executeAtFixedRate(
+      Duration initialDelay, Duration period, RunnableEx task);
 
   long getCurrentTime();
 
-//  default reactor.core.scheduler.Scheduler toReactor() {
-//    return convertToReactor(this);
-//  }
+  //  default reactor.core.scheduler.Scheduler toReactor() {
+  //    return convertToReactor(this);
+  //  }
 
   default CompletableFuture<Void> executeR(Runnable task) {
     return execute(task::run);
   }
 
   default CompletableFuture<Void> execute(RunnableEx task) {
-    return execute(() -> {task.run(); return null;});
+    return execute(
+        () -> {
+          task.run();
+          return null;
+        });
   }
 
   default CompletableFuture<Void> executeWithDelayR(Duration delay, Runnable task) {
@@ -36,28 +38,36 @@ public interface Scheduler {
   }
 
   default CompletableFuture<Void> executeWithDelay(Duration delay, RunnableEx task) {
-    return executeWithDelay(delay, () -> {task.run(); return null;});
+    return executeWithDelay(
+        delay,
+        () -> {
+          task.run();
+          return null;
+        });
   }
 
   @SuppressWarnings("unchecked")
-  default <C> CompletableFuture<C> orTimeout(CompletableFuture<C> future, Duration futureTimeout,
-                                             Supplier<Exception> exceptionSupplier) {
-    return (CompletableFuture<C>) CompletableFuture.anyOf(
-        future,
-        executeWithDelay(futureTimeout,
-            () -> {throw exceptionSupplier.get();}));
+  default <C> CompletableFuture<C> orTimeout(
+      CompletableFuture<C> future, Duration futureTimeout, Supplier<Exception> exceptionSupplier) {
+    return (CompletableFuture<C>)
+        CompletableFuture.anyOf(
+            future,
+            executeWithDelay(
+                futureTimeout,
+                () -> {
+                  throw exceptionSupplier.get();
+                }));
   }
 
-//  default reactor.core.scheduler.Scheduler convertToReactor(Scheduler scheduler) {
-//    if (scheduler instanceof ExecutorScheduler) {
-//      return new DelegatingReactorScheduler(
-//          reactor.core.scheduler.Schedulers.fromExecutorService(
-//              ((ExecutorScheduler) scheduler).getExecutorService()),
-//          this::getCurrentTime);
-//    } else {
-//      throw new UnsupportedOperationException(
-//          "Conversion from custom Scheduler to Reactor Scheduler not implemented yet.");
-//    }
-//  }
+  //  default reactor.core.scheduler.Scheduler convertToReactor(Scheduler scheduler) {
+  //    if (scheduler instanceof ExecutorScheduler) {
+  //      return new DelegatingReactorScheduler(
+  //          reactor.core.scheduler.Schedulers.fromExecutorService(
+  //              ((ExecutorScheduler) scheduler).getExecutorService()),
+  //          this::getCurrentTime);
+  //    } else {
+  //      throw new UnsupportedOperationException(
+  //          "Conversion from custom Scheduler to Reactor Scheduler not implemented yet.");
+  //    }
+  //  }
 }
-

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/Schedulers.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/Schedulers.java
@@ -4,24 +4,23 @@ import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 /**
- * The collection of standard Schedulers, Scheduler factory and system time supplier
- * Any scheduler withing a system should be obtained or created via this interface
+ * The collection of standard Schedulers, Scheduler factory and system time supplier Any scheduler
+ * withing a system should be obtained or created via this interface
  */
 public interface Schedulers {
 
-  /**
-   * Creates default Schedulers implementation for production functioning
-   */
+  /** Creates default Schedulers implementation for production functioning */
   static Schedulers createDefault() {
     return new DefaultSchedulers();
   }
 
   /**
-   * Creates the ControlledSchedulers implementation (normally for testing or simulation)
-   * with the specified delegate Executor factory.
+   * Creates the ControlledSchedulers implementation (normally for testing or simulation) with the
+   * specified delegate Executor factory.
+   *
    * @param delegateExecutor all the tasks are finally executed on executors created by this
-   * factory. Normally a single executor should be sufficient and could be supplied as
-   * <code>() -> mySingleExecutor</code>
+   *     factory. Normally a single executor should be sufficient and could be supplied as <code>
+   *     () -> mySingleExecutor</code>
    */
   static ControlledSchedulers createControlled(Supplier<Executor> delegateExecutor) {
     return new ControlledSchedulersImpl() {
@@ -33,55 +32,49 @@ public interface Schedulers {
   }
 
   /**
-   * Creates the ControlledSchedulers implementation (normally for testing or simulation)
-   * which executes all the tasks immediately on the same thread or if a task scheduled for
-   * later execution then this task would be executed within appropriate
-   * {@link ControlledSchedulers#setCurrentTime(long)} call
+   * Creates the ControlledSchedulers implementation (normally for testing or simulation) which
+   * executes all the tasks immediately on the same thread or if a task scheduled for later
+   * execution then this task would be executed within appropriate {@link
+   * ControlledSchedulers#setCurrentTime(long)} call
    */
   static ControlledSchedulers createControlled() {
     return createControlled(() -> Runnable::run);
   }
 
   /**
-   * Returns the current system time
-   * This method should be used by all components to obtain the current system time
-   * <code>System.currentTimeMillis()</code> (or other standard Java means) is prohibited.
+   * Returns the current system time This method should be used by all components to obtain the
+   * current system time <code>System.currentTimeMillis()</code> (or other standard Java means) is
+   * prohibited.
    */
   long getCurrentTime();
 
   /**
-   * Scheduler to execute CPU heavy tasks
-   * This is normally based on a thread pool with the number of threads
-   * equal to number of CPU cores
+   * Scheduler to execute CPU heavy tasks This is normally based on a thread pool with the number of
+   * threads equal to number of CPU cores
    */
   Scheduler cpuHeavy();
 
   /**
-   * The scheduler to execute disk read/write tasks (like DB access, file read/write etc)
-   * and other tasks with potentially short blocking time.
-   * Tasks with potentially longer blocking time (like waiting for network response) is
-   * highly recommended to execute in a non-blocking (reactive) manner or at least on
-   * a dedicated Scheduler
+   * The scheduler to execute disk read/write tasks (like DB access, file read/write etc) and other
+   * tasks with potentially short blocking time. Tasks with potentially longer blocking time (like
+   * waiting for network response) is highly recommended to execute in a non-blocking (reactive)
+   * manner or at least on a dedicated Scheduler
    *
-   * This Scheduler is normally based on a dynamic pool with sufficient number of threads
+   * <p>This Scheduler is normally based on a dynamic pool with sufficient number of threads
    */
   Scheduler blocking();
 
-  /**
-   * Dedicated Scheduler for internal system asynchronous events
-   */
+  /** Dedicated Scheduler for internal system asynchronous events */
   Scheduler events();
 
-  /**
-   * Creates new single thread Scheduler with the specified thread name
-   */
+  /** Creates new single thread Scheduler with the specified thread name */
   default Scheduler newSingleThreadDaemon(String threadName) {
     return newParallelDaemon(threadName, 1);
   }
 
   /**
-   * Creates new multi-thread Scheduler with the specified thread namePattern and
-   * number of pool threads
+   * Creates new multi-thread Scheduler with the specified thread namePattern and number of pool
+   * threads
    */
   Scheduler newParallelDaemon(String threadNamePattern, int threadPoolCount);
 }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/TaskQueue.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/TaskQueue.java
@@ -11,77 +11,83 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 public class TaskQueue {
 
-    private NavigableMap<Long, Queue<TimeController.Task>> tasks = Collections.synchronizedNavigableMap(new TreeMap<>());
-    private boolean executing = false;
+  private NavigableMap<Long, Queue<TimeController.Task>> tasks =
+      Collections.synchronizedNavigableMap(new TreeMap<>());
+  private boolean executing = false;
 
-    public void add(TimeController.Task task) {
-        tasks.computeIfAbsent(task.getTime(), t -> new ConcurrentLinkedQueue<>()).add(task);
-    }
+  public void add(TimeController.Task task) {
+    tasks.computeIfAbsent(task.getTime(), t -> new ConcurrentLinkedQueue<>()).add(task);
+  }
 
-    public void remove(TimeController.Task task) {
-        tasks.computeIfPresent(task.getTime(), (t, queue) -> {
-            queue.remove(task);
-            return queue;
+  public void remove(TimeController.Task task) {
+    tasks.computeIfPresent(
+        task.getTime(),
+        (t, queue) -> {
+          queue.remove(task);
+          return queue;
         });
-    }
+  }
 
-    public boolean isEmpty() {
-        return tasks.isEmpty();
-    }
+  public boolean isEmpty() {
+    return tasks.isEmpty();
+  }
 
-    public long getEarliestTime() {
-        Map.Entry<Long, Queue<TimeController.Task>> entry = tasks.firstEntry();
-        return entry == null ? 0 : entry.getKey();
-    }
+  public long getEarliestTime() {
+    Map.Entry<Long, Queue<TimeController.Task>> entry = tasks.firstEntry();
+    return entry == null ? 0 : entry.getKey();
+  }
 
-    private Queue<TimeController.Task> peekEarliest() {
-        return tasks.get(getEarliestTime());
-    }
+  private Queue<TimeController.Task> peekEarliest() {
+    return tasks.get(getEarliestTime());
+  }
 
-    public void dropEarliest() {
-        tasks.remove(getEarliestTime());
-    }
+  public void dropEarliest() {
+    tasks.remove(getEarliestTime());
+  }
 
-    public void executeEarliest() {
-        if (executing) return;
-        executing = true;
+  public void executeEarliest() {
+    if (executing) return;
+    executing = true;
+    try {
+      Queue<TimeController.Task> taskQueue = peekEarliest();
+      if (taskQueue == null) return;
+
+      Queue<CompletableFuture<Void>> resQueue = new LinkedBlockingQueue<>();
+
+      drainQueue(taskQueue, resQueue);
+
+      while (!resQueue.isEmpty()) {
         try {
-            Queue<TimeController.Task> taskQueue = peekEarliest();
-            if (taskQueue == null) return;
-
-            Queue<CompletableFuture<Void>> resQueue = new LinkedBlockingQueue<>();
-
-            drainQueue(taskQueue, resQueue);
-
-            while (!resQueue.isEmpty()) {
-                try {
-                    resQueue.poll().get();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            dropEarliest();
-        } finally {
-            executing = false;
+          resQueue.poll().get();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
         }
+      }
+      dropEarliest();
+    } finally {
+      executing = false;
     }
+  }
 
-    public boolean isExecuting() {
-        return executing;
-    }
+  public boolean isExecuting() {
+    return executing;
+  }
 
-    private synchronized void drainQueue(Queue<TimeController.Task> taskQueue, Queue<CompletableFuture<Void>> resQueue) {
-        while (!taskQueue.isEmpty()) {
-            TimeController.Task task = taskQueue.poll();
-            CompletableFuture<Void> taskFut = task.execute();
-            if (taskFut.isDone()) {
-                resQueue.add(taskFut);
-            } else {
-                CompletableFuture<Void> resFut = taskFut.whenComplete((v, t) -> {
-                    drainQueue(taskQueue, resQueue);
+  private synchronized void drainQueue(
+      Queue<TimeController.Task> taskQueue, Queue<CompletableFuture<Void>> resQueue) {
+    while (!taskQueue.isEmpty()) {
+      TimeController.Task task = taskQueue.poll();
+      CompletableFuture<Void> taskFut = task.execute();
+      if (taskFut.isDone()) {
+        resQueue.add(taskFut);
+      } else {
+        CompletableFuture<Void> resFut =
+            taskFut.whenComplete(
+                (v, t) -> {
+                  drainQueue(taskQueue, resQueue);
                 });
-                resQueue.add(resFut);
-            }
-        }
+        resQueue.add(resFut);
+      }
     }
+  }
 }

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/TimeController.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/TimeController.java
@@ -4,17 +4,13 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Controls global time and execution order of child executors
- * The instance can be either 'root' (with no parent) or dependent
- * on the parent controller.
- * In the latter case all the calls delegated to the parent controller
- * which manages the list of tasks and the global time
+ * Controls global time and execution order of child executors The instance can be either 'root'
+ * (with no parent) or dependent on the parent controller. In the latter case all the calls
+ * delegated to the parent controller which manages the list of tasks and the global time
  */
 public interface TimeController {
 
-  /**
-   * Abstract scheduled task
-   */
+  /** Abstract scheduled task */
   interface Task {
 
     long getTime();
@@ -23,40 +19,33 @@ public interface TimeController {
   }
 
   /**
-   * Returns this controller local time which differs from the parent
-   * time in case if time shift != 0
+   * Returns this controller local time which differs from the parent time in case if time shift !=
+   * 0
    */
   long getTime();
 
   /**
-   * The method call is only valid for the 'root' controller
-   * Sets internal clock time and executes any tasks scheduled in period from
-   * the previous time till new <code>currentTime</code> inclusive.
-   * Periodic tasks are executed several times if scheduled so.
-   * @param newTime should be >= the last set time
+   * The method call is only valid for the 'root' controller Sets internal clock time and executes
+   * any tasks scheduled in period from the previous time till new <code>currentTime</code>
+   * inclusive. Periodic tasks are executed several times if scheduled so.
    *
+   * @param newTime should be >= the last set time
    * @throws IllegalStateException if the controller is not root
    */
   void setTime(long newTime);
 
-  /**
-   * Child executors should add new scheduled tasks via this method
-   */
+  /** Child executors should add new scheduled tasks via this method */
   void addTask(Task task);
 
-  /**
-   * Child executors should cancel scheduled tasks via this method
-   */
+  /** Child executors should cancel scheduled tasks via this method */
   void cancelTask(Task task);
 
-  /**
-   * Sets the parent of this controller making it dependent
-   */
+  /** Sets the parent of this controller making it dependent */
   void setParent(TimeController parent);
 
   /**
-   * Simulates system clock deviations
-   * All children executors will see current time shifted by specified value
+   * Simulates system clock deviations All children executors will see current time shifted by
+   * specified value
    */
   void setTimeShift(long timeShift);
 

--- a/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/TimeControllerImpl.java
+++ b/tools/schedulers/src/main/java/io/libp2p/tools/schedulers/TimeControllerImpl.java
@@ -25,7 +25,7 @@ public class TimeControllerImpl implements TimeController {
   public void setTime(long newTime) {
     if (parent != null) {
       throw new IllegalStateException(
-              "setTime() is allowed only for the topmost TimeController (without parent)");
+          "setTime() is allowed only for the topmost TimeController (without parent)");
     }
     if (newTime < curTime) {
       throw new IllegalArgumentException("newTime < curTime: " + newTime + ", " + curTime);

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/gossip/GossipSimNetwork.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/gossip/GossipSimNetwork.kt
@@ -26,10 +26,11 @@ class GossipSimNetwork(
     val commonExecutor = ControlledExecutorServiceImpl(timeController)
 
     protected val peerExecutors =
-        if (cfg.iterationThreadsCount > 1)
+        if (cfg.iterationThreadsCount > 1) {
             (0 until cfg.iterationThreadsCount).map { Executors.newSingleThreadScheduledExecutor() }
-        else
+        } else {
             listOf(Executor { it.run() })
+        }
 
     var simPeerFactory: (Int, SimGossipRouterBuilder) -> GossipSimPeer = { number, router ->
         GossipSimPeer(number, commonRnd).apply {

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/gossip/GossipSimPeer.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/gossip/GossipSimPeer.kt
@@ -41,8 +41,11 @@ class GossipSimPeer(
         val logConnection = pubsubLogs(stream.remotePeerId())
         router.addPeerWithDebugHandler(
             stream,
-            if (logConnection)
-                LoggingHandler(name, LogLevel.ERROR) else null
+            if (logConnection) {
+                LoggingHandler(name, LogLevel.ERROR)
+            } else {
+                null
+            }
         )
         return dummy
     }

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/main/BlobDecouplingSimulation.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/main/BlobDecouplingSimulation.kt
@@ -135,7 +135,6 @@ class BlobDecouplingSimulation(
     }
 
     fun testOnlyBlockDecoupled() {
-
         for (i in 0 until messageCount) {
             val sendingPeer = sendingPeerIndexes[i]
             logger("Sending message $i from peer $sendingPeer")
@@ -153,7 +152,6 @@ class BlobDecouplingSimulation(
     }
 
     fun testAllDecoupled() {
-
         for (i in 0 until messageCount) {
             val sendingPeer = sendingPeerIndexes[i]
             logger("Sending message $i from peer $sendingPeer")
@@ -262,7 +260,7 @@ class BlobDecouplingSimulation(
 fun main() {
     val bandwidths = bandwidthDistributions.entries.toList()
         .let {
-            listOf(/*it[0],*/ it[2])
+            listOf(it[2])
         }.toMap()
     val slowBandwidth = Bandwidth.mbitsPerSec(10)
 
@@ -281,8 +279,11 @@ fun main() {
             val groupedDelays = sim.simulation.gatherPubDeliveryStats()
                 .aggregateSlowestByPublishTime()
                 .groupBy {
-                    if (it.toPeer.inboundBandwidth.totalBandwidth == slowBandwidth)
-                        "Slow" else "Fast"
+                    if (it.toPeer.inboundBandwidth.totalBandwidth == slowBandwidth) {
+                        "Slow"
+                    } else {
+                        "Fast"
+                    }
                 }
                 .mapValues { it.value.deliveryDelays }
             return GroupByRangeAggregator(groupedDelays)

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/main/GossipScoreTestSimulation.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/main/GossipScoreTestSimulation.kt
@@ -16,7 +16,6 @@ fun main() {
 class GossipScoreTestSimulation {
 
     fun run() {
-
         val simConfig = GossipSimConfig(
             totalPeers = 1000,
             topics = listOf(Topic(BlocksTopic)),

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/Libp2pConnectionImpl.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/Libp2pConnectionImpl.kt
@@ -10,7 +10,7 @@ import io.libp2p.transport.implementation.ConnectionOverNetty
 
 class Libp2pConnectionImpl(
     val remoteAddr:
-        Multiaddr,
+    Multiaddr,
     isInitiator: Boolean,
     localPubkey: PubKey,
     remotePubkey: PubKey,

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/StreamNettyChannel.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/StreamNettyChannel.kt
@@ -26,9 +26,9 @@ class StreamNettyChannel(
     vararg handlers: ChannelHandler?
 ) :
     SimChannel, EmbeddedChannel(
-    SimChannelId(id),
-    *handlers
-) {
+        SimChannelId(id),
+        *handlers
+    ) {
 
     override val msgVisitors: MutableList<SimChannelMessageVisitor> = mutableListOf()
 

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/StreamSimPeer.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/StreamSimPeer.kt
@@ -3,7 +3,7 @@ package io.libp2p.simulate.stream
 import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.StreamHandler
-import io.libp2p.core.crypto.KEY_TYPE
+import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.multiformats.MultiaddrComponent
@@ -42,7 +42,7 @@ abstract class StreamSimPeer<TProtocolController>(
     lateinit var currentTime: () -> Long
     var keyPair by lazyVar {
         generateKeyPair(
-            KEY_TYPE.ECDSA,
+            KeyType.ECDSA,
             random = SecureRandom(ByteArray(4).also { random.nextBytes(it) })
         )
     }

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/StreamSimStream.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/stream/StreamSimStream.kt
@@ -22,11 +22,17 @@ class StreamSimStream(
 
     init {
         val from =
-            if (streamInitiator == SimStream.StreamInitiator.CONNECTION_DIALER) connection.dialer
-            else connection.listener
+            if (streamInitiator == SimStream.StreamInitiator.CONNECTION_DIALER) {
+                connection.dialer
+            } else {
+                connection.listener
+            }
         val to =
-            if (streamInitiator == SimStream.StreamInitiator.CONNECTION_LISTENER) connection.dialer
-            else connection.listener
+            if (streamInitiator == SimStream.StreamInitiator.CONNECTION_LISTENER) {
+                connection.dialer
+            } else {
+                connection.listener
+            }
 
         val fromIsInitiator = from === connection.dialer
         val toIsInitiator = !fromIsInitiator
@@ -53,7 +59,6 @@ class StreamSimStream(
         connectionInitiator: Boolean,
         streamInitiator: Boolean
     ): StreamNettyChannel {
-
         return StreamNettyChannel(
             channelName,
             this,

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/util/NumExt.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/util/NumExt.kt
@@ -8,8 +8,7 @@ fun <TKey, TValue, TSrc> Collection<TSrc>.groupByRangesBy(
     valueExtractor: (TSrc) -> TValue,
     vararg ranges: ClosedRange<TKey>
 ): Map<ClosedRange<TKey>, List<TValue>>
-        where TKey : Number, TKey : Comparable<TKey> {
-
+    where TKey : Number, TKey : Comparable<TKey> {
     return this
         .mapNotNull { v -> ranges.firstOrNull { it.contains(keyExtractor(v)) }?.let { it to v } }
         .groupBy({ it.first }, { valueExtractor(it.second) })
@@ -20,15 +19,15 @@ fun <TKey, TSrc> Collection<TSrc>.groupByRangesBy(
     keyExtractor: (TSrc) -> TKey,
     vararg ranges: ClosedRange<TKey>
 ): Map<ClosedRange<TKey>, List<TSrc>>
-        where TKey : Number, TKey : Comparable<TKey> =
+    where TKey : Number, TKey : Comparable<TKey> =
     groupByRangesBy(keyExtractor, { it }, *ranges)
 
 fun <T, V> Collection<Pair<T, V>>.groupByRanges(vararg ranges: ClosedRange<T>): Map<ClosedRange<T>, List<V>>
-        where T : Number, T : Comparable<T> =
+    where T : Number, T : Comparable<T> =
     groupByRangesBy({ it.first }, { it.second }, *ranges)
 
 fun <T> Collection<T>.countByRanges(vararg ranges: ClosedRange<T>): List<Int>
-        where T : Number, T : Comparable<T> {
+    where T : Number, T : Comparable<T> {
     val v = this
         .map { it to it }
         .groupByRangesBy({ it.first }, { it.second }, *ranges)


### PR DESCRIPTION
Use spotless with ktlint (same as kotlinter), but it will also allow linting the java classes.

https://github.com/diffplug/spotless/tree/main/plugin-gradle

Required updating ktlint from version `45.2` used by kotlinter to `0.50`.

New rules were added for ktlint which required most of the changes in this PR after doing `spotlessApply`

- https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming

Renamed couple of things because of class-naming violation:

- KEY_TYPE enum in `Key.kt` to KeyType
- UNINITIALIZED_VALUE in `Delegates.kt` to UninitializedValue

Java classes were updated with the `googleJavaFormat` formatting after applying `spotlessApply`

Disabled enforcing of `trailing comma`