### PR TITLE
Send IDONTWANT prior to publish

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -242,7 +242,7 @@ data class GossipParams(
      * [iDontWantMinMessageSizeThreshold] controls the minimum size (in bytes) that an incoming message needs to be so that an IDONTWANT message is sent to mesh peers.
      * The default is 16 KB.
      */
-    val iDontWantMinMessageSizeThreshold: Int = 16000,
+    val iDontWantMinMessageSizeThreshold: Int = 16384,
 
     /**
      * [iDontWantTTL] Expiry time for cache of received IDONTWANT messages for peers

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -166,7 +166,7 @@ open class GossipRouter(
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
-        iDontWant(msg, peer)
+        iDontWant(msg)
         eventBroadcaster.notifyUnseenMessage(peer.peerId, msg)
         notifyAnyMessage(peer, msg)
     }
@@ -420,6 +420,7 @@ open class GossipRouter(
         mCache += msg
 
         return if (peers.isNotEmpty()) {
+            iDontWant(msg)
             val publishedMessages = peers
                 .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
                 .map { submitPublishMessage(it, msg) }
@@ -610,7 +611,7 @@ open class GossipRouter(
         enqueueIwant(peer, messageIds)
     }
 
-    private fun iDontWant(msg: PubsubMessage, receivedFrom: PeerHandler) {
+    private fun iDontWant(msg: PubsubMessage) {
         if (!this.protocol.supportsIDontWant()) return
         if (msg.protobufMessage.data.size() < params.iDontWantMinMessageSizeThreshold) return
         // we need to send IDONTWANT messages to mesh peers immediately in order for them to have an effect
@@ -618,7 +619,6 @@ open class GossipRouter(
             .mapNotNull { mesh[it] }
             .flatten()
             .distinct()
-            .minus(receivedFrom)
             .forEach { sendIdontwant(it, msg.messageId) }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -166,7 +166,7 @@ open class GossipRouter(
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
-        iDontWant(msg)
+        iDontWant(msg, peer)
         eventBroadcaster.notifyUnseenMessage(peer.peerId, msg)
         notifyAnyMessage(peer, msg)
     }
@@ -611,7 +611,7 @@ open class GossipRouter(
         enqueueIwant(peer, messageIds)
     }
 
-    private fun iDontWant(msg: PubsubMessage) {
+    private fun iDontWant(msg: PubsubMessage, receivedFrom: PeerHandler? = null) {
         if (!this.protocol.supportsIDontWant()) return
         if (msg.protobufMessage.data.size() < params.iDontWantMinMessageSizeThreshold) return
         // we need to send IDONTWANT messages to mesh peers immediately in order for them to have an effect
@@ -619,6 +619,7 @@ open class GossipRouter(
             .mapNotNull { mesh[it] }
             .flatten()
             .distinct()
+            .minus(setOfNotNull(receivedFrom))
             .forEach { sendIdontwant(it, msg.messageId) }
     }
 


### PR DESCRIPTION
Send IDONTWANT on each publish. Maybe we need to add some filtering to make it more selective, but not sure?

I removed filtering out excluding the `receivedFrom` peer when we are sending IDONTWANT on inbound messages. Think it simplifies the flow and could help in some cases, where `receivedFrom` may send the same message twice.

fixes #383 