### PR TITLE
Fix Gossip excessive memory consumption by SeenCache

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -194,7 +194,7 @@ abstract class AbstractRouter(
                 val validationResult = seenMessages[subscribedMessage]
                 if (validationResult != null) {
                     // Message has been seen
-                    notifySeenMessage(peer, seenMessages.getSeenMessage(subscribedMessage), validationResult)
+                    notifySeenMessage(peer, seenMessages.getSeenMessageCached(subscribedMessage), validationResult)
                     false
                 } else {
                     // Message is unseen

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/SeenCache.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/SeenCache.kt
@@ -19,7 +19,9 @@ interface SeenCache<TValue> {
     val size: Int
 
     /**
-     * Returns the 'matching' key if it already exist in the cache or returns the argument if not
+     * Returns the 'matching' message if it exists in the cache or falls back to returning the argument if not
+     * The returned instance may have some data prepared and cached (e.g. `messageId`) which may
+     * have positive performance effect
      */
     fun getSeenMessage(msg: PubsubMessage): PubsubMessage
     fun getValue(msg: PubsubMessage): TValue?
@@ -138,6 +140,10 @@ class FastIdSeenCache<TValue>(private val fastIdFunction: (PubsubMessage) -> Any
         fastIdMap.removeAllByValue(slowId)
     }
 
+    /**
+     * Wraps [delegate] instance and overrides [messageId] with a cached value
+     * to avoid slow `messageId` computation by the [delegate] instance
+     */
     private class FastIdPubsubMessage(
         val delegate: PubsubMessage,
         override val messageId: MessageId

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/SeenCacheTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/SeenCacheTest.kt
@@ -132,8 +132,6 @@ class LRUSeenCacheTest {
         assertThat(backingCache.size).isEqualTo(0)
     }
 
-
-
     @Test
     fun `test old entries are evicted`() {
         val backingCache = SimpleSeenCache<String>()
@@ -143,7 +141,7 @@ class LRUSeenCacheTest {
         lruCache[createPubsubMessage(3)] = "3"
 
         assertThat(lruCache.size).isEqualTo(3)
-        assertContainsEntries(lruCache, 1, 2 ,3)
+        assertContainsEntries(lruCache, 1, 2, 3)
 
         lruCache[createPubsubMessage(4)] = "4"
 
@@ -151,12 +149,11 @@ class LRUSeenCacheTest {
         assertDoesntContainEntry(lruCache, 1)
         assertContainsEntries(lruCache, 2, 3, 4)
 
-
         lruCache[createPubsubMessage(5)] = "5"
 
         assertThat(lruCache.size).isEqualTo(3)
         assertDoesntContainEntries(lruCache, 1, 2)
-        assertContainsEntries(lruCache, 3, 4 ,5)
+        assertContainsEntries(lruCache, 3, 4, 5)
 
         lruCache[createPubsubMessage(1)] = "1"
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/SeenCacheTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/SeenCacheTest.kt
@@ -24,6 +24,7 @@ fun createMessage(number: Int): Rpc.Message {
 fun createPubsubMessage(number: Int) = TestPubsubMessage(createMessage(number))
 fun createPubsubMessage(number: Int, fastId: Int) =
     TestPubsubMessage(createMessage(number)).also { it.fastID = fastId }
+operator fun SeenCache<*>.minusAssign(msg: PubsubMessage) = this.remove(msg.messageId)
 
 fun assertContainsEntry(cache: SeenCache<String>, fakeMsg: Int) {
     assertThat(cache.isSeen(createPubsubMessage(fakeMsg))).isTrue()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/SeenCacheTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/SeenCacheTest.kt
@@ -28,7 +28,7 @@ fun createPubsubMessage(number: Int, fastId: Int) =
 fun assertContainsEntry(cache: SeenCache<String>, fakeMsg: Int) {
     assertThat(cache.isSeen(createPubsubMessage(fakeMsg))).isTrue()
     assertThat(cache.isSeen(createPubsubMessage(fakeMsg).messageId)).isTrue()
-    assertThat(cache.getValue(createPubsubMessage(fakeMsg))).isEqualTo(fakeMsg.toString())
+    assertThat(cache.get(createPubsubMessage(fakeMsg))).isEqualTo(fakeMsg.toString())
 }
 fun assertContainsEntries(cache: SeenCache<String>, vararg fakeMsgs: Int) {
     fakeMsgs.forEach {
@@ -39,7 +39,7 @@ fun assertContainsEntries(cache: SeenCache<String>, vararg fakeMsgs: Int) {
 fun assertDoesntContainEntry(cache: SeenCache<String>, fakeMsg: Int) {
     assertThat(cache.isSeen(createPubsubMessage(fakeMsg))).isFalse()
     assertThat(cache.isSeen(createPubsubMessage(fakeMsg).messageId)).isFalse()
-    assertThat(cache.getValue(createPubsubMessage(fakeMsg))).isNull()
+    assertThat(cache.get(createPubsubMessage(fakeMsg))).isNull()
 }
 fun assertDoesntContainEntries(cache: SeenCache<String>, vararg fakeMsgs: Int) {
     fakeMsgs.forEach {
@@ -81,41 +81,41 @@ fun genericSanityTest(cache: SeenCache<String>) {
     assertThat(cache.size).isEqualTo(1)
     assertThat(cache.isSeen(createPubsubMessage(1))).isTrue()
     assertThat(cache.isSeen(createPubsubMessage(2))).isFalse()
-    assertThat(cache.getValue(createPubsubMessage(1))).isEqualTo("1")
-    assertThat(cache.getValue(createPubsubMessage(2))).isNull()
-    assertThat(cache.getSeenMessage(createPubsubMessage(1))).isEqualTo(createPubsubMessage(1))
+    assertThat(cache.get(createPubsubMessage(1))).isEqualTo("1")
+    assertThat(cache.get(createPubsubMessage(2))).isNull()
+    assertThat(cache.getSeenMessageCached(createPubsubMessage(1))).isEqualTo(createPubsubMessage(1))
 
     cache[createPubsubMessage(1)] = "1-1"
 
     assertThat(cache.size).isEqualTo(1)
     assertThat(cache.isSeen(createPubsubMessage(1))).isTrue()
     assertThat(cache.isSeen(createPubsubMessage(2))).isFalse()
-    assertThat(cache.getValue(createPubsubMessage(1))).isEqualTo("1-1")
-    assertThat(cache.getValue(createPubsubMessage(2))).isNull()
+    assertThat(cache.get(createPubsubMessage(1))).isEqualTo("1-1")
+    assertThat(cache.get(createPubsubMessage(2))).isNull()
 
     cache[createPubsubMessage(2)] = "2"
 
     assertThat(cache.size).isEqualTo(2)
     assertThat(cache.isSeen(createPubsubMessage(1))).isTrue()
     assertThat(cache.isSeen(createPubsubMessage(2))).isTrue()
-    assertThat(cache.getValue(createPubsubMessage(1))).isEqualTo("1-1")
-    assertThat(cache.getValue(createPubsubMessage(2))).isEqualTo("2")
+    assertThat(cache.get(createPubsubMessage(1))).isEqualTo("1-1")
+    assertThat(cache.get(createPubsubMessage(2))).isEqualTo("2")
 
     cache -= createPubsubMessage(1)
 
     assertThat(cache.size).isEqualTo(1)
     assertThat(cache.isSeen(createPubsubMessage(1))).isFalse()
     assertThat(cache.isSeen(createPubsubMessage(2))).isTrue()
-    assertThat(cache.getValue(createPubsubMessage(1))).isNull()
-    assertThat(cache.getValue(createPubsubMessage(2))).isEqualTo("2")
+    assertThat(cache.get(createPubsubMessage(1))).isNull()
+    assertThat(cache.get(createPubsubMessage(2))).isEqualTo("2")
 
     cache -= createPubsubMessage(2)
 
     assertThat(cache.size).isEqualTo(0)
     assertThat(cache.isSeen(createPubsubMessage(1))).isFalse()
     assertThat(cache.isSeen(createPubsubMessage(2))).isFalse()
-    assertThat(cache.getValue(createPubsubMessage(1))).isNull()
-    assertThat(cache.getValue(createPubsubMessage(2))).isNull()
+    assertThat(cache.get(createPubsubMessage(1))).isNull()
+    assertThat(cache.get(createPubsubMessage(2))).isNull()
 }
 
 class LRUSeenCacheTest {
@@ -365,14 +365,14 @@ class FastIdSeenCacheTest {
         assertThat(m1_1.canonicalId).isNotNull()
         assertThat(m1_2.canonicalId).isNull()
 
-        val m1_3 = cache.getSeenMessage(m1_2)
+        val m1_3 = cache.getSeenMessageCached(m1_2)
         assertThat(m1_3.messageId).isEqualTo(m1_1.canonicalId)
         assertThat(m1_2.canonicalId).isNull()
 
         assertThat(m1_2 in cache).isTrue()
         assertThat(m1_2.canonicalId).isNull()
 
-        assertThat(cache.getValue(m1_2)).isEqualTo("1-1")
+        assertThat(cache.get(m1_2)).isEqualTo("1-1")
         assertThat(m1_2.canonicalId).isNull()
     }
 
@@ -385,14 +385,14 @@ class FastIdSeenCacheTest {
         cache[m1_1] = "1-1"
         assertThat(m1_1 in cache).isTrue()
         assertThat(m1_2 in cache).isTrue()
-        assertThat(cache.getValue(m1_1)).isEqualTo("1-1")
-        assertThat(cache.getValue(m1_2)).isEqualTo("1-1")
+        assertThat(cache.get(m1_1)).isEqualTo("1-1")
+        assertThat(cache.get(m1_2)).isEqualTo("1-1")
 
         cache[m1_2] = "1-2"
         assertThat(m1_1 in cache).isTrue()
         assertThat(m1_2 in cache).isTrue()
-        assertThat(cache.getValue(m1_1)).isEqualTo("1-2")
-        assertThat(cache.getValue(m1_2)).isEqualTo("1-2")
+        assertThat(cache.get(m1_1)).isEqualTo("1-2")
+        assertThat(cache.get(m1_2)).isEqualTo("1-2")
 
         val m1_1_1 = createPubsubMessage(1, 1)
         val m1_2_1 = createPubsubMessage(1, 2)
@@ -404,8 +404,8 @@ class FastIdSeenCacheTest {
         cache -= m1_1
         assertThat(m1_1 in cache).isFalse()
         assertThat(m1_2 in cache).isFalse()
-        assertThat(cache.getValue(m1_1)).isNull()
-        assertThat(cache.getValue(m1_2)).isNull()
+        assertThat(cache.get(m1_1)).isNull()
+        assertThat(cache.get(m1_2)).isNull()
 
         assertThat(cache.fastIdMap.isEmpty()).isTrue()
         assertThat(cache.slowIdMap).isEmpty()


### PR DESCRIPTION
The `SeenCache` aims to effectively filter duplicate messages for a longer period (2 minutes by default) than `mCache` stores (5 seconds by default). The `SeenCache` implementations shouldn't retain references to received messages' content since it could be significant memory consumption in case of heavy gossip traffic:

![image](https://github.com/libp2p/jvm-libp2p/assets/8173857/f57955a3-7527-43b4-bcf0-e3baa244cfce)

The secondary purpose of the `SeenCache` is to cache `messageId` (which calculation could be resource consuming) of seen messages based of a fast message id (see `SeenCache.getSeenMessageCached()` method and `FastIdSeenCache` implementation) 

To address the memory issue the `SeenCache` implementations should rely on message ids (either slow or fast or both) and don't keep the `PubsubMessage` references. 

To preserve the secondary purpose the `FastIdSeenCache.getSeenMessageCached()` wraps the `PubsubMessage` with a wrapper instance which is supplied with the cached `messageId` when available. 