### PR TITLE
Fix unit test consistency

### DIFF
--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -261,8 +261,11 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
 
         val range = 1..messagesToSend
 
-        // 100 window updates should be sent to ensure buffer is flushed and all messages are sent so will send them at random times
-        val windowUpdatesIndices = (range).shuffled().take(100).toSet()
+        // 100 window updates should be sent to ensure buffer is flushed and all messages are sent
+        // so will send them at random times ensuring maxBufferedConnectionWrites can never be reached
+        val windowUpdatesIndices = (range).chunked(100).flatMap {
+            it.shuffled().take(20)
+        }
 
         for (i in range) {
             if (i in windowUpdatesIndices) {


### PR DESCRIPTION
There is a tiny possibility the test reaches the test configured `maxBufferedConnectionWrites` (512) if the randomly selected indices are at the end (total bytes sent in this test are 1392), so made it so that 20 indices are selected from every 100 indices in which case the `maxBufferedConnectionWrites`  will never be reached.