### PR TITLE
[Yamux] Send whole data if window size is > 0

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
@@ -22,7 +22,7 @@ fun interface StreamMuxerProtocol {
         }
 
         /**
-         * @param maxBufferedConnectionWrites the maximum amount of bytes in the write buffer per connection before termination
+         * @param maxBufferedConnectionWrites the maximum amount of bytes in the write buffer per connection
          */
         @JvmStatic
         @JvmOverloads

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -90,8 +90,7 @@ open class YamuxHandler(
         if (size == 0) {
             return
         }
-        val windowSize = receiveWindowSizes[msg.id]
-        if (windowSize == null) {
+        val windowSize = receiveWindowSizes[msg.id] ?: run {
             releaseMessage(msg.data!!)
             throw Libp2pException("Unable to retrieve receive window size for ${msg.id}")
         }
@@ -141,8 +140,7 @@ open class YamuxHandler(
     override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf) {
         val ctx = getChannelHandlerContext()
 
-        val windowSize = sendWindowSizes[child.id]
-        if (windowSize == null) {
+        val windowSize = sendWindowSizes[child.id] ?: run {
             releaseMessage(data)
             throw Libp2pException("Unable to retrieve receive send window size for ${child.id}")
         }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -101,8 +101,8 @@ open class YamuxHandler(
         if (newWindow < INITIAL_WINDOW_SIZE / 2) {
             val delta = INITIAL_WINDOW_SIZE - newWindow
             windowSize.addAndGet(delta)
-            ctx.write(YamuxFrame(msg.id, YamuxType.WINDOW_UPDATE, 0, delta.toLong()))
-            ctx.flush()
+            val frame = YamuxFrame(msg.id, YamuxType.WINDOW_UPDATE, 0, delta.toLong())
+            ctx.writeAndFlush(frame)
         }
         childRead(msg.id, msg.data!!)
     }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -158,13 +158,12 @@ open class YamuxHandler(
                     val length = slicedData.readableBytes()
                     windowSize.addAndGet(-length)
                     val frame = YamuxFrame(id, YamuxType.DATA, 0, length.toLong(), slicedData)
-                    ctx.write(frame)
+                    ctx.writeAndFlush(frame)
                 } else {
                     // wait until the window is increased to send
                     addToSendBuffer(id, data, ctx)
                 }
             }
-        ctx.flush()
     }
 
     private fun addToSendBuffer(id: MuxId, data: ByteBuf, ctx: ChannelHandlerContext) {

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -151,7 +151,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
     }
 
     @Test
-    fun `buffered data should be partially sent if it does not fit within window`() {
+    fun `buffered data should not be sent if it does not fit within window`() {
         val handler = openStreamByLocal()
         val streamId = readFrameOrThrow().streamId
 
@@ -176,19 +176,16 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
                 streamId.toMuxId(),
                 YamuxType.WINDOW_UPDATE,
                 YamuxFlags.ACK,
-                3
+                2
             )
         )
 
         var frame = readFrameOrThrow()
-        // one message is fully received
+        // one message is received
         assertThat(frame.data).isEqualTo("1984")
-        frame = readFrameOrThrow()
-        // the other message is partially received
-        assertThat(frame.data).isEqualTo("19")
-        // need to wait for another window update to receive more data
+        // need to wait for another window update to send more data
         assertThat(readFrame()).isNull()
-        // sending window update to read the final part of the buffer
+        // sending window update
         ech.writeInbound(
             YamuxFrame(
                 streamId.toMuxId(),
@@ -198,7 +195,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             )
         )
         frame = readFrameOrThrow()
-        assertThat(frame.data).isEqualTo("84")
+        assertThat(frame.data).isEqualTo("1984")
     }
 
     @Test


### PR DESCRIPTION
There were some inconsistencies with `sendFrames` method and the send buffer `flush` approach to sending data.

- `sendFrames` was checking if window size is <= 0 and adding to buffer if so and afterwards was slicing the data based on the window size and sending across. So essentially if window size is 10 and data is 100 bytes, it will send across 10 frames of 10 bytes.
- `flush` was respecting the window size and was sending partial data if the length of the data is less than the window size.

I would imagine a better approach is if window size is > 0, just send the whole data respecting the `maxFrameDataLength`. 

- Made `flush` not use `sendFrames` since the data is already limited by `maxFrameDataLength` so no slicing needed
- Renamed `sendFrames` to `sendData`
- Changed `sendData` to respect the window size and add to buffer there instead of `onChildWrite`
- Modified tests accordingly
- Release message when `onChildWrite` and no window size is found.

