### PR TITLE
AbstractRouter.getPeerTopics() may throw ConcurrentModificationException

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -323,7 +323,11 @@ abstract class AbstractRouter(
 
     override fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>> {
         return submitOnEventThread {
-            peersTopics.asFirstToSecondMap().mapKeys { it.key.peerId }
+            peersTopics.asFirstToSecondMap()
+                .map { (key, value) ->
+                    key.peerId to value.toSet()
+                }
+                .toMap()
         }
     }
 


### PR DESCRIPTION
Fix returning internal mutable set to avoid ConcurrentModificationException

Might result in the following exception: 
```
java.util.concurrent.CompletionException: java.util.ConcurrentModificationException
at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:687)
at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:662)
at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2200)
at io.libp2p.pubsub.PubsubApiImpl.getPeerTopics(PubsubApiImpl.kt:114)
at io.libp2p.pubsub.gossip.Gossip.getPeerTopics(Gossip.kt)
```