### PR TITLE
Add support for Extension Control Messages (gossipsub v1.3) 1/2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ package-lock.json
 
 #Jenv
 .java-version
+
+# Claude
+CLAUDE.local.md
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,314 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+jvm-libp2p is a JVM implementation of the [libp2p](https://libp2p.io/) networking stack, written in Kotlin. It provides peer-to-peer networking capabilities including transport protocols (TCP, QUIC, WebSocket), security channels (Noise, TLS), stream multiplexing (Yamux, Mplex), and pub/sub messaging (Gossipsub, Floodsub).
+
+Notable users: Teku (Ethereum Consensus Layer client), Nabu (minimal IPFS), Peergos (peer-to-peer encrypted filesystem).
+
+## Build Commands
+
+```bash
+# Build the entire project
+./gradlew build
+
+# Run all tests (excludes interop tests tagged with "interop")
+./gradlew test
+
+# Run tests for a specific module
+./gradlew :libp2p:test
+
+# Run a specific test class
+./gradlew :libp2p:test --tests "io.libp2p.pubsub.gossip.GossipRpcPartsQueueTest"
+
+# Run a specific test method
+./gradlew :libp2p:test --tests "io.libp2p.pubsub.gossip.GossipRpcPartsQueueTest.mergeMessageParts*"
+
+# Check code formatting
+./gradlew spotlessCheck
+
+# Apply code formatting
+./gradlew spotlessApply
+
+# Run static analysis (Detekt)
+./gradlew detekt
+
+# Generate documentation
+./gradlew dokkaHtml
+# Output in build/dokka/
+
+# Clean build artifacts
+./gradlew clean
+```
+
+**Requirements:** JDK 11 or higher
+
+**Module Structure:**
+- `:libp2p` - Main library module
+- `:tools:simulator` - Gossip network simulator
+- `:tools:schedulers` - Test scheduling utilities
+- `:examples:chatter`, `:examples:cli-chatter`, `:examples:pinger` - Example applications
+- `:interop-test-client` - Interoperability testing client
+
+## Architecture Overview
+
+### Core Abstraction Layers
+
+The library follows a layered architecture with protocol negotiation at each layer:
+
+```
+Application Layer
+    ↓ (Protocol negotiation via multistream-select)
+Stream/Protocol Layer (PingProtocol, ChatProtocol, PubsubRouter)
+    ↓ (Stream creation)
+Stream Multiplexing Layer (Yamux, Mplex)
+    ↓ (Multiplexer negotiation)
+Security Layer (Noise, TLS)
+    ↓ (Security negotiation)
+Transport Layer (TCP, QUIC, WebSocket)
+    ↓
+Raw Network
+```
+
+### Key Interfaces and Their Roles
+
+**`Host`** (`core/Host.kt`):
+- Main entry point for all libp2p operations
+- Manages identity (`PeerId`, `PrivKey`), network, and protocol handlers
+- Created via DSL builder: `host { identity { ... }; transports { ... }; protocols { ... } }`
+
+**`Network`** (`core/Network.kt`):
+- Manages transports and active connections
+- Handles `listen()` and `dial()` operations
+- Reuses connections to the same peer
+
+**`Connection`** and **`Stream`** (both extend `P2PChannel`):
+- `Connection`: Secured, multiplexed connection between two peers
+- `Stream`: Logical stream over a connection for a specific protocol
+
+**`Transport`** (`transport/Transport.kt`):
+- Handles raw connection establishment (TCP, QUIC, WebSocket)
+- Each transport parses specific multiaddr formats (e.g., `/ip4/127.0.0.1/tcp/30333`)
+
+**`SecureChannel`** (`security/SecureChannel.kt`):
+- Protocol binding for security layer negotiation
+- Returns `SecureChannel.Session` with `remoteId`, `remotePubKey`
+- Implementations: `NoiseXXSecureChannel` (production), `TlsSecureChannel` (beta)
+
+**`StreamMuxer`** (`mux/StreamMuxer.kt`):
+- Protocol binding for multiplexer negotiation
+- Returns `StreamMuxer.Session` for creating/receiving streams
+- Implementations: `MplexStreamMuxer` (production), `YamuxStreamMuxer` (beta)
+
+### The Connection Upgrade Pipeline
+
+When a raw transport connection is established, it goes through staged upgrades:
+
+```
+1. Raw Transport (TCP/QUIC/WS)
+   ↓
+2. ConnectionBuilder (transport/implementation/ConnectionBuilder.kt)
+   ↓
+3. Security Negotiation → SecureChannel.Session
+   ↓
+4. Multiplexer Negotiation → StreamMuxer.Session
+   ↓
+5. Full Connection Ready → ConnectionOverNetty
+```
+
+**Key Class:** `ConnectionUpgrader` (`transport/implementation/ConnectionUpgrader.kt`)
+- Orchestrates security and muxer protocol negotiation
+- Uses `MultistreamProtocol` for protocol selection
+- Supports early muxer negotiation (TLS 1.3 feature)
+
+### Protocol Handler Pattern
+
+Custom protocols implement `ProtocolHandler<TController>`:
+
+```kotlin
+// Define protocol binding
+StrictProtocolBinding("/ipfs/ping/1.0.0", PingProtocol())
+
+// Implement handler
+class PingProtocol : ProtocolHandler<PingController> {
+    override fun onStartInitiator(stream: Stream): CompletableFuture<PingController>
+    override fun onStartResponder(stream: Stream): CompletableFuture<PingController>
+}
+```
+
+See `examples/chatter/ChatProtocol.kt` for a complete example.
+
+### Pub/Sub Architecture
+
+The pub/sub system is located in `pubsub/` and follows this structure:
+
+**`AbstractRouter`** (`pubsub/AbstractRouter.kt`):
+- Base class providing common pubsub logic
+- Manages peer subscriptions via `peersTopics` (multi-bimap)
+- Implements message validation, deduplication (via `SeenCache`), and batching
+- Uses single-threaded event loop (`P2PService`) for thread-safety
+
+**Message Batching via `RpcPartsQueue`**:
+- Per-peer queue that accumulates message parts before transmission
+- Pattern: accumulate parts → flush via `takeMerged()` → send merged RPC
+- Default implementation merges all parts into single RPC
+- Gossip implementation (`GossipRpcPartsQueue`) splits messages to respect per-category limits
+
+**Message Flow:**
+```
+Outbound: publish() → validateAndBroadcast() → submitPublishMessage(peer)
+          → queue.addPublish() → flushPending() → queue.takeMerged() → send()
+
+Inbound:  channelRead() → onInbound() → validate & deduplicate
+          → broadcastInbound() → queue.addPublish() → flushPending()
+```
+
+**Gossip-Specific:**
+- **`GossipRouter`** extends `AbstractRouter` with mesh topology management
+- Heartbeat mechanism for GRAFT/PRUNE/IHAVE/IWANT control messages
+- Peer scoring for spam resistance
+- Control messages batched via `GossipRpcPartsQueue`
+
+**Key Flush Triggers:**
+- After processing inbound messages (sync validation complete)
+- After async message validation completes
+- On peer activation (sends initial subscriptions)
+- During Gossip heartbeat (mesh management operations)
+- After explicit publish/subscribe API calls
+
+### Multistream Protocol Negotiation
+
+**`MultistreamProtocol`** (`protocol/multistream/MultistreamProtocol.kt`):
+- Used at three layers: security negotiation, muxer negotiation, protocol negotiation
+- Contains list of `ProtocolBinding`s with protocol names
+- Delegates to `Negotiator` (initiator/responder)
+- Completes with `ProtocolSelect<T>` containing selected protocol handler
+
+**Pattern:** Any negotiable component extends `ProtocolBinding<T>`:
+- Security channels, stream muxers, application protocols all use this pattern
+
+## Development Patterns
+
+### Netty Integration
+
+All protocol logic is implemented as Netty `ChannelHandler`s:
+- **`P2PChannelOverNetty`**: Base wrapper for both `Connection` and `Stream`
+- **`ConnectionOverNetty`**: Wraps connection-level channel with secure and muxer sessions
+- **`StreamOverNetty`**: Wraps stream-level channel with protocol negotiation
+
+### Async Pattern
+
+Extensive use of `CompletableFuture<T>` for async operations:
+- Protocol negotiation with timeouts
+- Connection establishment across multiple addresses
+- Message publishing and validation
+
+### Event Thread Safety
+
+The pub/sub system (and other components) use single-threaded event loops via `P2PService`:
+- All operations run on `executor: ScheduledExecutorService`
+- Components like `RpcPartsQueue` are explicitly "NOT thread safe" but guaranteed single-threaded access
+- Methods: `runOnEventThread {}`, `submitOnEventThread {}`, `submitAsyncOnEventThread {}`
+
+### Testing Patterns
+
+**JUnit 5** with:
+- `@Test` for standard tests
+- `@ParameterizedTest` with `@MethodSource` for data-driven tests
+- AssertJ for fluent assertions (`assertThat(...)`)
+- MockK for mocking
+
+**Test Infrastructure:**
+- Test fixtures in `src/testFixtures/` for shared test utilities
+- Host builder DSL used extensively in tests
+- `TestChannel` and `TestLogAppender` utilities
+
+**Example Test Pattern (from GossipRpcPartsQueueTest):**
+```kotlin
+@ParameterizedTest
+@MethodSource("testCases")
+fun `test message merging`(params: GossipParams, queue: TestQueue) {
+    val monolith = queue.mergedSingle()  // Ground truth
+    val split = queue.takeMerged()       // Actual implementation
+
+    // Verify limits respected
+    assertThat(split).allMatch { router.validateMessageListLimits(it) }
+
+    // Verify semantic equivalence
+    assertThat(split.merge().disperse()).isEqualTo(monolith.disperse())
+}
+```
+
+### Code Style
+
+- Kotlin 1.6 with JVM target 11
+- ktlint formatting (run `./gradlew spotlessApply`)
+- Detekt static analysis
+- Wildcard imports allowed
+- No trailing commas enforced
+- All warnings as errors (`allWarningsAsErrors = true`)
+
+## Important Implementation Details
+
+### Protobuf Code Generation
+
+Protobuf definitions in `src/main/proto/` are compiled via `com.google.protobuf` Gradle plugin.
+Generated code in `build/generated/source/proto/main/java/`.
+
+To regenerate: `./gradlew :libp2p:clean :libp2p:build`
+
+### Multiaddr Format
+
+Network addresses use multiaddr format:
+- Example: `/ip4/127.0.0.1/tcp/30333/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N`
+- Parsed/managed in `core/multiformats/`
+- Each transport validates specific multiaddr components
+
+### PeerId Generation
+
+`PeerId` is derived from peer's public key:
+- Multihash of the public key bytes
+- 32-50 bytes depending on key type
+- Supports RSA, Ed25519, Secp256k1, ECDSA
+
+### Security Handshake Timeout
+
+Default timeout for security handshakes: **5 seconds**
+- Applies to Noise and TLS handshakes
+- Configurable in protocol implementations
+
+## Common Development Workflows
+
+### Adding a New Protocol
+
+1. Define protocol binding with multistream name (e.g., `/myapp/myprotocol/1.0.0`)
+2. Implement `ProtocolHandler<TController>` with initiator/responder logic
+3. Register with Host via `protocols { add(...) }` in builder
+4. Implement controller interface for protocol operations
+
+See `examples/chatter/` for a complete example.
+
+### Adding a New Transport
+
+1. Extend `Transport` interface
+2. Implement `listen()` and `dial()` for raw connection establishment
+3. Delegate to `ConnectionUpgrader` for security/muxer negotiation
+4. Add multiaddr parsing logic for transport-specific components
+5. Register with Host via `transports { add(...) }`
+
+### Debugging Connection Issues
+
+- Use `ConnectionVisitor` and `StreamVisitor` for lifecycle observation
+- Enable debug logging for `io.libp2p` package
+- Check multiaddr format compatibility between peers
+- Verify protocol versions match (especially for security/muxer)
+
+### Working with Pub/Sub
+
+- All pub/sub operations run on event thread (thread-safe by design)
+- Message validation happens before broadcasting
+- Seen cache prevents duplicate message processing
+- Control messages automatically batched for efficiency
+- Gossip mesh heartbeat runs every 1 second (default)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -139,6 +139,11 @@ abstract class AbstractRouter(
      */
     protected abstract fun processControl(ctrl: Rpc.ControlMessage, receivedFrom: PeerHandler)
 
+    /**
+     * Processes Gossipsub extensions messages
+     */
+    protected abstract fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler)
+
     override fun onPeerActive(peer: PeerHandler) {
         val partsQueue = pendingRpcParts.getQueue(peer)
         subscribedTopics.forEach {
@@ -178,6 +183,10 @@ abstract class AbstractRouter(
 
         if (msg.hasControl()) {
             processControl(msg.control, peer)
+        }
+
+        if (protocol.supportsExtensions()) {
+            processExtensions(msg, peer)
         }
 
         val (msgSubscribed, nonSubscribed) = msg.publishList

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubProtocol.kt
@@ -7,6 +7,7 @@ enum class PubsubProtocol(val announceStr: ProtocolId) {
     Gossip_V_1_0("/meshsub/1.0.0"),
     Gossip_V_1_1("/meshsub/1.1.0"),
     Gossip_V_1_2("/meshsub/1.2.0"),
+    Gossip_V_1_3("/meshsub/1.3.0"),
     Floodsub("/floodsub/1.0.0");
 
     companion object {
@@ -26,5 +27,12 @@ enum class PubsubProtocol(val announceStr: ProtocolId) {
      */
     fun supportsIDontWant(): Boolean {
         return this == Gossip_V_1_2
+    }
+
+    /**
+     * https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.3.md#the-extensions-control-message
+     */
+    fun supportsExtensions(): Boolean {
+        return this == Gossip_V_1_3
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
@@ -36,6 +36,10 @@ class FloodRouter(executor: ScheduledExecutorService = Executors.newSingleThread
         // NOP
     }
 
+    override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
+        // NOP
+    }
+
     private fun broadcast(msg: PubsubMessage, receivedFrom: PeerHandler?): CompletableFuture<Unit> {
         val peers = msg.topics
             .map { getTopicPeers(it) }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -31,6 +31,14 @@ class Gossip @JvmOverloads constructor(
 
     override val protocolDescriptor =
         when (router.protocol) {
+            PubsubProtocol.Gossip_V_1_3 -> {
+                ProtocolDescriptor(
+                    PubsubProtocol.Gossip_V_1_3.announceStr,
+                    PubsubProtocol.Gossip_V_1_2.announceStr,
+                    PubsubProtocol.Gossip_V_1_1.announceStr,
+                    PubsubProtocol.Gossip_V_1_0.announceStr
+                )
+            }
             PubsubProtocol.Gossip_V_1_2 -> {
                 ProtocolDescriptor(
                     PubsubProtocol.Gossip_V_1_2.announceStr,

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -388,7 +388,7 @@ open class GossipRouter(
         }.forEach { processControlMessage(it, receivedFrom) }
 
         if (protocol.supportsExtensions() && ctrl.hasExtensions()) {
-            processControlExtensions(ctrl.extensions, receivedFrom);
+            processControlExtensions(ctrl.extensions, receivedFrom)
         }
     }
 
@@ -399,7 +399,7 @@ open class GossipRouter(
         logger.info("Received control extension {}", ctrlExtensions.toString())
 
         if (peerExtensionSupportMap[receivedFrom.peerId] != null) {
-            //TODO Should downscore peers that send control extension multiple times? (https://github.com/libp2p/jvm-libp2p/issues/437)
+            // TODO Should downscore peers that send control extension multiple times? (https://github.com/libp2p/jvm-libp2p/issues/437)
             logger.trace(
                 "Received another control extension message from peer {}",
                 receivedFrom.peerId
@@ -439,9 +439,9 @@ open class GossipRouter(
         )
 
         val response =
-            Rpc.RPC.newBuilder().setTestExtension(Rpc.TestExtension.newBuilder().build()).build();
+            Rpc.RPC.newBuilder().setTestExtension(Rpc.TestExtension.newBuilder().build()).build()
 
-        send(receivedFrom, response);
+        send(receivedFrom, response)
     }
 
     private fun processPartialMessageExtension(
@@ -453,7 +453,7 @@ open class GossipRouter(
             partialMessagesExtension.toString(),
             receivedFrom.peerId
         )
-        //TODO: implement partial message handling (https://github.com/libp2p/jvm-libp2p/issues/435)
+        // TODO: implement partial message handling (https://github.com/libp2p/jvm-libp2p/issues/435)
     }
 
     override fun broadcastInbound(msgs: List<PubsubMessage>, receivedFrom: PeerHandler) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -396,7 +396,7 @@ open class GossipRouter(
         ctrlExtensions: Rpc.ControlExtensions,
         receivedFrom: PeerHandler
     ) {
-        logger.info("Received control extension {}", ctrlExtensions.toString())
+        logger.trace("Received control extension {}", ctrlExtensions.toString())
 
         if (peerExtensionSupportMap[receivedFrom.peerId] != null) {
             // TODO Should downscore peers that send control extension multiple times? (https://github.com/libp2p/jvm-libp2p/issues/437)
@@ -413,7 +413,7 @@ open class GossipRouter(
     override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
         val peerSupportedExtensions = peerExtensionSupportMap[receivedFrom.peerId]
         if (peerSupportedExtensions == null) {
-            logger.info(
+            logger.trace(
                 "Ignoring extension messages from peer {} - did it send an extension control message?",
                 receivedFrom.peerId
             )

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -132,6 +132,8 @@ open class GossipRouter(
     private val acceptRequestsWhitelist = mutableMapOf<PeerHandler, AcceptRequestsWhitelistEntry>()
     override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
+    private val peerExtensionSupportMap = mutableMapOf<PeerId, Rpc.ControlExtensions>()
+
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
         backoffExpireTimes[peer.peerId to topic] = currentTimeSupplier() + delay
@@ -384,6 +386,74 @@ open class GossipRouter(
         ctrl.run {
             (graftList + pruneList + ihaveList + iwantList + idontwantList)
         }.forEach { processControlMessage(it, receivedFrom) }
+
+        if (protocol.supportsExtensions() && ctrl.hasExtensions()) {
+            processControlExtensions(ctrl.extensions, receivedFrom);
+        }
+    }
+
+    private fun processControlExtensions(
+        ctrlExtensions: Rpc.ControlExtensions,
+        receivedFrom: PeerHandler
+    ) {
+        logger.info("Received control extension {}", ctrlExtensions.toString())
+
+        if (peerExtensionSupportMap[receivedFrom.peerId] != null) {
+            //TODO Should downscore peers that send control extension multiple times? (https://github.com/libp2p/jvm-libp2p/issues/437)
+            logger.trace(
+                "Received another control extension message from peer {}",
+                receivedFrom.peerId
+            )
+            return
+        } else {
+            peerExtensionSupportMap[receivedFrom.peerId] = ctrlExtensions
+        }
+    }
+
+    override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
+        val peerSupportedExtensions = peerExtensionSupportMap[receivedFrom.peerId]
+        if (peerSupportedExtensions == null) {
+            logger.info(
+                "Ignoring extension messages from peer {} - did it send an extension control message?",
+                receivedFrom.peerId
+            )
+        } else {
+            when {
+                peerSupportedExtensions.hasTestExtension() && msg.hasTestExtension() ->
+                    processTestExtensionMessage(msg.testExtension, receivedFrom)
+
+                peerSupportedExtensions.hasPartialMessages() && msg.hasPartial() ->
+                    processPartialMessageExtension(msg.partial, receivedFrom)
+            }
+        }
+    }
+
+    private fun processTestExtensionMessage(
+        testExtensionMessage: Rpc.TestExtension,
+        receivedFrom: PeerHandler
+    ) {
+        logger.trace(
+            "Processing test extension message {} from {}",
+            testExtensionMessage.toByteArray(),
+            receivedFrom.peerId
+        )
+
+        val response =
+            Rpc.RPC.newBuilder().setTestExtension(Rpc.TestExtension.newBuilder().build()).build();
+
+        send(receivedFrom, response);
+    }
+
+    private fun processPartialMessageExtension(
+        partialMessagesExtension: Rpc.PartialMessagesExtension,
+        receivedFrom: PeerHandler
+    ) {
+        logger.trace(
+            "Processing partial message extension message {} from {}",
+            partialMessagesExtension.toString(),
+            receivedFrom.peerId
+        )
+        //TODO: implement partial message handling (https://github.com/libp2p/jvm-libp2p/issues/435)
     }
 
     override fun broadcastInbound(msgs: List<PubsubMessage>, receivedFrom: PeerHandler) {

--- a/libp2p/src/main/proto/rpc.proto
+++ b/libp2p/src/main/proto/rpc.proto
@@ -16,7 +16,12 @@ message RPC {
 	}
 
 	optional ControlMessage control = 3;
+
+	// Canonical Extensions
 	optional PartialMessagesExtension partial = 10;
+
+	// Experimental Extensions
+  optional TestExtension testExtension = 6492434;
 }
 
 message Message {
@@ -62,6 +67,10 @@ message ControlIDontWant {
 
 message ControlExtensions {
 	optional bool partialMessages = 10;
+
+	// Experimental extensions must use field numbers larger than 0x200000 to be
+  // encoded with at least 4 bytes
+  optional bool testExtension = 6492434;
 }
 
 message PeerInfo {
@@ -103,3 +112,5 @@ message TopicDescriptor {
 		}
 	}
 }
+
+message TestExtension {}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_3Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_3Tests.kt
@@ -1,0 +1,19 @@
+@file:Suppress("ktlint:standard:class-naming")
+
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.pubsub.PubsubProtocol
+import org.junit.jupiter.api.Test
+
+class GossipV1_3Tests : GossipTestsBase() {
+
+    @Test
+    fun selfSanityTest() {
+        val test = TwoRoutersTest(protocol = PubsubProtocol.Gossip_V_1_3)
+
+        test.mockRouter.subscribe("topic1")
+        val msg = newMessage("topic1", 0L, "Hello".toByteArray())
+        test.gossipRouter.publish(msg)
+        test.mockRouter.waitForMessage { it.publishCount > 0 }
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -31,7 +31,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
     @Test
     fun `extension messages sent to peer prior to sending extension control messages are ignored`() {
         val test = TwoRoutersTest(
-            protocol = PubsubProtocol.Gossip_V_1_2
+            protocol = PubsubProtocol.Gossip_V_1_3
         )
 
         val rpcMessageWithTestExtension =

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -83,7 +83,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             Rpc.ControlMessage.newBuilder()
                 .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true).build())
                 .build()
-        ).build();
+        ).build()
 
         fun controlExtensionMessage(testExtensionEnabled: Boolean = false): Rpc.ControlExtensions {
             return Rpc.ControlExtensions.newBuilder().setTestExtension(testExtensionEnabled).build()
@@ -96,7 +96,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
                 test.mockRouter.waitForMessage(
                     { it.hasTestExtension() },
                     500L
-                );
+                )
             }
         }
     }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -1,0 +1,103 @@
+package io.libp2p.pubsub.gossip.extensions
+
+import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.gossip.GossipTestsBase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import pubsub.pb.Rpc
+import java.util.concurrent.TimeoutException
+
+class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
+
+    @Test
+    fun `extension messages sent to peer prior to gossip v1_3 are ignored`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_2
+        )
+
+        val rpcMessageWithControlExtensionAndTestExtensionMessages = Rpc.RPC.newBuilder()
+            .setControl(
+                Rpc.ControlMessage.newBuilder()
+                    .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true))
+                    .build()
+            )
+            .setTestExtension(Rpc.TestExtension.newBuilder().build())
+            .build()
+        test.mockRouter.sendToSingle(rpcMessageWithControlExtensionAndTestExtensionMessages)
+
+        assertNoResponseFromTestExtension(test)
+    }
+
+    @Test
+    fun `extension messages sent to peer prior to sending extension control messages are ignored`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_2
+        )
+
+        val rpcMessageWithTestExtension =
+            Rpc.RPC.newBuilder().setTestExtension(testExtensionMessage).build()
+        test.mockRouter.sendToSingle(rpcMessageWithTestExtension)
+
+        assertNoResponseFromTestExtension(test)
+    }
+
+    @Test
+    fun `extension message flow with extension control message before actual extension message`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        val rpcMessageWithControl = Rpc.RPC.newBuilder().setControl(
+            Rpc.ControlMessage.newBuilder().setExtensions(controlExtensionMessage())
+        ).build()
+        test.mockRouter.sendToSingle(rpcMessageWithControl)
+
+        val rpcMessageWithTestExtension =
+            Rpc.RPC.newBuilder().setTestExtension(testExtensionMessage).build()
+        test.mockRouter.sendToSingle(rpcMessageWithTestExtension)
+
+        test.mockRouter.waitForMessage { it.hasTestExtension() }
+    }
+
+    @Test
+    fun `extension message flow with extension control and extension message in the same rpc message`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        val rpcMessageWithControlExtensionAndTestExtensionMessages = Rpc.RPC.newBuilder()
+            .setControl(
+                Rpc.ControlMessage.newBuilder()
+                    .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true))
+                    .build()
+            )
+            .setTestExtension(Rpc.TestExtension.newBuilder().build())
+            .build()
+        test.mockRouter.sendToSingle(rpcMessageWithControlExtensionAndTestExtensionMessages)
+
+        test.mockRouter.waitForMessage { it.hasTestExtension() }
+    }
+
+    companion object {
+        val testExtensionControlEnabledMessage: Rpc.RPC = Rpc.RPC.newBuilder().setControl(
+            Rpc.ControlMessage.newBuilder()
+                .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true).build())
+                .build()
+        ).build();
+
+        fun controlExtensionMessage(testExtensionEnabled: Boolean = false): Rpc.ControlExtensions {
+            return Rpc.ControlExtensions.newBuilder().setTestExtension(testExtensionEnabled).build()
+        }
+
+        val testExtensionMessage: Rpc.TestExtension = Rpc.TestExtension.newBuilder().build()
+
+        fun assertNoResponseFromTestExtension(test: TwoRoutersTest) {
+            assertThrows<TimeoutException> {
+                test.mockRouter.waitForMessage(
+                    { it.hasTestExtension() },
+                    500L
+                );
+            }
+        }
+    }
+}

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -8,6 +8,8 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
+private const val DEFAULT_WAIT_FOR_MESSAGE_TIMEOUT_IN_MILLIS = 5000L
+
 open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
     protocol = PubsubProtocol.Floodsub,
     executor = executor,
@@ -26,9 +28,16 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
     }
 
     fun waitForMessage(predicate: (Rpc.RPC) -> Boolean): Rpc.RPC {
+        return waitForMessage(predicate, DEFAULT_WAIT_FOR_MESSAGE_TIMEOUT_IN_MILLIS)
+    }
+
+    fun waitForMessage(
+        predicate: (Rpc.RPC) -> Boolean,
+        timeoutInMillis: Long = DEFAULT_WAIT_FOR_MESSAGE_TIMEOUT_IN_MILLIS
+    ): Rpc.RPC {
         var cnt = 0
         while (true) {
-            val msg = inboundMessages.poll(5, TimeUnit.SECONDS)
+            val msg = inboundMessages.poll(timeoutInMillis, TimeUnit.MILLISECONDS)
                 ?: throw TimeoutException("No matching message received among $cnt")
             if (predicate(msg)) return msg
             cnt++
@@ -47,4 +56,5 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
     override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> = CompletableFuture.completedFuture(null)
     override fun broadcastInbound(msgs: List<PubsubMessage>, receivedFrom: PeerHandler) {}
     override fun processControl(ctrl: Rpc.ControlMessage, receivedFrom: PeerHandler) {}
+    override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {}
 }


### PR DESCRIPTION
This is the first part of the support for extension control messages (https://github.com/libp2p/specs/blob/marco/partial-messages/pubsub/gossipsub/gossipsub-v1.3.md).

It adds support for incoming control and extension messages from peers.

Next PR will add support for us sending the control messages when we want to notify peers of our support for an extension.

part of #436