### PR TITLE
Add propagator in `MessageApi` when subscribed to a pubsub topic

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/pubsub/PubsubApi.kt
@@ -167,6 +167,11 @@ interface PubsubApi : PubsubSubscriberApi {
  */
 interface MessageApi {
 
+    /**
+     * The identity of the peer who has propagated this message
+     */
+    val propagator: PeerId
+
     val originalMessage: PubsubMessage
 
     /**

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -77,7 +77,7 @@ interface PubsubMessageRouter {
      * All the messages received by the router are forwarded to the [handler] independently
      * of any client subscriptions. Is it up to the client API to sort out subscriptions
      */
-    fun initHandler(handler: (PubsubMessage) -> CompletableFuture<ValidationResult>)
+    fun initHandler(handler: (PeerId, PubsubMessage) -> CompletableFuture<ValidationResult>)
 
     /**
      * Notifies the router that a client wants to receive messages on the following topics

--- a/libp2p/src/test/java/io/libp2p/pubsub/GossipApiTest.java
+++ b/libp2p/src/test/java/io/libp2p/pubsub/GossipApiTest.java
@@ -53,8 +53,8 @@ public class GossipApiTest {
 
     BlockingQueue<PubsubMessage> messages = new LinkedBlockingQueue<>();
     router.initHandler(
-        m -> {
-          messages.add(m);
+        (__, msg) -> {
+          messages.add(msg);
           return CompletableFuture.completedFuture(ValidationResult.Valid);
         });
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -422,7 +422,7 @@ class GossipV1_1Tests {
     fun testAppValidatorScore() {
         val test = TwoRoutersTest()
         val validator = AtomicReference<CompletableFuture<ValidationResult>>(RESULT_VALID)
-        test.gossipRouter.initHandler { validator.get() }
+        test.gossipRouter.initHandler { _, _ -> validator.get() }
 
         test.mockRouter.subscribe("topic1")
         test.gossipRouter.subscribe("topic1")
@@ -860,7 +860,7 @@ class GossipV1_1Tests {
     fun testValidatorIgnoreResult() {
         val test = ManyRoutersTest(mockRouterCount = 2)
         val validator = AtomicReference<CompletableFuture<ValidationResult>>(RESULT_VALID)
-        test.gossipRouter.initHandler { validator.get() }
+        test.gossipRouter.initHandler { _, _ -> validator.get() }
         test.connectAll()
         test.gossipRouter.subscribe("topic1")
         test.routers.forEach { it.router.subscribe("topic1") }

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/TestRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/TestRouter.kt
@@ -40,8 +40,8 @@ class TestRouter(
 
     val inboundMessages = LinkedBlockingQueue<PubsubMessage>()
     var handlerValidationResult = RESULT_VALID
-    val routerHandler: (PubsubMessage) -> CompletableFuture<ValidationResult> = {
-        inboundMessages += it
+    val routerHandler: (PeerId, PubsubMessage) -> CompletableFuture<ValidationResult> = { _, msg ->
+        inboundMessages += msg
         handlerValidationResult
     }
 


### PR DESCRIPTION
Add `val propagator` to `MessageApi` which can be used by downstream subscribers to know who has propagated the gossip message