### PR TITLE
Fix remotePubKey in Noise secure Session

### DIFF
--- a/libp2p/src/test/java/io/libp2p/core/RelayTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/RelayTestJava.java
@@ -211,7 +211,7 @@ public class RelayTestJava {
     System.out.println("Blob controller created");
 
     Assertions.assertThrows(
-        ExecutionException.class, () -> blobCtr.blob().get(5, TimeUnit.SECONDS));
+        ExecutionException.class, () -> blobCtr.blob().get(30, TimeUnit.SECONDS));
 
     clientHost.stop().get(5, TimeUnit.SECONDS);
     System.out.println("Client stopped");


### PR DESCRIPTION
Noise negotiator was putting the wrong pubKey into `SecureChannel.Session`: local instead of remote

- Fix the issue
- Add a unit test 