### PR TITLE
Refactor YamuxHandler.SendBuffer

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/ByteBufQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/ByteBufQueue.kt
@@ -1,0 +1,44 @@
+package io.libp2p.etc.util.netty
+
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+
+class ByteBufQueue {
+    private val data: MutableList<ByteBuf> = mutableListOf()
+
+    fun push(buf: ByteBuf) {
+        data += buf
+    }
+
+    fun take(maxLength: Int): ByteBuf {
+        val wholeBuffers = mutableListOf<ByteBuf>()
+        var size = 0
+        while (data.isNotEmpty()) {
+            val bufLen = data.first().readableBytes()
+            if (size + bufLen > maxLength) break
+            size += bufLen
+            wholeBuffers += data.removeFirst()
+            if (size == maxLength) break
+        }
+
+        val partialBufferSlice =
+            when {
+                data.isEmpty() -> null
+                size == maxLength -> null
+                else -> data.first()
+            }
+                ?.let { buf ->
+                    val remainingBytes = maxLength - size
+                    buf.readSlice(remainingBytes).retain()
+                }
+
+        val allBuffers = wholeBuffers + listOfNotNull(partialBufferSlice)
+        return Unpooled.wrappedBuffer(*allBuffers.toTypedArray())
+    }
+
+    fun dispose() {
+        data.forEach { it.release() }
+    }
+
+    fun readableBytes(): Int = data.sumOf { it.readableBytes() }
+}

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/ByteBufQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/ByteBufQueue.kt
@@ -29,7 +29,7 @@ class ByteBufQueue {
             }
                 ?.let { buf ->
                     val remainingBytes = maxLength - size
-                    buf.readSlice(remainingBytes).retain()
+                    buf.readRetainedSlice(remainingBytes)
                 }
 
         val allBuffers = wholeBuffers + listOfNotNull(partialBufferSlice)

