### PR TITLE
[Yamux] Fix sending of buffered messages after a window update

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -47,8 +47,8 @@ open class YamuxHandler(
                 val length = data.readableBytes()
                 if (length <= windowSize.get()) {
                     sendBlocks(ctx, data, windowSize, id)
-                    bufferedBytes.addAndGet(-length)
                     data.release()
+                    bufferedBytes.addAndGet(-length)
                     bufferedData.removeFirst()
                 } else {
                     // partial write to fit within window

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -150,7 +150,7 @@ open class YamuxHandler(
             val buffer = sendBuffers.getOrPut(child.id) { SendBuffer(child.id, ctx) }
             buffer.add(data)
             if (calculateTotalBufferedWrites() > MAX_BUFFERED_CONNECTION_WRITES) {
-                throw Libp2pException("Overflowed send buffer for connection")
+                throw Libp2pException("Overflowed send buffer for connection ${ctx.channel().id()}")
             }
             return
         }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -88,14 +88,14 @@ open class YamuxHandler(
 
     private fun handleDataRead(msg: YamuxFrame) {
         handleFlags(msg)
+        val size = msg.length.toInt()
+        if (size == 0) {
+            return
+        }
         val windowSize = windowSizes[msg.id]
         if (windowSize == null) {
             releaseMessage(msg.data!!)
             throw Libp2pException("Unable to retrieve window size for ${msg.id}")
-        }
-        val size = msg.length.toInt()
-        if (size == 0) {
-            return
         }
         val ctx = getChannelHandlerContext()
         val newWindow = windowSize.addAndGet(-size)
@@ -111,11 +111,11 @@ open class YamuxHandler(
 
     private fun handleWindowUpdate(msg: YamuxFrame) {
         handleFlags(msg)
-        val windowSize = windowSizes[msg.id] ?: throw Libp2pException("Unable to retrieve window size for ${msg.id}")
         val delta = msg.length.toInt()
         if (delta == 0) {
             return
         }
+        val windowSize = windowSizes[msg.id] ?: throw Libp2pException("Unable to retrieve window size for ${msg.id}")
         windowSize.addAndGet(delta)
         // try to send any buffered messages after the window update
         sendBuffers[msg.id]?.flush(windowSize)

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -149,8 +149,13 @@ open class YamuxHandler(
             // wait until the window is increased to send more data
             val buffer = sendBuffers.getOrPut(child.id) { SendBuffer(child.id, ctx) }
             buffer.add(data)
-            if (calculateTotalBufferedWrites() > MAX_BUFFERED_CONNECTION_WRITES) {
-                throw Libp2pException("Overflowed send buffer for connection ${ctx.channel().id()}")
+            val totalBufferedWrites = calculateTotalBufferedWrites()
+            if (totalBufferedWrites > MAX_BUFFERED_CONNECTION_WRITES) {
+                throw Libp2pException(
+                    "Overflowed send buffer ($totalBufferedWrites/$MAX_BUFFERED_CONNECTION_WRITES) for connection ${
+                        ctx.channel().id().asLongText()
+                    }"
+                )
             }
             return
         }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -88,14 +88,14 @@ open class YamuxHandler(
 
     private fun handleDataRead(msg: YamuxFrame) {
         handleFlags(msg)
-        val size = msg.length.toInt()
-        if (size == 0) {
-            return
-        }
         val windowSize = windowSizes[msg.id]
         if (windowSize == null) {
             releaseMessage(msg.data!!)
             throw Libp2pException("Unable to retrieve window size for ${msg.id}")
+        }
+        val size = msg.length.toInt()
+        if (size == 0) {
+            return
         }
         val ctx = getChannelHandlerContext()
         val newWindow = windowSize.addAndGet(-size)
@@ -111,15 +111,14 @@ open class YamuxHandler(
 
     private fun handleWindowUpdate(msg: YamuxFrame) {
         handleFlags(msg)
+        val windowSize = windowSizes[msg.id] ?: throw Libp2pException("Unable to retrieve window size for ${msg.id}")
         val delta = msg.length.toInt()
         if (delta == 0) {
             return
         }
-        val windowSize = windowSizes[msg.id] ?: return
         windowSize.addAndGet(delta)
-        val buffer = sendBuffers[msg.id] ?: return
         // try to send any buffered messages after the window update
-        buffer.flush(windowSize)
+        sendBuffers[msg.id]?.flush(windowSize)
     }
 
     private fun handleFlags(msg: YamuxFrame) {

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -32,7 +32,7 @@ open class YamuxHandler(
         private val bufferedData = ArrayDeque<ByteBuf>()
 
         fun add(data: ByteBuf) {
-            bufferedData.add(data.retain())
+            bufferedData.add(data)
         }
 
         fun bufferedBytes(): Int {
@@ -45,13 +45,12 @@ open class YamuxHandler(
                 val length = data.readableBytes()
                 if (length <= windowSize.get()) {
                     sendBlocks(ctx, data, windowSize, id)
-                    data.release()
                     bufferedData.removeFirst()
                 } else {
                     // partial write to fit within window
                     val toRead = windowSize.get()
                     if (toRead > 0) {
-                        val partialData = data.readSlice(toRead)
+                        val partialData = data.readRetainedSlice(toRead)
                         sendBlocks(ctx, partialData, windowSize, id)
                     }
                     break

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -177,6 +177,8 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         frame = readFrameOrThrow()
         // the other message is partially received
         assertThat(frame.data).isEqualTo("19")
+        // need to wait for another window update to receive more data
+        assertThat(readFrame()).isNull()
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -142,7 +142,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
     }
 
     @Test
-    fun `partial data is written if it fits windows`() {
+    fun `partial buffered data is sent if it fits windows`() {
         val handler = openStreamByLocal()
         val streamId = readFrameOrThrow().streamId
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -171,9 +171,12 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             )
         )
 
-        val frame = readFrameOrThrow()
+        var frame = readFrameOrThrow()
         // one message is fully received
         assertThat(frame.data).isEqualTo("1984")
+        frame = readFrameOrThrow()
+        // the other message is partially received
+        assertThat(frame.data).isEqualTo("19")
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -142,7 +142,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
     }
 
     @Test
-    fun `partial buffered data is sent if it fits windows`() {
+    fun `buffered data should be partially sent if it does not fit within window`() {
         val handler = openStreamByLocal()
         val streamId = readFrameOrThrow().streamId
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -184,6 +184,17 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         assertThat(frame.data).isEqualTo("19")
         // need to wait for another window update to receive more data
         assertThat(readFrame()).isNull()
+        // sending window update to read the final part of the buffer
+        ech.writeInbound(
+            YamuxFrame(
+                streamId.toMuxId(),
+                YamuxType.WINDOW_UPDATE,
+                YamuxFlags.ACK,
+                1
+            )
+        )
+        frame = readFrameOrThrow()
+        assertThat(frame.data).isEqualTo("84")
     }
 
     @Test


### PR DESCRIPTION
Mainly changes and refactoring around `SendBuffer` class. Also using a single `windowSizes` map for receive and send window sizes since the MuxId is different.

Before logic was checking the total written bytes in the buffer against the `sendWindow` to determine if it fits within window. That is not entirely correct since the sendWindow is changed inside `sendBlocks` method. That could lead to incorrect behaviour. 

Also there is a possibility that `sendWindow` is negative, so adding a check which will help with one of the exceptions captured in https://github.com/libp2p/jvm-libp2p/issues/311 `java.lang.IllegalArgumentException: minimumReadableBytes : -52227 (expected: >= 0)`

Also change to calculate `totalBufferedWrites` on the fly based on the existing `SendBuffer` values in the map.

Removed `data.retain` and `data.release` in `SendBuffer.add()` and `SendBuffer.flush()`. Use `data.readRetainedSlice()` for the partial buffer sending.