### PR TITLE
Disable customization of the generated pom

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,6 +153,14 @@ configure(
             publications {
                 register("mavenJava", MavenPublication::class) {
                     from(components["java"])
+                    versionMapping {
+                        usage("java-api") {
+                            fromResolutionOf("runtimeClasspath")
+                        }
+                        usage("java-runtime") {
+                            fromResolutionResult()
+                        }
+                    }
                     artifact(sourcesJar.get())
                     artifact(dokkaJar.get())
                     groupId = "io.libp2p"

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,4 +1,8 @@
 dependencyManagement {
+    // https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/#pom-generation-disabling
+    generatedPomCustomization {
+        enabled = false
+    }
     dependencies {
 
         dependency "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"


### PR DESCRIPTION
Basically the generated pom will not have `<dependencyManagement>` section and versions will be resolved automatically by the publish plugin.

https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/#pom-generation-disabling
https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:resolved_dependencies

This results in a clean pom same as version 0.10.0 and below:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>io.libp2p</groupId>
  <artifactId>jvm-libp2p</artifactId>
  <version>develop</version>
  <dependencies>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-common</artifactId>
      <version>4.1.90.Final</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-buffer</artifactId>
      <version>4.1.90.Final</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-transport</artifactId>
      <version>4.1.90.Final</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.protobuf</groupId>
      <artifactId>protobuf-java</artifactId>
      <version>3.21.12</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib-jdk8</artifactId>
      <version>1.6.21</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlinx</groupId>
      <artifactId>kotlinx-coroutines-core</artifactId>
      <version>1.6.4</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>31.1-jre</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>2.0.7</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>com.github.multiformats</groupId>
      <artifactId>java-multibase</artifactId>
      <version>v1.1.1</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-handler</artifactId>
      <version>4.1.90.Final</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-codec-http</artifactId>
      <version>4.1.90.Final</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>tech.pegasys</groupId>
      <artifactId>noise-java</artifactId>
      <version>22.1.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcprov-jdk15on</artifactId>
      <version>1.70</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcpkix-jdk15on</artifactId>
      <version>1.70</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bctls-jdk15on</artifactId>
      <version>1.70</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>

```