### PR TITLE
[Yamux] Increase the max buffered connection writes

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -16,7 +16,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 const val INITIAL_WINDOW_SIZE = 256 * 1024
-const val DEFAULT_MAX_BUFFERED_CONNECTION_WRITES = 10 * 1024 * 1024 // 10 MiB
+
+// defaulting the maxBufferedConnectionWrites to 150 MiB as a band-aid fix until proper backpressure is implemented
+const val DEFAULT_MAX_BUFFERED_CONNECTION_WRITES = 150 * 1024 * 1024
 
 open class YamuxHandler(
     override val multistreamProtocol: MultistreamProtocol,


### PR DESCRIPTION
Increase the max buffered connection writes to 150 MiB until proper backpressure is implemented as part of https://github.com/libp2p/jvm-libp2p/issues/282

150 MiB is enough to serve Ethereum [BeaconBlocksByRange](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beaconblocksbyrange) requests 

fixes #311 

