### PR TITLE
[Yamux] Send RST when write buffer has overflowed

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -102,14 +102,13 @@ open class YamuxHandler(
             releaseMessage(msg.data!!)
             throw Libp2pException("Unable to retrieve receive window size for ${msg.id}")
         }
-        val ctx = getChannelHandlerContext()
         val newWindow = windowSize.addAndGet(-size)
         // send a window update frame once half of the window is depleted
         if (newWindow < INITIAL_WINDOW_SIZE / 2) {
             val delta = INITIAL_WINDOW_SIZE - newWindow
             windowSize.addAndGet(delta)
             val frame = YamuxFrame(msg.id, YamuxType.WINDOW_UPDATE, 0, delta.toLong())
-            ctx.writeAndFlush(frame)
+            getChannelHandlerContext().writeAndFlush(frame)
         }
         childRead(msg.id, msg.data!!)
     }
@@ -146,36 +145,38 @@ open class YamuxHandler(
     }
 
     override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf) {
-        val ctx = getChannelHandlerContext()
-
         val windowSize = sendWindowSizes[child.id] ?: run {
             releaseMessage(data)
-            throw Libp2pException("Unable to retrieve receive send window size for ${child.id}")
+            throw Libp2pException("Unable to retrieve send window size for ${child.id}")
         }
 
-        sendData(ctx, data, windowSize, child.id)
+        sendData(child, windowSize, data)
     }
 
     private fun calculateTotalBufferedWrites(): Int {
         return sendBuffers.values.sumOf { it.bufferedBytes() }
     }
 
-    private fun sendData(ctx: ChannelHandlerContext, data: ByteBuf, windowSize: AtomicInteger, id: MuxId) {
+    private fun sendData(
+        child: MuxChannel<ByteBuf>,
+        windowSize: AtomicInteger,
+        data: ByteBuf
+    ) {
         data.sliceMaxSize(maxFrameDataLength)
             .forEach { slicedData ->
                 if (windowSize.get() > 0) {
                     val length = slicedData.readableBytes()
                     windowSize.addAndGet(-length)
-                    val frame = YamuxFrame(id, YamuxType.DATA, 0, length.toLong(), slicedData)
-                    ctx.writeAndFlush(frame)
+                    val frame = YamuxFrame(child.id, YamuxType.DATA, 0, length.toLong(), slicedData)
+                    getChannelHandlerContext().writeAndFlush(frame)
                 } else {
                     // wait until the window is increased to send
-                    addToSendBuffer(id, data, ctx)
+                    addToSendBuffer(child, data)
                 }
             }
     }
 
-    private fun addToSendBuffer(child: MuxChannel<ByteBuf>, data: ByteBuf, ctx: ChannelHandlerContext) {
+    private fun addToSendBuffer(child: MuxChannel<ByteBuf>, data: ByteBuf) {
         val buffer = sendBuffers.getOrPut(child.id) { SendBuffer(child.id) }
         buffer.add(data)
         val totalBufferedWrites = calculateTotalBufferedWrites()
@@ -183,7 +184,7 @@ open class YamuxHandler(
             onLocalClose(child)
             throw Libp2pException(
                 "Overflowed send buffer ($totalBufferedWrites/$maxBufferedConnectionWrites) for connection ${
-                    ctx.channel().id().asLongText()
+                    getChannelHandlerContext().channel().id().asLongText()
                 }"
             )
         }

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -199,7 +199,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
     }
 
     @Test
-    fun `overflowing buffer throws an exception`() {
+    fun `overflowing buffer sends RST flag and throws an exception`() {
         val handler = openStreamByLocal()
         val streamId = readFrameOrThrow().streamId
 
@@ -226,6 +226,9 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         assertThat(writeResult.cause())
             .isInstanceOf(Libp2pException::class.java)
             .hasMessage("Overflowed send buffer (612/512) for connection test")
+
+        val frame = readYamuxFrameOrThrow()
+        assertThat(frame.flags).isEqualTo(YamuxFlags.RST)
     }
 
     @Test


### PR DESCRIPTION
- Send a reset frame when a write buffer has overflown. 
- Ensure we remove entry from `sendWindowSizes` to stop further writes on both FIN and RST
- Close buffer when RST and on `onChildClosed`
- Flush and close buffer on FIN
