### PR TITLE
[Yamux] Don't send frame if send buffer is not empty

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/ByteArrayExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/ByteArrayExt.kt
@@ -13,7 +13,7 @@ fun String.fromHex() =
 
 operator fun ByteArray.compareTo(other: ByteArray): Int {
     if (size != other.size) return size - other.size
-    for (i in 0 until size) {
+    for (i in indices) {
         if (this[i] != other[i]) return this[i].toInt().and(0xFF) - other[i].toInt().and(0xFF)
     }
     return 0

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -47,7 +47,7 @@ open class YamuxHandler(
         }
 
         fun flush(windowSize: AtomicInteger) {
-            while (!bufferedData.isEmpty() && windowSize.get() > 0) {
+            while (!isEmpty() && windowSize.get() > 0) {
                 val data = bufferedData.removeFirst()
                 val length = data.readableBytes()
                 windowSize.addAndGet(-length)

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -236,6 +236,55 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
     }
 
     @Test
+    fun `frames are sent in order when send buffer is used`() {
+        val handler = openStreamLocal()
+        val streamId = readFrameOrThrow().streamId
+
+        val createMessage: (String) -> ByteBuf =
+            { it.toByteArray().toByteBuf(allocateBuf()) }
+
+        val customWindowSize = 14
+        val sendWindowUpdate: (Long) -> Unit = {
+            ech.writeInbound(
+                YamuxFrame(
+                    streamId.toMuxId(),
+                    YamuxType.WINDOW_UPDATE,
+                    YamuxFlags.ACK,
+                    it
+                )
+            )
+        }
+        val messagesToSend = 500
+
+        // approximately every 5 messages window size will be depleted
+        sendWindowUpdate(-INITIAL_WINDOW_SIZE.toLong() + customWindowSize)
+
+        val range = 1..messagesToSend
+
+        // 100 window updates should be sent to ensure buffer is flushed and all messages are sent so will send them at random times
+        val windowUpdatesIndices = (range).shuffled().take(100).toSet()
+
+        for (i in range) {
+            if (i in windowUpdatesIndices) {
+                sendWindowUpdate(customWindowSize.toLong())
+            }
+            handler.ctx.writeAndFlush(createMessage(i.toString()))
+        }
+
+        for (i in range) {
+            val frame = readYamuxFrame()
+            assertThat(frame).overridingErrorMessage(
+                "Expected to send %s messages but it sent only %s",
+                messagesToSend,
+                messagesToSend - i
+            ).isNotNull()
+            assertThat(frame!!.data).isNotNull()
+            val data = String(frame.data!!.readAllBytesAndRelease())
+            assertThat(data).isEqualTo(i.toString())
+        }
+    }
+
+    @Test
     fun `test ping`() {
         val id: Long = YamuxId.SESSION_STREAM_ID
         ech.writeInbound(

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -243,7 +243,6 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         val createMessage: (String) -> ByteBuf =
             { it.toByteArray().toByteBuf(allocateBuf()) }
 
-        val customWindowSize = 14
         val sendWindowUpdate: (Long) -> Unit = {
             ech.writeInbound(
                 YamuxFrame(
@@ -254,9 +253,10 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
                 )
             )
         }
-        val messagesToSend = 500
 
         // approximately every 5 messages window size will be depleted
+        val messagesToSend = 500
+        val customWindowSize = 14
         sendWindowUpdate(-INITIAL_WINDOW_SIZE.toLong() + customWindowSize)
 
         val range = 1..messagesToSend
@@ -271,6 +271,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             handler.ctx.writeAndFlush(createMessage(i.toString()))
         }
 
+        // verify the order of messages
         for (i in range) {
             val frame = readYamuxFrame()
             assertThat(frame).overridingErrorMessage(


### PR DESCRIPTION
There could be a race condition case where a frame is being sent before the send buffer has been flushed, which would result in unordered frames. Very hard to replicate in actual test, so wrote a generic test to test order of messages when send buffer is used.