### PR TITLE
Updating com.google.protobuf to 3.25.5

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -27,7 +27,7 @@ dependencyManagement {
             entry 'jmh-generator-annprocess'
         }
 
-        dependencySet(group: "com.google.protobuf", version: "3.24.3") {
+        dependencySet(group: "com.google.protobuf", version: "3.25.5") {
             entry 'protobuf-java'
             entry 'protoc'
         }


### PR DESCRIPTION
A recent vulnerability was found in previous versions. Reference: https://avd.aquasec.com/nvd/2024/cve-2024-7254/

This affects our Teku dependencies analysis, so we might want to do a release soon.