--- a/libp2p/src/test/kotlin/io/libp2p/etc/util/netty/ByteBufQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/etc/util/netty/ByteBufQueueTest.kt
@@ -1,0 +1,167 @@
+package io.libp2p.etc.util.netty
+
+import io.libp2p.tools.readAllBytesAndRelease
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class ByteBufQueueTest {
+
+    val queue = ByteBufQueue()
+
+    val allocatedBufs = mutableListOf<ByteBuf>()
+
+    @AfterEach
+    fun cleanUpAndCheck() {
+        allocatedBufs.forEach {
+            assertThat(it.refCnt()).isEqualTo(1)
+        }
+    }
+
+    fun allocateBuf(): ByteBuf {
+        val buf = Unpooled.buffer()
+        buf.retain() // ref counter to 2 to check that exactly 1 ref remains at the end
+        allocatedBufs += buf
+        return buf
+    }
+
+    fun allocateData(data: String): ByteBuf =
+        allocateBuf().writeBytes(data.toByteArray())
+
+    fun ByteBuf.readString() = String(this.readAllBytesAndRelease())
+
+    @Test
+    fun emptyTest() {
+        assertThat(queue.take(100).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun zeroTest() {
+        queue.push(allocateData("abc"))
+        assertThat(queue.take(0).readString()).isEqualTo("")
+        assertThat(queue.take(100).readString()).isEqualTo("abc")
+    }
+
+    @Test
+    fun emptyZeroTest() {
+        assertThat(queue.take(0).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun emptyBuffersTest1() {
+        queue.push(allocateData(""))
+        assertThat(queue.take(10).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun emptyBuffersTest2() {
+        queue.push(allocateData(""))
+        assertThat(queue.take(0).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun emptyBuffersTest3() {
+        queue.push(allocateData(""))
+        queue.push(allocateData("a"))
+        queue.push(allocateData(""))
+        assertThat(queue.take(10).readString()).isEqualTo("a")
+    }
+
+    @Test
+    fun emptyBuffersTest4() {
+        queue.push(allocateData("a"))
+        queue.push(allocateData(""))
+        assertThat(queue.take(10).readString()).isEqualTo("a")
+    }
+
+    @Test
+    fun emptyBuffersTest5() {
+        queue.push(allocateData("a"))
+        queue.push(allocateData(""))
+        assertThat(queue.take(1).readString()).isEqualTo("a")
+        assertThat(queue.take(1).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun emptyBuffersTest6() {
+        queue.push(allocateData("a"))
+        queue.push(allocateData(""))
+        queue.push(allocateData(""))
+        queue.push(allocateData("b"))
+        assertThat(queue.take(10).readString()).isEqualTo("ab")
+    }
+
+    @Test
+    fun pushTake1() {
+        queue.push(allocateData("abc"))
+        queue.push(allocateData("def"))
+
+        assertThat(queue.take(4).readString()).isEqualTo("abcd")
+        assertThat(queue.take(1).readString()).isEqualTo("e")
+        assertThat(queue.take(100).readString()).isEqualTo("f")
+        assertThat(queue.take(100).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun pushTake2() {
+        queue.push(allocateData("abc"))
+        queue.push(allocateData("def"))
+
+        assertThat(queue.take(2).readString()).isEqualTo("ab")
+        assertThat(queue.take(2).readString()).isEqualTo("cd")
+        assertThat(queue.take(2).readString()).isEqualTo("ef")
+        assertThat(queue.take(2).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun pushTake3() {
+        queue.push(allocateData("abc"))
+        queue.push(allocateData("def"))
+
+        assertThat(queue.take(1).readString()).isEqualTo("a")
+        assertThat(queue.take(1).readString()).isEqualTo("b")
+        assertThat(queue.take(1).readString()).isEqualTo("c")
+        assertThat(queue.take(1).readString()).isEqualTo("d")
+        assertThat(queue.take(1).readString()).isEqualTo("e")
+        assertThat(queue.take(1).readString()).isEqualTo("f")
+        assertThat(queue.take(1).readString()).isEqualTo("")
+    }
+
+    @Test
+    fun pushTakePush1() {
+        queue.push(allocateData("abc"))
+        assertThat(queue.take(2).readString()).isEqualTo("ab")
+        queue.push(allocateData("def"))
+        assertThat(queue.take(2).readString()).isEqualTo("cd")
+        assertThat(queue.take(100).readString()).isEqualTo("ef")
+    }
+
+    @Test
+    fun pushTakePush2() {
+        queue.push(allocateData("abc"))
+        assertThat(queue.take(3).readString()).isEqualTo("abc")
+        queue.push(allocateData("def"))
+        assertThat(queue.take(2).readString()).isEqualTo("de")
+        assertThat(queue.take(100).readString()).isEqualTo("f")
+    }
+
+    @Test
+    fun pushTakePush3() {
+        queue.push(allocateData("abc"))
+        queue.push(allocateData("def"))
+        assertThat(queue.take(1).readString()).isEqualTo("a")
+        queue.push(allocateData("ghi"))
+        assertThat(queue.take(100).readString()).isEqualTo("bcdefghi")
+    }
+
+    @Test
+    fun pushTakePush4() {
+        queue.push(allocateData("abc"))
+        assertThat(queue.take(1).readString()).isEqualTo("a")
+        queue.push(allocateData("def"))
+        queue.push(allocateData("ghi"))
+        assertThat(queue.take(100).readString()).isEqualTo("bcdefghi")
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -14,7 +14,6 @@ import io.netty.channel.ChannelHandlerContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import kotlin.random.Random
 
 class YamuxHandlerTest : MuxHandlerAbstractTest() {
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -14,11 +14,13 @@ import io.netty.channel.ChannelHandlerContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class YamuxHandlerTest : MuxHandlerAbstractTest() {
 
     override val maxFrameDataLength = 256
     private val maxBufferedConnectionWrites = 512
+    private val initialWindowSize = 300
     override val localMuxIdGenerator = YamuxStreamIdGenerator(isLocalConnectionInitiator).toIterator()
     override val remoteMuxIdGenerator = YamuxStreamIdGenerator(!isLocalConnectionInitiator).toIterator()
 
@@ -32,7 +34,8 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             null,
             streamHandler,
             true,
-            maxBufferedConnectionWrites
+            maxBufferedConnectionWrites,
+            initialWindowSize
         ) {
             // MuxHandler consumes the exception. Override this behaviour for testing
             @Deprecated("Deprecated in Java")
@@ -112,7 +115,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         val streamId = readFrameOrThrow().streamId
 
         // > 1/2 window size
-        val length = (INITIAL_WINDOW_SIZE / 2) + 42
+        val length = (initialWindowSize / 2) + 42
         ech.writeInbound(
             YamuxFrame(
                 streamId.toMuxId(),
@@ -141,7 +144,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
                 streamId.toMuxId(),
                 YamuxType.WINDOW_UPDATE,
                 YamuxFlags.ACK,
-                -INITIAL_WINDOW_SIZE.toLong()
+                -initialWindowSize.toLong()
             )
         )
 
@@ -164,7 +167,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
                 streamId.toMuxId(),
                 YamuxType.WINDOW_UPDATE,
                 YamuxFlags.ACK,
-                -INITIAL_WINDOW_SIZE.toLong()
+                -initialWindowSize.toLong()
             )
         )
 
@@ -199,7 +202,18 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             )
         )
         frame = readFrameOrThrow()
-        assertThat(frame.data).isEqualTo("1984")
+        assertThat(frame.data).isEqualTo("19")
+
+        ech.writeInbound(
+            YamuxFrame(
+                streamId.toMuxId(),
+                YamuxType.WINDOW_UPDATE,
+                YamuxFlags.ACK,
+                10000
+            )
+        )
+        frame = readFrameOrThrow()
+        assertThat(frame.data).isEqualTo("84")
     }
 
     @Test
@@ -212,7 +226,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
                 muxId,
                 YamuxType.WINDOW_UPDATE,
                 YamuxFlags.ACK,
-                -INITIAL_WINDOW_SIZE.toLong()
+                -initialWindowSize.toLong()
             )
         )
 
@@ -243,13 +257,13 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         val createMessage: (String) -> ByteBuf =
             { it.toByteArray().toByteBuf(allocateBuf()) }
 
-        val sendWindowUpdate: (Long) -> Unit = {
+        val sendWindowUpdate: (Int) -> Unit = {
             ech.writeInbound(
                 YamuxFrame(
                     streamId.toMuxId(),
                     YamuxType.WINDOW_UPDATE,
                     YamuxFlags.ACK,
-                    it
+                    it.toLong()
                 )
             )
         }
@@ -257,7 +271,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         // approximately every 5 messages window size will be depleted
         val messagesToSend = 500
         val customWindowSize = 14
-        sendWindowUpdate(-INITIAL_WINDOW_SIZE.toLong() + customWindowSize)
+        sendWindowUpdate(-initialWindowSize + customWindowSize)
 
         val range = 1..messagesToSend
 
@@ -269,23 +283,23 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
 
         for (i in range) {
             if (i in windowUpdatesIndices) {
-                sendWindowUpdate(customWindowSize.toLong())
+                sendWindowUpdate(customWindowSize)
             }
             handler.ctx.writeAndFlush(createMessage(i.toString()))
         }
 
-        // verify the order of messages
-        for (i in range) {
-            val frame = readYamuxFrame()
-            assertThat(frame).overridingErrorMessage(
-                "Expected to send %s messages but it sent only %s",
-                messagesToSend,
-                messagesToSend - i
-            ).isNotNull()
-            assertThat(frame!!.data).isNotNull()
-            val data = String(frame.data!!.readAllBytesAndRelease())
-            assertThat(data).isEqualTo(i.toString())
+        val receivedData = generateSequence {
+            readYamuxFrame()
         }
+            .map {
+                assertThat(it.data).isNotNull()
+                String(it.data!!.readAllBytesAndRelease())
+            }
+            .joinToString(separator = "")
+
+        val expectedData = range.joinToString(separator = "")
+
+        assertThat(receivedData).isEqualTo(expectedData)
     }
 
     @Test
@@ -343,6 +357,55 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             openStreamRemote(incorrectId)
         }
         assertThat(ech.isOpen).isFalse()
+    }
+
+    @Test
+    fun `negative sendWindowSize should be correctly handled`() {
+        val handler = openStreamLocal()
+        val muxId = readFrameOrThrow().streamId.toMuxId()
+
+        val msg = "42".repeat(initialWindowSize + 1).fromHex().toByteBuf(allocateBuf())
+        // writing a message which is larger than sendWindowSize
+        handler.ctx.writeAndFlush(msg)
+
+        // sendWindowSize is 0 now
+
+        // remote party wants to reduce the window by 10
+        ech.writeInbound(
+            YamuxFrame(
+                muxId,
+                YamuxType.WINDOW_UPDATE,
+                YamuxFlags.ACK,
+                -10
+            )
+        )
+
+        // sendWindowSize is -10 now
+
+        val msgPart1 = readYamuxFrameOrThrow()
+        assertThat(msgPart1.length).isEqualTo(256L)
+        assertThat(msgPart1.data!!.readableBytes()).isEqualTo(256)
+        msgPart1.data!!.release()
+
+        val msgPart2 = readYamuxFrameOrThrow()
+        assertThat(msgPart2.length.toInt()).isEqualTo(initialWindowSize - 256)
+        assertThat(msgPart2.data!!.readableBytes()).isEqualTo(initialWindowSize - 256)
+        msgPart2.data!!.release()
+
+        // ACKing message receive
+        ech.writeInbound(
+            YamuxFrame(
+                muxId,
+                YamuxType.WINDOW_UPDATE,
+                YamuxFlags.ACK,
+                initialWindowSize.toLong()
+            )
+        )
+
+        val msgPart3 = readYamuxFrameOrThrow()
+        assertThat(msgPart3.length).isEqualTo(1L)
+        assertThat(msgPart3.data!!.readableBytes()).isEqualTo(1)
+        msgPart3.data!!.release()
     }
 
     companion object {


### PR DESCRIPTION
* Introduce ByteBufQueue
* Add ByteBufQueue tests
* Writing exec path is always through fill/drain buffer
* Adopt/fix existing tests
* Add new test checking correct handling of negative sendWindowSize