### PR TITLE
Don't try and dial DNSADDR addresses

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/tcp/TcpTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/tcp/TcpTransport.kt
@@ -2,6 +2,7 @@ package io.libp2p.transport.tcp
 
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.multiformats.Protocol.DNSADDR
 import io.libp2p.core.multiformats.Protocol.IP4
 import io.libp2p.core.multiformats.Protocol.IP6
 import io.libp2p.core.multiformats.Protocol.TCP
@@ -27,7 +28,8 @@ open class TcpTransport(
     override fun handles(addr: Multiaddr) =
         handlesHost(addr) &&
             addr.has(TCP) &&
-            !addr.has(WS)
+            !addr.has(WS) &&
+            !addr.has(DNSADDR)
 
     override fun serverTransportBuilder(
         connectionBuilder: ConnectionBuilder,

--- a/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -35,8 +35,7 @@ class TcpTransportTest : TransportTests() {
             "/ip4/0.0.0.0/tcp/1234",
             "/ip6/fe80::6f77:b303:aa6e:a16/tcp/42",
             "/dns4/localhost/tcp/9999",
-            "/dns6/localhost/tcp/9999",
-            "/dnsaddr/ipfs.io/tcp/97"
+            "/dns6/localhost/tcp/9999"
         ).map { Multiaddr(it) }
 
         @JvmStatic


### PR DESCRIPTION
These should mainly be used for bootstrap with a DNS TXT record lookup to expand to list of node multiaddrs

This removes a lot of log spam from failed dial attempts in kademlia