### PR TITLE
[Yamux] Clear caches when connection is closed

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -58,6 +58,14 @@ open class YamuxHandler(
         }
     }
 
+    override fun channelInactive(ctx: ChannelHandlerContext) {
+        sendWindowSizes.clear()
+        sendBuffers.values.forEach { it.close() }
+        sendBuffers.clear()
+        receiveWindowSizes.clear()
+        super.channelUnregistered(ctx)
+    }
+
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         msg as YamuxFrame
         when (msg.type) {

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -63,7 +63,7 @@ open class YamuxHandler(
         sendBuffers.values.forEach { it.close() }
         sendBuffers.clear()
         receiveWindowSizes.clear()
-        super.channelUnregistered(ctx)
+        super.channelInactive(ctx)
     }
 
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -58,12 +58,12 @@ open class YamuxHandler(
         }
     }
 
-    override fun channelInactive(ctx: ChannelHandlerContext) {
+    override fun channelUnregistered(ctx: ChannelHandlerContext?) {
         sendWindowSizes.clear()
         sendBuffers.values.forEach { it.close() }
         sendBuffers.clear()
         receiveWindowSizes.clear()
-        super.channelInactive(ctx)
+        super.channelUnregistered(ctx)
     }
 
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {


### PR DESCRIPTION
Clear sendBuffers and windowSizes when connection is closed (`channelUnregistered` Netty callback)