### PR TITLE
[Yamux] Limit the send buffer size per stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Add the library to the `dependencies` section of the pom file:
   <groupId>io.libp2p</groupId>
   <artifactId>jvm-libp2p</artifactId>
   <version>X.Y.Z-RELEASE</version>
-  <type>pom</type>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import java.net.URL
 // To publish the release artifact to CloudSmith repo run the following :
 // ./gradlew publish -PcloudsmithUser=<user> -PcloudsmithApiKey=<api-key>
 
-description = "an implementation of libp2p for the jvm"
+description = "a libp2p implementation for the JVM, written in Kotlin"
 
 plugins {
     val kotlinVersion = "1.6.21"

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -171,7 +171,7 @@ open class YamuxHandler(
     }
 
     fun sendFrames(ctx: ChannelHandlerContext, data: ByteBuf, windowSize: AtomicInteger, id: MuxId) {
-        data.sliceMaxSize(minOf(windowSize.get(), maxFrameDataLength))
+        data.sliceMaxSize(maxFrameDataLength)
             .map { slicedData ->
                 val length = slicedData.readableBytes()
                 windowSize.addAndGet(-length)

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -151,10 +151,15 @@ open class YamuxHandler(
 
         if (windowSize.get() <= 0) {
             // add to buffer until the window is increased
-            log.trace("Adding message of {} bytes to the send buffer for {}", data.readableBytes(), child.id)
             val buffer = sendBuffers.getOrPut(child.id) { SendBuffer(child.id, ctx) }
             buffer.add(data)
             val bufferedBytes = buffer.bufferedBytes()
+            log.trace(
+                "Added {} bytes to the send buffer for {}. Its buffer size is now {} bytes",
+                data.readableBytes(),
+                child.id,
+                bufferedBytes
+            )
             if (bufferedBytes > MAX_BUFFER_SIZE) {
                 throw Libp2pException(
                     "Overflowed send buffer ($bufferedBytes/$MAX_BUFFER_SIZE) for ${child.id}"

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -166,7 +166,7 @@ open class YamuxHandler(
     }
 
     fun sendFrames(ctx: ChannelHandlerContext, data: ByteBuf, windowSize: AtomicInteger, id: MuxId) {
-        data.sliceMaxSize(maxFrameDataLength)
+        data.sliceMaxSize(minOf(windowSize.get(), maxFrameDataLength))
             .map { slicedData ->
                 val length = slicedData.readableBytes()
                 windowSize.addAndGet(-length)

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -144,12 +144,7 @@ open class YamuxHandler(
         val windowSize =
             windowSizes[child.id] ?: throw Libp2pException("Unable to retrieve window size for ${child.id}")
 
-        if (data.readableBytes() > windowSize.get()) {
-            if (windowSize.get() > 0) {
-                // send partial data to fit within window
-                val partialData = data.readRetainedSlice(windowSize.get())
-                sendFrames(ctx, partialData, windowSize, child.id)
-            }
+        if (windowSize.get() <= 0) {
             // add to buffer until the window is increased
             val buffer = sendBuffers.getOrPut(child.id) { SendBuffer(child.id, ctx) }
             buffer.add(data)


### PR DESCRIPTION
Before we were limiting the sending buffer for the whole connection. I had a look in rust implementation and it looks like their implementation is limiting it per stream https://github.com/libp2p/rust-yamux/blob/master/yamux/src/lib.rs .This change could help with https://github.com/libp2p/jvm-libp2p/issues/311

- Changed currently configured MAX_BUFFER_SIZE to be per stream
- Renamed `sendBlocks` to `sendFrames`