### PR TITLE
Don't throw NoPeersForOutboundMessageException if peers DONTWANT message

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -419,9 +419,10 @@ open class GossipRouter(
         val list = peers
             .map {
                 if (peerDoesNotWantMessage(it, msg.messageId)) {
-                    return CompletableFuture.completedFuture(null)
+                    CompletableFuture.completedFuture(Unit)
+                } else {
+                    submitPublishMessage(it, msg)
                 }
-                return submitPublishMessage(it, msg)
             }
 
         mCache += msg

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -420,11 +420,14 @@ open class GossipRouter(
         mCache += msg
 
         return if (peers.isNotEmpty()) {
-            val list = peers
+            val publishedMessages = peers
                 .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
                 .map { submitPublishMessage(it, msg) }
+            if (publishedMessages.isEmpty()) {
+                return CompletableFuture.completedFuture(Unit)
+            }
             flushAllPending()
-            anyComplete(list)
+            anyComplete(publishedMessages)
         } else {
             completedExceptionally(
                 NoPeersForOutboundMessageException("No peers for message topics ${msg.topics} found")

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -416,19 +416,14 @@ open class GossipRouter(
                     }
                     .flatten()
             }
-        val list = peers
-            .map {
-                if (peerDoesNotWantMessage(it, msg.messageId)) {
-                    CompletableFuture.completedFuture(Unit)
-                } else {
-                    submitPublishMessage(it, msg)
-                }
-            }
 
         mCache += msg
-        flushAllPending()
 
-        return if (list.isNotEmpty()) {
+        return if (peers.isNotEmpty()) {
+            val list = peers
+                .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
+                .map { submitPublishMessage(it, msg) }
+            flushAllPending()
             anyComplete(list)
         } else {
             completedExceptionally(

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -417,8 +417,12 @@ open class GossipRouter(
                     .flatten()
             }
         val list = peers
-            .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
-            .map { submitPublishMessage(it, msg) }
+            .map {
+                if (peerDoesNotWantMessage(it, msg.messageId)) {
+                    return CompletableFuture.completedFuture(null)
+                }
+                return submitPublishMessage(it, msg)
+            }
 
         mCache += msg
         flushAllPending()


### PR DESCRIPTION
If all peers for a certain topic have sent IDONTWANT for a messageId, then when we publish it outbound, we don't want NoPeersForOutboundMessageException to be thrown