### PR TITLE
[Yamux] Increase write buffer size and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Add the library to the `dependencies` section of the pom file:
   <groupId>io.libp2p</groupId>
   <artifactId>jvm-libp2p</artifactId>
   <version>X.Y.Z-RELEASE</version>
-  <type>pom</type>
 </dependency>
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import java.net.URL
 // To publish the release artifact to CloudSmith repo run the following :
 // ./gradlew publish -PcloudsmithUser=<user> -PcloudsmithApiKey=<api-key>
 
-description = "an implementation of libp2p for the jvm"
+description = "a libp2p implementation for the JVM, written in Kotlin"
 
 plugins {
     val kotlinVersion = "1.6.21"

--- a/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
@@ -3,6 +3,7 @@ package io.libp2p.core.mux
 import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.mux.mplex.MplexStreamMuxer
+import io.libp2p.mux.yamux.DEFAULT_MAX_BUFFERED_CONNECTION_WRITES
 import io.libp2p.mux.yamux.YamuxStreamMuxer
 
 fun interface StreamMuxerProtocol {
@@ -20,14 +21,21 @@ fun interface StreamMuxerProtocol {
             )
         }
 
+        /**
+         * @param maxBufferedConnectionWrites the maximum amount of bytes in the write buffer per connection before termination
+         */
         @JvmStatic
-        val Yamux = StreamMuxerProtocol { multistreamProtocol, protocols ->
-            YamuxStreamMuxer(
-                multistreamProtocol.createMultistream(
-                    protocols
-                ).toStreamHandler(),
-                multistreamProtocol
-            )
+        @JvmOverloads
+        fun getYamux(maxBufferedConnectionWrites: Int = DEFAULT_MAX_BUFFERED_CONNECTION_WRITES): StreamMuxerProtocol {
+            return StreamMuxerProtocol { multistreamProtocol, protocols ->
+                YamuxStreamMuxer(
+                    multistreamProtocol.createMultistream(
+                        protocols
+                    ).toStreamHandler(),
+                    multistreamProtocol,
+                    maxBufferedConnectionWrites
+                )
+            }
         }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -58,6 +58,11 @@ open class YamuxHandler(
                 }
             }
         }
+
+        fun close() {
+            bufferedData.forEach { it.release() }
+            bufferedData.clear()
+        }
     }
 
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
@@ -151,6 +156,7 @@ open class YamuxHandler(
             buffer.add(data)
             val totalBufferedWrites = calculateTotalBufferedWrites()
             if (totalBufferedWrites > maxBufferedConnectionWrites) {
+                buffer.close()
                 throw Libp2pException(
                     "Overflowed send buffer ($totalBufferedWrites/$maxBufferedConnectionWrites) for connection ${
                         ctx.channel().id().asLongText()

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
@@ -12,7 +12,8 @@ import java.util.concurrent.CompletableFuture
 
 class YamuxStreamMuxer(
     val inboundStreamHandler: StreamHandler<*>,
-    private val multistreamProtocol: MultistreamProtocol
+    private val multistreamProtocol: MultistreamProtocol,
+    private val maxBufferedConnectionWrites: Int
 ) : StreamMuxer, StreamMuxerDebug {
 
     override val protocolDescriptor = ProtocolDescriptor("/yamux/1.0.0")
@@ -30,7 +31,8 @@ class YamuxStreamMuxer(
                 yamuxFrameCodec.maxFrameDataLength,
                 muxSessionReady,
                 inboundStreamHandler,
-                ch.isInitiator
+                ch.isInitiator,
+                maxBufferedConnectionWrites
             )
         )
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -23,7 +23,8 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             maxFrameDataLength,
             null,
             streamHandler,
-            true
+            true,
+            DEFAULT_MAX_BUFFERED_CONNECTION_WRITES
         ) {
             // MuxHandler consumes the exception. Override this behaviour for testing
             @Deprecated("Deprecated in Java")

--- a/libp2p/src/test/kotlin/io/libp2p/security/tls/TlsSecureChannelTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/tls/TlsSecureChannelTest.kt
@@ -19,7 +19,7 @@ val MultistreamProtocolV1: MultistreamProtocolDebug = MultistreamProtocolDebugV1
 @Tag("secure-channel")
 class TlsSecureChannelTest : SecureChannelTestBase(
     ::TlsSecureChannel,
-    listOf(StreamMuxerProtocol.Yamux.createMuxer(MultistreamProtocolV1, listOf())),
+    listOf(StreamMuxerProtocol.getYamux().createMuxer(MultistreamProtocolV1, listOf())),
     TlsSecureChannel.announce
 ) {
     @Test


### PR DESCRIPTION
- Make `maxBufferedConnectionWrites` configurable and default it to 10MiB
- Release and clear  `buffer` when overflowed.