### PR TITLE
Fix mdns when listening with ipv6 wildcard (which includes ipv4)

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/discovery/MDnsDiscovery.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/discovery/MDnsDiscovery.kt
@@ -76,7 +76,14 @@ class MDnsDiscovery(
         val address = host.listenAddresses().find {
             it.has(Protocol.IP4)
         }
-        val str = address?.getFirstComponent(Protocol.TCP)?.stringValue!!
+        val ipv6OnlyAddress = if (address == null) {
+            host.listenAddresses().find {
+                it.has(Protocol.IP6)
+            }
+        } else {
+            address
+        }
+        val str = ipv6OnlyAddress?.getFirstComponent(Protocol.TCP)?.stringValue!!
         return Integer.parseInt(str)
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/discovery/MDnsDiscoveryTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/discovery/MDnsDiscoveryTest.kt
@@ -24,6 +24,18 @@ class MDnsDiscoveryTest {
         }
     }
 
+    val hostIpv6 = object : NullHost() {
+        override val peerId: PeerId = PeerId.fromPubKey(
+            generateEcdsaKeyPair().second
+        )
+
+        override fun listenAddresses(): List<Multiaddr> {
+            return listOf(
+                Multiaddr("/ip6/::/tcp/4001")
+            )
+        }
+    }
+
     val otherHost = object : NullHost() {
         override val peerId: PeerId = PeerId.fromPubKey(
             generateEcdsaKeyPair().second
@@ -41,6 +53,15 @@ class MDnsDiscoveryTest {
     @Test
     fun `start and stop discovery`() {
         val discoverer = MDnsDiscovery(host, testServiceTag)
+
+        discoverer.start().get(1, TimeUnit.SECONDS)
+        TimeUnit.MILLISECONDS.sleep(100)
+        discoverer.stop().get(1, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `start and stop discovery ipv6`() {
+        val discoverer = MDnsDiscovery(hostIpv6, testServiceTag)
 
         discoverer.start().get(1, TimeUnit.SECONDS)
         TimeUnit.MILLISECONDS.sleep(100)


### PR DESCRIPTION
The listen port method was throwing NPE