### PR TITLE
[Yamux] Allow max ACK backlog of 256 streams

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
@@ -3,6 +3,7 @@ package io.libp2p.core.mux
 import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.mux.mplex.MplexStreamMuxer
+import io.libp2p.mux.yamux.DEFAULT_ACK_BACKLOG_LIMIT
 import io.libp2p.mux.yamux.DEFAULT_MAX_BUFFERED_CONNECTION_WRITES
 import io.libp2p.mux.yamux.YamuxStreamMuxer
 
@@ -23,17 +24,22 @@ fun interface StreamMuxerProtocol {
 
         /**
          * @param maxBufferedConnectionWrites the maximum amount of bytes in the write buffer per connection
+         * @param ackBacklogLimit the maximum amount of opened streams per connection which have not been acknowledged
          */
         @JvmStatic
         @JvmOverloads
-        fun getYamux(maxBufferedConnectionWrites: Int = DEFAULT_MAX_BUFFERED_CONNECTION_WRITES): StreamMuxerProtocol {
+        fun getYamux(
+            maxBufferedConnectionWrites: Int = DEFAULT_MAX_BUFFERED_CONNECTION_WRITES,
+            ackBacklogLimit: Int = DEFAULT_ACK_BACKLOG_LIMIT
+        ): StreamMuxerProtocol {
             return StreamMuxerProtocol { multistreamProtocol, protocols ->
                 YamuxStreamMuxer(
                     multistreamProtocol.createMultistream(
                         protocols
                     ).toStreamHandler(),
                     multistreamProtocol,
-                    maxBufferedConnectionWrites
+                    maxBufferedConnectionWrites,
+                    ackBacklogLimit
                 )
             }
         }

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
@@ -19,7 +19,7 @@ fun <C> CompletableFuture<C>.bind(result: CompletableFuture<out C>) {
 
 fun <C> CompletableFuture<C>.forward(forwardTo: CompletableFuture<in C>) = forwardTo.bind(this)
 
-fun <C, R> CompletableFuture<C>.forwardExceptionTo(forwardTo: CompletableFuture<R>): CompletableFuture<C> {
+fun <C, R> CompletableFuture<C>.forwardException(forwardTo: CompletableFuture<R>): CompletableFuture<C> {
     return whenComplete { _, t ->
         if (t != null) {
             forwardTo.completeExceptionally(t)

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/AsyncExt.kt
@@ -19,6 +19,14 @@ fun <C> CompletableFuture<C>.bind(result: CompletableFuture<out C>) {
 
 fun <C> CompletableFuture<C>.forward(forwardTo: CompletableFuture<in C>) = forwardTo.bind(this)
 
+fun <C, R> CompletableFuture<C>.forwardExceptionTo(forwardTo: CompletableFuture<R>): CompletableFuture<C> {
+    return whenComplete { _, t ->
+        if (t != null) {
+            forwardTo.completeExceptionally(t)
+        }
+    }
+}
+
 /**
  * The same as [CompletableFuture.get] but unwraps [ExecutionException]
  */

--- a/libp2p/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
@@ -9,6 +9,7 @@ import io.libp2p.core.mux.StreamMuxer
 import io.libp2p.etc.CONNECTION
 import io.libp2p.etc.STREAM
 import io.libp2p.etc.types.forward
+import io.libp2p.etc.types.forwardExceptionTo
 import io.libp2p.etc.util.netty.mux.AbstractMuxHandler
 import io.libp2p.etc.util.netty.mux.MuxChannel
 import io.libp2p.etc.util.netty.mux.MuxChannelInitializer
@@ -51,11 +52,7 @@ abstract class MuxHandler(
             streamHandler.handleStream(createStream(it)).forward(controller)
         }
             .thenApply { it.attr(STREAM).get() }
-            .whenComplete { _, t ->
-                if (t != null) {
-                    controller.completeExceptionally(t)
-                }
-            }
+            .forwardExceptionTo(controller)
         return StreamPromise(stream, controller)
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
@@ -9,7 +9,7 @@ import io.libp2p.core.mux.StreamMuxer
 import io.libp2p.etc.CONNECTION
 import io.libp2p.etc.STREAM
 import io.libp2p.etc.types.forward
-import io.libp2p.etc.types.forwardExceptionTo
+import io.libp2p.etc.types.forwardException
 import io.libp2p.etc.util.netty.mux.AbstractMuxHandler
 import io.libp2p.etc.util.netty.mux.MuxChannel
 import io.libp2p.etc.util.netty.mux.MuxChannelInitializer
@@ -52,7 +52,7 @@ abstract class MuxHandler(
             streamHandler.handleStream(createStream(it)).forward(controller)
         }
             .thenApply { it.attr(STREAM).get() }
-            .forwardExceptionTo(controller)
+            .forwardException(controller)
         return StreamPromise(stream, controller)
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/MuxHandler.kt
@@ -49,7 +49,13 @@ abstract class MuxHandler(
         val controller = CompletableFuture<T>()
         val stream = newStream {
             streamHandler.handleStream(createStream(it)).forward(controller)
-        }.thenApply { it.attr(STREAM).get() }
+        }
+            .thenApply { it.attr(STREAM).get() }
+            .whenComplete { _, t ->
+                if (t != null) {
+                    controller.completeExceptionally(t)
+                }
+            }
         return StreamPromise(stream, controller)
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/mux/MuxerException.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/MuxerException.kt
@@ -5,6 +5,8 @@ import io.libp2p.etc.util.netty.mux.MuxId
 
 open class MuxerException(message: String, ex: Exception?) : Libp2pException(message, ex)
 
+class AckBacklogLimitExceededMuxerException(message: String) : MuxerException(message, null)
+
 open class ReadMuxerException(message: String, ex: Exception?) : MuxerException(message, ex)
 open class WriteMuxerException(message: String, ex: Exception?) : MuxerException(message, ex)
 
@@ -13,4 +15,5 @@ class UnknownStreamIdMuxerException(muxId: MuxId) : ReadMuxerException("Stream w
 class InvalidFrameMuxerException(message: String) : ReadMuxerException(message, null)
 
 class WriteBufferOverflowMuxerException(message: String) : WriteMuxerException(message, null)
-class ClosedForWritingMuxerException(muxId: MuxId) : WriteMuxerException("Couldn't write, stream was closed for writing: $muxId", null)
+class ClosedForWritingMuxerException(muxId: MuxId) :
+    WriteMuxerException("Couldn't write, stream was closed for writing: $muxId", null)

--- a/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
@@ -57,4 +57,7 @@ open class MplexHandler(
     }
 
     override fun onChildClosed(child: MuxChannel<ByteBuf>) {}
+
+    override fun checkCanOpenNewStream() {
+    }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
@@ -57,7 +57,4 @@ open class MplexHandler(
     }
 
     override fun onChildClosed(child: MuxChannel<ByteBuf>) {}
-
-    override fun checkCanOpenNewStream() {
-    }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -92,9 +92,7 @@ open class YamuxHandler(
                 }
 
                 YamuxFlag.ACK in msg.flags -> {
-                    if (outbound) {
-                        acknowledged.set(true)
-                    }
+                    acknowledgeOutboundStreamIfNeeded()
                 }
 
                 YamuxFlag.FIN in msg.flags -> onRemoteDisconnect(msg.id)
@@ -104,6 +102,12 @@ open class YamuxHandler(
 
         private fun acknowledgeInboundStreamIfNeeded() {
             if (!outbound) {
+                acknowledged.set(true)
+            }
+        }
+
+        private fun acknowledgeOutboundStreamIfNeeded() {
+            if (outbound) {
                 acknowledged.set(true)
             }
         }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -104,7 +104,7 @@ open class YamuxHandler(
 
         private fun acknowledgeInboundStreamIfNeeded() {
             if (!outbound) {
-                acknowledged.compareAndSet(false, true)
+                acknowledged.set(true)
             }
         }
 

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
@@ -13,7 +13,8 @@ import java.util.concurrent.CompletableFuture
 class YamuxStreamMuxer(
     val inboundStreamHandler: StreamHandler<*>,
     private val multistreamProtocol: MultistreamProtocol,
-    private val maxBufferedConnectionWrites: Int
+    private val maxBufferedConnectionWrites: Int,
+    private val ackBacklogLimit: Int
 ) : StreamMuxer, StreamMuxerDebug {
 
     override val protocolDescriptor = ProtocolDescriptor("/yamux/1.0.0")
@@ -32,7 +33,8 @@ class YamuxStreamMuxer(
                 muxSessionReady,
                 inboundStreamHandler,
                 ch.isInitiator,
-                maxBufferedConnectionWrites
+                maxBufferedConnectionWrites,
+                ackBacklogLimit
             )
         )
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -16,7 +16,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class YamuxHandlerTest : MuxHandlerAbstractTest() {
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -450,6 +450,26 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         assertThat(closeFrame.data).isNull()
     }
 
+    @Test
+    fun `does not send SYN flag for a new stream if ACK backlog is full`() {
+        for (i in 1..ACK_BACKLOG_ALLOWANCE) {
+            openStreamLocal()
+        }
+        // no SYN flag should be sent for this stream
+        openStreamLocal()
+
+        var synFlagFrames = 0
+        do {
+            val frame = readYamuxFrame()
+            frame?.let {
+                assertThat(it.flags).isEqualTo(YamuxFlag.SYN.asSet)
+                synFlagFrames += 1
+            }
+        } while (frame != null)
+
+        assertThat(synFlagFrames).isEqualTo(ACK_BACKLOG_ALLOWANCE)
+    }
+
     companion object {
         private fun YamuxStreamIdGenerator.toIterator() = iterator {
             while (true) {


### PR DESCRIPTION
https://github.com/libp2p/specs/blob/master/yamux/README.md#ack-backlog--backpressure

Implements `SHOULD at most allow an ACK backlog of 256 streams.`

- Added new parameter `ackBacklogLimit` when initializing Yamux
- Introduced notion of `acknowledged` when initializing yamux stream
- throw and don't create new stream if more than 256 streams are not acknowledged