### PR TITLE
Sending control extension message to remote peers

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -149,9 +149,6 @@ abstract class AbstractRouter(
         subscribedTopics.forEach {
             partsQueue.addSubscribe(it)
         }
-
-        // TODO end control extension
-
         flushPending(peer)
     }
 
@@ -188,7 +185,9 @@ abstract class AbstractRouter(
             processControl(msg.control, peer)
         }
 
-        if (protocol.supportsExtensions()) {
+        // TODO we need to handle the existence of extension messages more generically (https://github.com/libp2p/jvm-libp2p/issues/441)
+
+        if (protocol.supportsExtensions() && (msg.hasTestExtension() || msg.hasPartial())) {
             processExtensions(msg, peer)
         }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -149,6 +149,9 @@ abstract class AbstractRouter(
         subscribedTopics.forEach {
             partsQueue.addSubscribe(it)
         }
+
+        // TODO end control extension
+
         flushPending(peer)
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -12,6 +12,7 @@ import io.libp2p.pubsub.PubsubApiImpl
 import io.libp2p.pubsub.PubsubProtocol
 import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.netty.channel.ChannelHandler
+import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 
 class Gossip @JvmOverloads constructor(
@@ -20,6 +21,8 @@ class Gossip @JvmOverloads constructor(
     private val debugGossipHandler: ChannelHandler? = null
 ) :
     ProtocolBinding<Unit>, ConnectionHandler, PubsubApi by api {
+
+    private val logger = LoggerFactory.getLogger(Gossip::class.java)
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
         router.score.updateTopicParams(scoreParams)
@@ -62,6 +65,7 @@ class Gossip @JvmOverloads constructor(
     }
 
     override fun initChannel(ch: P2PChannel, selectedProtocol: String): CompletableFuture<out Unit> {
+        logger.trace("Gossip initChannel - selected protocol: {}", selectedProtocol)
         router.addPeerWithDebugHandler(ch as Stream, debugGossipHandler)
         return CompletableFuture.completedFuture(Unit)
     }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsState.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsState.kt
@@ -6,33 +6,33 @@ import pubsub.pb.Rpc
 class GossipExtensionsState {
 
     /*
-        Tracks the peers that we have already sent an extension control message
+        Tracks the peers that we have already sent a control extensions message
      */
-    private val outgoingExtensionControlMsgPeers: MutableSet<PeerId> = mutableSetOf()
+    private val outgoingControlExtensionsMsgPeers: MutableSet<PeerId> = mutableSetOf()
 
     /*
-        Tracks peers that already sent us an extension control message
+        Tracks peers that already sent us a control extensions message
      */
     private val peerExtensionSupportMap: MutableMap<PeerId, Rpc.ControlExtensions> = mutableMapOf()
 
     fun onPeerDisconnected(peer: PeerId) {
-        outgoingExtensionControlMsgPeers.remove(peer)
+        outgoingControlExtensionsMsgPeers.remove(peer)
         peerExtensionSupportMap.remove(peer)
     }
 
-    fun onExtensionControlMessage(ctrlExtensions: Rpc.ControlExtensions, receivedFrom: PeerId) {
+    fun onControlExtensionsMessage(ctrlExtensions: Rpc.ControlExtensions, receivedFrom: PeerId) {
         peerExtensionSupportMap[receivedFrom] = ctrlExtensions
     }
 
     fun registerControlExtensionMessageSentToPeers(peerId: PeerId) {
-        outgoingExtensionControlMsgPeers.add(peerId)
+        outgoingControlExtensionsMsgPeers.add(peerId)
     }
 
     fun peerSupportedExtensions(peerId: PeerId) = peerExtensionSupportMap[peerId]
 
-    fun hasReceivedExtensionControlFrom(peer: PeerId) =
+    fun hasReceivedControlExtensionsFrom(peer: PeerId) =
         peerExtensionSupportMap.contains(peer)
 
-    fun hasSentExtensionControlTo(peer: PeerId) =
-        outgoingExtensionControlMsgPeers.contains(peer)
+    fun hasSentControlExtensionsTo(peer: PeerId) =
+        outgoingControlExtensionsMsgPeers.contains(peer)
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsState.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsState.kt
@@ -8,7 +8,7 @@ class GossipExtensionsState {
     /*
         Tracks the peers that we have already sent an extension control message
      */
-    private val outgoingExtensionControlMsgPeers: MutableList<PeerId> = mutableListOf()
+    private val outgoingExtensionControlMsgPeers: MutableSet<PeerId> = mutableSetOf()
 
     /*
         Tracks peers that already sent us an extension control message
@@ -22,6 +22,10 @@ class GossipExtensionsState {
 
     fun onExtensionControlMessage(ctrlExtensions: Rpc.ControlExtensions, receivedFrom: PeerId) {
         peerExtensionSupportMap[receivedFrom] = ctrlExtensions
+    }
+
+    fun registerControlExtensionMessageSentToPeers(peerId: PeerId) {
+        outgoingExtensionControlMsgPeers.add(peerId)
     }
 
     fun peerSupportedExtensions(peerId: PeerId) = peerExtensionSupportMap[peerId]

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsState.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsState.kt
@@ -1,0 +1,34 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.PeerId
+import pubsub.pb.Rpc
+
+class GossipExtensionsState {
+
+    /*
+        Tracks the peers that we have already sent an extension control message
+     */
+    private val outgoingExtensionControlMsgPeers: MutableList<PeerId> = mutableListOf()
+
+    /*
+        Tracks peers that already sent us an extension control message
+     */
+    private val peerExtensionSupportMap: MutableMap<PeerId, Rpc.ControlExtensions> = mutableMapOf()
+
+    fun onPeerDisconnected(peer: PeerId) {
+        outgoingExtensionControlMsgPeers.remove(peer)
+        peerExtensionSupportMap.remove(peer)
+    }
+
+    fun onExtensionControlMessage(ctrlExtensions: Rpc.ControlExtensions, receivedFrom: PeerId) {
+        peerExtensionSupportMap[receivedFrom] = ctrlExtensions
+    }
+
+    fun peerSupportedExtensions(peerId: PeerId) = peerExtensionSupportMap[peerId]
+
+    fun hasReceivedExtensionControlFrom(peer: PeerId) =
+        peerExtensionSupportMap.contains(peer)
+
+    fun hasSentExtensionControlTo(peer: PeerId) =
+        outgoingExtensionControlMsgPeers.contains(peer)
+}

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -167,7 +167,7 @@ open class GossipRouter(
         super.onPeerActive(peer)
         eventBroadcaster.notifyConnected(peer.peerId, peer.getRemoteAddress())
         heartbeatTask.hashCode() // force lazy initialization
-        sendExtensionsControl(peer)
+        sendControlExtensions(peer)
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
@@ -400,7 +400,7 @@ open class GossipRouter(
     ) {
         logger.trace("Received control extension {}", ctrlExtensions.toString())
 
-        if (gossipExtensionsState.hasReceivedExtensionControlFrom(receivedFrom.peerId)) {
+        if (gossipExtensionsState.hasReceivedControlExtensionsFrom(receivedFrom.peerId)) {
             // TODO Should disconnect peers that send control extension multiple times (https://github.com/libp2p/jvm-libp2p/issues/437)
             logger.trace(
                 "Received another control extension message from peer {}",
@@ -408,27 +408,48 @@ open class GossipRouter(
             )
             return
         } else {
-            gossipExtensionsState.onExtensionControlMessage(ctrlExtensions, receivedFrom.peerId)
+            gossipExtensionsState.onControlExtensionsMessage(ctrlExtensions, receivedFrom.peerId)
         }
     }
 
     override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
         val peerSupportedExtensions =
             gossipExtensionsState.peerSupportedExtensions(receivedFrom.peerId)
-        if (peerSupportedExtensions == null) {
-            logger.trace(
-                "Ignoring extension messages from peer {} - did it send an extension control message?",
-                receivedFrom.peerId
-            )
-        } else {
-            when {
-                peerSupportedExtensions.hasTestExtension() && msg.hasTestExtension() ->
-                    processTestExtensionMessage(msg.testExtension, receivedFrom)
 
-                peerSupportedExtensions.hasPartialMessages() && msg.hasPartial() ->
-                    processPartialMessageExtension(msg.partial, receivedFrom)
-            }
+        // TODO Revisit this logic as part of adding feature flags (https://github.com/libp2p/jvm-libp2p/issues/441)
+
+        when {
+            msg.hasTestExtension() && checkPeerExtensionSupport(
+                peerSupportedExtensions,
+                Rpc.ControlExtensions::hasTestExtension
+            ) ->
+                processTestExtensionMessage(msg.testExtension, receivedFrom)
+
+            msg.hasPartial() && checkPeerExtensionSupport(
+                peerSupportedExtensions,
+                Rpc.ControlExtensions::hasPartialMessages
+            ) ->
+                processPartialMessageExtension(msg.partial, receivedFrom)
         }
+    }
+
+    private fun checkPeerExtensionSupport(
+        peerSavedPreferences: Rpc.ControlExtensions?,
+        checkSupportFunction: (Rpc.ControlExtensions) -> Boolean
+    ): Boolean {
+        if (peerSavedPreferences == null) {
+            return false
+        }
+
+        if (!checkSupportFunction.invoke(peerSavedPreferences)) {
+            logger.trace(
+                "Ignoring extension messages from peer {} - did it send an control extensions message?",
+                peerSavedPreferences
+            )
+            return false
+        }
+
+        return true
     }
 
     private fun processTestExtensionMessage(
@@ -582,7 +603,7 @@ open class GossipRouter(
             lastPublished -= topic
         }
 
-        activePeers.forEach { sendExtensionsControl(it) }
+        activePeers.forEach { sendControlExtensions(it) }
     }
 
     override fun unsubscribe(topic: Topic) {
@@ -783,23 +804,25 @@ open class GossipRouter(
         send(peer, iDontWant)
     }
 
-    private fun sendExtensionsControl(peer: PeerHandler) {
+    private fun sendControlExtensions(peer: PeerHandler) {
         if (!this.protocol.supportsExtensions()) {
             logger.trace(
-                "Protocol does not support extensions. Won't send extensions control message."
+                "Protocol does not support extensions. Won't send control extensions message."
             )
             return
         }
 
-        if (gossipExtensionsState.hasSentExtensionControlTo(peer.peerId)) {
+        if (gossipExtensionsState.hasSentControlExtensionsTo(peer.peerId)) {
             logger.trace(
-                "Already sent extension control msg to peer {}. Won't send another one.",
+                "Already sent control extensions msg to peer {}. Won't send another one.",
                 peer.peerId
             )
             return
         }
 
-        pendingRpcParts.getQueue(peer).addExtensionsControl(
+        logger.trace("Sending control extensions message to peer {}", peer.peerId)
+
+        pendingRpcParts.getQueue(peer).addControlExtensions(
             Rpc.ControlExtensions.newBuilder()
                 .setTestExtension(true)
                 .setPartialMessages(true)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -784,6 +784,13 @@ open class GossipRouter(
     }
 
     private fun sendExtensionsControl(peer: PeerHandler) {
+        if (!this.protocol.supportsExtensions()) {
+            logger.trace(
+                "Protocol does not support extensions. Won't send extensions control message."
+            )
+            return
+        }
+
         if (gossipExtensionsState.hasSentExtensionControlTo(peer.peerId)) {
             logger.trace(
                 "Already sent extension control msg to peer {}. Won't send another one.",

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -132,7 +132,10 @@ open class GossipRouter(
     private val acceptRequestsWhitelist = mutableMapOf<PeerHandler, AcceptRequestsWhitelistEntry>()
     override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
+    // TODO-lucas maybe we need to move this into a peer extension state that will also hold the information of the peers that we already sent our extension control to
     private val peerExtensionSupportMap = mutableMapOf<PeerId, Rpc.ControlExtensions>()
+    val peerExtensionSupportMapView: Map<PeerId, Rpc.ControlExtensions>
+        get() = peerExtensionSupportMap.toMap()
 
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
@@ -159,6 +162,7 @@ open class GossipRouter(
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
         pendingRpcParts.popQueue(peer) // discard them
+        peerExtensionSupportMap.remove(peer.peerId)
         super.onPeerDisconnected(peer)
     }
 
@@ -578,6 +582,8 @@ open class GossipRouter(
             fanout -= topic
             lastPublished -= topic
         }
+
+        // TODO-lucas we might want to send our extension control here in case we haven't sent it yet. but it needs to keep track of which peer we have already sent it to
     }
 
     override fun unsubscribe(topic: Topic) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -132,10 +132,7 @@ open class GossipRouter(
     private val acceptRequestsWhitelist = mutableMapOf<PeerHandler, AcceptRequestsWhitelistEntry>()
     override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
-    // TODO-lucas maybe we need to move this into a peer extension state that will also hold the information of the peers that we already sent our extension control to
-    private val peerExtensionSupportMap = mutableMapOf<PeerId, Rpc.ControlExtensions>()
-    val peerExtensionSupportMapView: Map<PeerId, Rpc.ControlExtensions>
-        get() = peerExtensionSupportMap.toMap()
+    val gossipExtensionsState = GossipExtensionsState()
 
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
@@ -162,7 +159,7 @@ open class GossipRouter(
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
         pendingRpcParts.popQueue(peer) // discard them
-        peerExtensionSupportMap.remove(peer.peerId)
+        gossipExtensionsState.onPeerDisconnected(peer.peerId)
         super.onPeerDisconnected(peer)
     }
 
@@ -170,6 +167,7 @@ open class GossipRouter(
         super.onPeerActive(peer)
         eventBroadcaster.notifyConnected(peer.peerId, peer.getRemoteAddress())
         heartbeatTask.hashCode() // force lazy initialization
+        sendExtensionsControl(peer)
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {
@@ -402,20 +400,21 @@ open class GossipRouter(
     ) {
         logger.trace("Received control extension {}", ctrlExtensions.toString())
 
-        if (peerExtensionSupportMap[receivedFrom.peerId] != null) {
-            // TODO Should downscore peers that send control extension multiple times? (https://github.com/libp2p/jvm-libp2p/issues/437)
+        if (gossipExtensionsState.hasReceivedExtensionControlFrom(receivedFrom.peerId)) {
+            // TODO Should disconnect peers that send control extension multiple times (https://github.com/libp2p/jvm-libp2p/issues/437)
             logger.trace(
                 "Received another control extension message from peer {}",
                 receivedFrom.peerId
             )
             return
         } else {
-            peerExtensionSupportMap[receivedFrom.peerId] = ctrlExtensions
+            gossipExtensionsState.onExtensionControlMessage(ctrlExtensions, receivedFrom.peerId)
         }
     }
 
     override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
-        val peerSupportedExtensions = peerExtensionSupportMap[receivedFrom.peerId]
+        val peerSupportedExtensions =
+            gossipExtensionsState.peerSupportedExtensions(receivedFrom.peerId)
         if (peerSupportedExtensions == null) {
             logger.trace(
                 "Ignoring extension messages from peer {} - did it send an extension control message?",
@@ -583,7 +582,7 @@ open class GossipRouter(
             lastPublished -= topic
         }
 
-        // TODO-lucas we might want to send our extension control here in case we haven't sent it yet. but it needs to keep track of which peer we have already sent it to
+        activePeers.forEach { sendExtensionsControl(it) }
     }
 
     override fun unsubscribe(topic: Topic) {
@@ -782,6 +781,23 @@ open class GossipRouter(
             )
         ).build()
         send(peer, iDontWant)
+    }
+
+    private fun sendExtensionsControl(peer: PeerHandler) {
+        if (gossipExtensionsState.hasSentExtensionControlTo(peer.peerId)) {
+            logger.trace(
+                "Already sent extension control msg to peer {}. Won't send another one.",
+                peer.peerId
+            )
+            return
+        }
+
+        pendingRpcParts.getQueue(peer).addExtensionsControl(
+            Rpc.ControlExtensions.newBuilder()
+                .setTestExtension(true)
+                .setPartialMessages(true)
+                .build()
+        )
     }
 
     data class AcceptRequestsWhitelistEntry(val whitelistedTill: Long, val messagesAccepted: Int = 0) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -798,6 +798,7 @@ open class GossipRouter(
                 .setPartialMessages(true)
                 .build()
         )
+        gossipExtensionsState.registerControlExtensionMessageSentToPeers(peer.peerId)
     }
 
     data class AcceptRequestsWhitelistEntry(val whitelistedTill: Long, val messagesAccepted: Int = 0) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -26,6 +26,8 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
      * Gossip 1.1 variant
      */
     fun addPrune(topic: Topic, backoffSeconds: Long, backoffPeers: List<PeerId>)
+
+    fun addExtensionsControl(ctrlMessage: Rpc.ControlExtensions)
 }
 
 /**
@@ -81,6 +83,12 @@ open class DefaultGossipRpcPartsQueue(
         }
     }
 
+    protected data class ControlExtensionPart(val ctrlExtension: Rpc.ControlExtensions) : AbstractPart {
+        override fun appendToBuilder(builder: Rpc.RPC.Builder) {
+            builder.controlBuilder.setExtensions(ctrlExtension)
+        }
+    }
+
     override fun addIHave(messageId: MessageId, topic: Topic) {
         addPart(IHavePart(messageId, topic))
     }
@@ -99,6 +107,10 @@ open class DefaultGossipRpcPartsQueue(
 
     override fun addPrune(topic: Topic, backoffSeconds: Long, backoffPeers: List<PeerId>) {
         addPart(PrunePart(topic, backoffSeconds, backoffPeers))
+    }
+
+    override fun addExtensionsControl(ctrlMessage: Rpc.ControlExtensions) {
+        addPart(ControlExtensionPart(ctrlMessage))
     }
 
     override fun takeMerged(): List<Rpc.RPC> {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -27,6 +27,7 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
      */
     fun addPrune(topic: Topic, backoffSeconds: Long, backoffPeers: List<PeerId>)
 
+    // TODO Need to check if we should handle when control extension and extension messages could be separated by split  (https://github.com/libp2p/jvm-libp2p/issues/440)
     fun addExtensionsControl(ctrlMessage: Rpc.ControlExtensions)
 }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -28,7 +28,7 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
     fun addPrune(topic: Topic, backoffSeconds: Long, backoffPeers: List<PeerId>)
 
     // TODO Need to check if we should handle when control extension and extension messages could be separated by split  (https://github.com/libp2p/jvm-libp2p/issues/440)
-    fun addExtensionsControl(ctrlMessage: Rpc.ControlExtensions)
+    fun addControlExtensions(ctrlMessage: Rpc.ControlExtensions)
 }
 
 /**
@@ -110,7 +110,7 @@ open class DefaultGossipRpcPartsQueue(
         addPart(PrunePart(topic, backoffSeconds, backoffPeers))
     }
 
-    override fun addExtensionsControl(ctrlMessage: Rpc.ControlExtensions) {
+    override fun addControlExtensions(ctrlMessage: Rpc.ControlExtensions) {
         addPart(ControlExtensionPart(ctrlMessage))
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsStateTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsStateTest.kt
@@ -22,13 +22,13 @@ class GossipExtensionsStateTest {
     }
 
     @Test
-    fun `onExtensionControlMessage() stores peer extensions support`() {
+    fun `onControlExtensionsMessage() stores peer extensions support`() {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .setTestExtension(false)
             .build()
 
-        extensionsState.onExtensionControlMessage(extension, peer1)
+        extensionsState.onControlExtensionsMessage(extension, peer1)
 
         val stored = extensionsState.peerSupportedExtensions(peer1)
         assertThat(stored).isNotNull
@@ -37,21 +37,21 @@ class GossipExtensionsStateTest {
     }
 
     @Test
-    fun `hasReceivedExtensionControlFrom() returns true after receiving extensions`() {
+    fun `hasReceivedControlExtensionsFrom() returns true after receiving extensions`() {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
 
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
 
-        extensionsState.onExtensionControlMessage(extension, peer1)
+        extensionsState.onControlExtensionsMessage(extension, peer1)
 
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isTrue()
     }
 
     @Test
-    fun `hasReceivedExtensionControlFrom() returns false for unknown peer`() {
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+    fun `hasReceivedControlExtensionsFrom() returns false for unknown peer`() {
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
     }
 
     @Test
@@ -66,7 +66,7 @@ class GossipExtensionsStateTest {
         config given it most likely has the most up-to-date data for that particular peer
      */
     @Test
-    fun `onExtensionControlMessage() overwrites previous extensions from same peer`() {
+    fun `onControlExtensionsMessage() overwrites previous extensions from same peer`() {
         val extension1 = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .setTestExtension(false)
@@ -77,8 +77,8 @@ class GossipExtensionsStateTest {
             .setTestExtension(true)
             .build()
 
-        extensionsState.onExtensionControlMessage(extension1, peer1)
-        extensionsState.onExtensionControlMessage(extension2, peer1)
+        extensionsState.onControlExtensionsMessage(extension1, peer1)
+        extensionsState.onControlExtensionsMessage(extension2, peer1)
 
         val stored = extensionsState.peerSupportedExtensions(peer1)
         assertThat(stored).isNotNull
@@ -87,24 +87,24 @@ class GossipExtensionsStateTest {
     }
 
     @Test
-    fun `hasSentExtensionControlTo() returns false for unknown peer`() {
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+    fun `hasSentControlExtensionsTo() returns false for unknown peer`() {
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
     }
 
     @Test
     fun `registerControlExtensionMessageSentToPeers() registers peer`() {
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
 
         extensionsState.registerControlExtensionMessageSentToPeers(peer1)
 
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
     }
 
     @Test
-    fun `hasSentExtensionControlTo() returns true after registration`() {
+    fun `hasSentControlExtensionsTo() returns true after registration`() {
         extensionsState.registerControlExtensionMessageSentToPeers(peer1)
 
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
     }
 
     @Test
@@ -112,9 +112,9 @@ class GossipExtensionsStateTest {
         extensionsState.registerControlExtensionMessageSentToPeers(peer1)
         extensionsState.registerControlExtensionMessageSentToPeers(peer2)
 
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
-        assertThat(extensionsState.hasSentExtensionControlTo(peer2)).isTrue()
-        assertThat(extensionsState.hasSentExtensionControlTo(peer3)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer2)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer3)).isFalse()
     }
 
     @Test
@@ -126,15 +126,15 @@ class GossipExtensionsStateTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        extensionsState.onExtensionControlMessage(extension, peer2)
+        extensionsState.onControlExtensionsMessage(extension, peer2)
 
         // Verify sent tracking
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
-        assertThat(extensionsState.hasSentExtensionControlTo(peer2)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer2)).isFalse()
 
         // Verify received tracking
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer2)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer2)).isTrue()
     }
 
     @Test
@@ -146,11 +146,11 @@ class GossipExtensionsStateTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        extensionsState.onExtensionControlMessage(extension, peer1)
+        extensionsState.onControlExtensionsMessage(extension, peer1)
 
         // Both should be tracked
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isTrue()
     }
 
     @Test
@@ -170,9 +170,9 @@ class GossipExtensionsStateTest {
             .setTestExtension(true)
             .build()
 
-        extensionsState.onExtensionControlMessage(extension1, peer1)
-        extensionsState.onExtensionControlMessage(extension2, peer2)
-        extensionsState.onExtensionControlMessage(extension3, peer3)
+        extensionsState.onControlExtensionsMessage(extension1, peer1)
+        extensionsState.onControlExtensionsMessage(extension2, peer2)
+        extensionsState.onControlExtensionsMessage(extension3, peer3)
 
         // Verify each peer has correct extensions
         val stored1 = extensionsState.peerSupportedExtensions(peer1)
@@ -188,9 +188,9 @@ class GossipExtensionsStateTest {
         assertThat(stored3.testExtension).isTrue()
 
         // Verify all peers are tracked
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer2)).isTrue()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer3)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer2)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer3)).isTrue()
     }
 
     @Test
@@ -201,12 +201,12 @@ class GossipExtensionsStateTest {
             .build()
 
         peers.forEach { peer ->
-            extensionsState.onExtensionControlMessage(extension, peer)
+            extensionsState.onControlExtensionsMessage(extension, peer)
         }
 
         // Verify all peers are tracked
         peers.forEach { peer ->
-            assertThat(extensionsState.hasReceivedExtensionControlFrom(peer)).isTrue()
+            assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer)).isTrue()
             assertThat(extensionsState.peerSupportedExtensions(peer)).isNotNull
         }
     }
@@ -217,12 +217,12 @@ class GossipExtensionsStateTest {
             .setPartialMessages(true)
             .build()
 
-        extensionsState.onExtensionControlMessage(extension, peer1)
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+        extensionsState.onControlExtensionsMessage(extension, peer1)
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isTrue()
 
         extensionsState.onPeerDisconnected(peer1)
 
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
         assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
     }
 
@@ -232,7 +232,7 @@ class GossipExtensionsStateTest {
         extensionsState.onPeerDisconnected(peer1)
 
         // State should remain empty
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
         assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
     }
 
@@ -246,18 +246,18 @@ class GossipExtensionsStateTest {
             .setTestExtension(true)
             .build()
 
-        extensionsState.onExtensionControlMessage(extension1, peer1)
-        extensionsState.onExtensionControlMessage(extension2, peer2)
+        extensionsState.onControlExtensionsMessage(extension1, peer1)
+        extensionsState.onControlExtensionsMessage(extension2, peer2)
 
         // Disconnect peer1
         extensionsState.onPeerDisconnected(peer1)
 
         // peer1 should be removed
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
         assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
 
         // peer2 should remain
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer2)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer2)).isTrue()
         assertThat(extensionsState.peerSupportedExtensions(peer2)).isNotNull
         assertThat(extensionsState.peerSupportedExtensions(peer2)!!.testExtension).isTrue()
     }
@@ -269,18 +269,18 @@ class GossipExtensionsStateTest {
             .build()
 
         // Connect
-        extensionsState.onExtensionControlMessage(extension, peer1)
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+        extensionsState.onControlExtensionsMessage(extension, peer1)
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isTrue()
 
         // Disconnect
         extensionsState.onPeerDisconnected(peer1)
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
 
         // Reconnect with different extensions
         val newExtension = Rpc.ControlExtensions.newBuilder()
             .setTestExtension(true)
             .build()
-        extensionsState.onExtensionControlMessage(newExtension, peer1)
+        extensionsState.onControlExtensionsMessage(newExtension, peer1)
 
         val stored = extensionsState.peerSupportedExtensions(peer1)
         assertThat(stored).isNotNull
@@ -291,11 +291,11 @@ class GossipExtensionsStateTest {
     @Test
     fun `onPeerDisconnected() removes peer from sent extensions list`() {
         extensionsState.registerControlExtensionMessageSentToPeers(peer1)
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
 
         extensionsState.onPeerDisconnected(peer1)
 
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
     }
 
     @Test
@@ -307,18 +307,18 @@ class GossipExtensionsStateTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        extensionsState.onExtensionControlMessage(extension, peer1)
+        extensionsState.onControlExtensionsMessage(extension, peer1)
 
         // Verify both tracked
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isTrue()
 
         // Disconnect
         extensionsState.onPeerDisconnected(peer1)
 
         // Both should be removed
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
         assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
     }
 
@@ -329,30 +329,30 @@ class GossipExtensionsStateTest {
 
         extensionsState.onPeerDisconnected(peer1)
 
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
-        assertThat(extensionsState.hasSentExtensionControlTo(peer2)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer2)).isTrue()
     }
 
     @Test
     fun `reconnecting peer can have sent extension registered again`() {
         // First connection - register sent
         extensionsState.registerControlExtensionMessageSentToPeers(peer1)
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
 
         // Disconnect
         extensionsState.onPeerDisconnected(peer1)
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
 
         // Reconnect - register sent again
         extensionsState.registerControlExtensionMessageSentToPeers(peer1)
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isTrue()
     }
 
     @Test
     fun `querying empty state returns expected values`() {
         extensionsState = GossipExtensionsState()
-        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
-        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedControlExtensionsFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasSentControlExtensionsTo(peer1)).isFalse()
         assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsStateTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipExtensionsStateTest.kt
@@ -1,0 +1,358 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.PeerId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+
+class GossipExtensionsStateTest {
+
+    private lateinit var extensionsState: GossipExtensionsState
+    private lateinit var peer1: PeerId
+    private lateinit var peer2: PeerId
+    private lateinit var peer3: PeerId
+
+    @BeforeEach
+    fun setup() {
+        extensionsState = GossipExtensionsState()
+        peer1 = PeerId.random()
+        peer2 = PeerId.random()
+        peer3 = PeerId.random()
+    }
+
+    @Test
+    fun `onExtensionControlMessage() stores peer extensions support`() {
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .setTestExtension(false)
+            .build()
+
+        extensionsState.onExtensionControlMessage(extension, peer1)
+
+        val stored = extensionsState.peerSupportedExtensions(peer1)
+        assertThat(stored).isNotNull
+        assertThat(stored!!.partialMessages).isTrue()
+        assertThat(stored.testExtension).isFalse()
+    }
+
+    @Test
+    fun `hasReceivedExtensionControlFrom() returns true after receiving extensions`() {
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+
+        extensionsState.onExtensionControlMessage(extension, peer1)
+
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+    }
+
+    @Test
+    fun `hasReceivedExtensionControlFrom() returns false for unknown peer`() {
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+    }
+
+    @Test
+    fun `peerSupportedExtensions() returns null for unknown peer`() {
+        val extensions = extensionsState.peerSupportedExtensions(peer1)
+        assertThat(extensions).isNull()
+    }
+
+    /*
+        In practice, we should not receive more than one control message from the same peer on
+        the same connection, but if this ever happens, it makes sense to override the in-memory
+        config given it most likely has the most up-to-date data for that particular peer
+     */
+    @Test
+    fun `onExtensionControlMessage() overwrites previous extensions from same peer`() {
+        val extension1 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .setTestExtension(false)
+            .build()
+
+        val extension2 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(false)
+            .setTestExtension(true)
+            .build()
+
+        extensionsState.onExtensionControlMessage(extension1, peer1)
+        extensionsState.onExtensionControlMessage(extension2, peer1)
+
+        val stored = extensionsState.peerSupportedExtensions(peer1)
+        assertThat(stored).isNotNull
+        assertThat(stored!!.partialMessages).isFalse()
+        assertThat(stored.testExtension).isTrue()
+    }
+
+    @Test
+    fun `hasSentExtensionControlTo() returns false for unknown peer`() {
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+    }
+
+    @Test
+    fun `registerControlExtensionMessageSentToPeers() registers peer`() {
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+    }
+
+    @Test
+    fun `hasSentExtensionControlTo() returns true after registration`() {
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+    }
+
+    @Test
+    fun `registerControlExtensionMessageSentToPeers() can register multiple peers`() {
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+        extensionsState.registerControlExtensionMessageSentToPeers(peer2)
+
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentExtensionControlTo(peer2)).isTrue()
+        assertThat(extensionsState.hasSentExtensionControlTo(peer3)).isFalse()
+    }
+
+    @Test
+    fun `sent and received extension tracking are independent`() {
+        // Register that we sent to peer1
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+
+        // Receive from peer2
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        extensionsState.onExtensionControlMessage(extension, peer2)
+
+        // Verify sent tracking
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasSentExtensionControlTo(peer2)).isFalse()
+
+        // Verify received tracking
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer2)).isTrue()
+    }
+
+    @Test
+    fun `peer can be in both sent and received tracking`() {
+        // Register that we sent to peer1
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+
+        // Receive from peer1
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        extensionsState.onExtensionControlMessage(extension, peer1)
+
+        // Both should be tracked
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+    }
+
+    @Test
+    fun `tracks multiple peers with different extensions`() {
+        val extension1 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .setTestExtension(false)
+            .build()
+
+        val extension2 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(false)
+            .setTestExtension(true)
+            .build()
+
+        val extension3 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .setTestExtension(true)
+            .build()
+
+        extensionsState.onExtensionControlMessage(extension1, peer1)
+        extensionsState.onExtensionControlMessage(extension2, peer2)
+        extensionsState.onExtensionControlMessage(extension3, peer3)
+
+        // Verify each peer has correct extensions
+        val stored1 = extensionsState.peerSupportedExtensions(peer1)
+        assertThat(stored1!!.partialMessages).isTrue()
+        assertThat(stored1.testExtension).isFalse()
+
+        val stored2 = extensionsState.peerSupportedExtensions(peer2)
+        assertThat(stored2!!.partialMessages).isFalse()
+        assertThat(stored2.testExtension).isTrue()
+
+        val stored3 = extensionsState.peerSupportedExtensions(peer3)
+        assertThat(stored3!!.partialMessages).isTrue()
+        assertThat(stored3.testExtension).isTrue()
+
+        // Verify all peers are tracked
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer2)).isTrue()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer3)).isTrue()
+    }
+
+    @Test
+    fun `tracks many peers simultaneously`() {
+        val peers = (1..10).map { PeerId.random() }
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+
+        peers.forEach { peer ->
+            extensionsState.onExtensionControlMessage(extension, peer)
+        }
+
+        // Verify all peers are tracked
+        peers.forEach { peer ->
+            assertThat(extensionsState.hasReceivedExtensionControlFrom(peer)).isTrue()
+            assertThat(extensionsState.peerSupportedExtensions(peer)).isNotNull
+        }
+    }
+
+    @Test
+    fun `onPeerDisconnected() removes peer from received extensions map`() {
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+
+        extensionsState.onExtensionControlMessage(extension, peer1)
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+
+        extensionsState.onPeerDisconnected(peer1)
+
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
+    }
+
+    @Test
+    fun `onPeerDisconnected() handles unknown peer gracefully`() {
+        // Should not throw exception for unknown peer
+        extensionsState.onPeerDisconnected(peer1)
+
+        // State should remain empty
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
+    }
+
+    @Test
+    fun `onPeerDisconnected() only removes specified peer`() {
+        val extension1 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+
+        val extension2 = Rpc.ControlExtensions.newBuilder()
+            .setTestExtension(true)
+            .build()
+
+        extensionsState.onExtensionControlMessage(extension1, peer1)
+        extensionsState.onExtensionControlMessage(extension2, peer2)
+
+        // Disconnect peer1
+        extensionsState.onPeerDisconnected(peer1)
+
+        // peer1 should be removed
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
+
+        // peer2 should remain
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer2)).isTrue()
+        assertThat(extensionsState.peerSupportedExtensions(peer2)).isNotNull
+        assertThat(extensionsState.peerSupportedExtensions(peer2)!!.testExtension).isTrue()
+    }
+
+    @Test
+    fun `multiple disconnects and reconnects work correctly`() {
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+
+        // Connect
+        extensionsState.onExtensionControlMessage(extension, peer1)
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+
+        // Disconnect
+        extensionsState.onPeerDisconnected(peer1)
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+
+        // Reconnect with different extensions
+        val newExtension = Rpc.ControlExtensions.newBuilder()
+            .setTestExtension(true)
+            .build()
+        extensionsState.onExtensionControlMessage(newExtension, peer1)
+
+        val stored = extensionsState.peerSupportedExtensions(peer1)
+        assertThat(stored).isNotNull
+        assertThat(stored!!.hasPartialMessages()).isFalse()
+        assertThat(stored.testExtension).isTrue()
+    }
+
+    @Test
+    fun `onPeerDisconnected() removes peer from sent extensions list`() {
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+
+        extensionsState.onPeerDisconnected(peer1)
+
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+    }
+
+    @Test
+    fun `onPeerDisconnected() removes peer from both sent and received tracking`() {
+        // Register sent
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+
+        // Register received
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        extensionsState.onExtensionControlMessage(extension, peer1)
+
+        // Verify both tracked
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isTrue()
+
+        // Disconnect
+        extensionsState.onPeerDisconnected(peer1)
+
+        // Both should be removed
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
+    }
+
+    @Test
+    fun `onPeerDisconnected() only removes specified peer from sent list`() {
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+        extensionsState.registerControlExtensionMessageSentToPeers(peer2)
+
+        extensionsState.onPeerDisconnected(peer1)
+
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.hasSentExtensionControlTo(peer2)).isTrue()
+    }
+
+    @Test
+    fun `reconnecting peer can have sent extension registered again`() {
+        // First connection - register sent
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+
+        // Disconnect
+        extensionsState.onPeerDisconnected(peer1)
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+
+        // Reconnect - register sent again
+        extensionsState.registerControlExtensionMessageSentToPeers(peer1)
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isTrue()
+    }
+
+    @Test
+    fun `querying empty state returns expected values`() {
+        extensionsState = GossipExtensionsState()
+        assertThat(extensionsState.hasReceivedExtensionControlFrom(peer1)).isFalse()
+        assertThat(extensionsState.hasSentExtensionControlTo(peer1)).isFalse()
+        assertThat(extensionsState.peerSupportedExtensions(peer1)).isNull()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -306,4 +306,191 @@ class GossipRpcPartsQueueTest {
                 .addMessageIDs("2222".toWBytes().toProtobuf()).build(),
         )
     }
+
+    @Test
+    fun `addExtensionsControl() sets testExtension flag in control message`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setTestExtension(true)
+            .build()
+
+        partsQueue.addExtensionsControl(extension)
+
+        val res = partsQueue.takeMerged().first()
+
+        assertThat(res.hasControl()).isTrue()
+        assertThat(res.control.hasExtensions()).isTrue()
+        assertThat(res.control.extensions.testExtension).isTrue()
+    }
+
+    @Test
+    fun `addExtensionsControl() sets partialMessages flag in control message`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+
+        partsQueue.addExtensionsControl(extension)
+
+        val res = partsQueue.takeMerged().first()
+
+        assertThat(res.hasControl()).isTrue()
+        assertThat(res.control.hasExtensions()).isTrue()
+        assertThat(res.control.extensions.partialMessages).isTrue()
+    }
+
+    @Test
+    fun `addExtensionsControl() sets all extension flags`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .setTestExtension(true)
+            .build()
+
+        partsQueue.addExtensionsControl(extension)
+
+        val res = partsQueue.takeMerged().first()
+
+        assertThat(res.hasControl()).isTrue()
+        assertThat(res.control.hasExtensions()).isTrue()
+        assertThat(res.control.extensions.partialMessages).isTrue()
+        assertThat(res.control.extensions.testExtension).isTrue()
+    }
+
+    @Test
+    fun `extension control message works with other control messages`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        // Add various control messages
+        partsQueue.addIHave(byteArrayOf(1).toWBytes(), "topic1")
+        partsQueue.addIWant(byteArrayOf(2).toWBytes())
+        partsQueue.addGraft("topic2")
+        partsQueue.addPrune("topic3")
+
+        // Add extension
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        partsQueue.addExtensionsControl(extension)
+
+        val res = partsQueue.takeMerged().first()
+
+        // Verify all control messages are present
+        assertThat(res.hasControl()).isTrue()
+        assertThat(res.control.ihaveList).hasSize(1)
+        assertThat(res.control.iwantList).hasSize(1)
+        assertThat(res.control.graftList).hasSize(1)
+        assertThat(res.control.pruneList).hasSize(1)
+
+        // Verify extension is present
+        assertThat(res.control.hasExtensions()).isTrue()
+        assertThat(res.control.extensions.partialMessages).isTrue()
+    }
+
+    @Test
+    fun `extension control message with subscriptions and publishes`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        partsQueue.addSubscribe("topic1")
+        partsQueue.addPublish(createRpcMessage("topic1", "data1"))
+
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        partsQueue.addExtensionsControl(extension)
+
+        val res = partsQueue.takeMerged().first()
+
+        // Verify subscriptions and publishes
+        assertThat(res.subscriptionsList).hasSize(1)
+        assertThat(res.publishList).hasSize(1)
+
+        // Verify extension
+        assertThat(res.control.hasExtensions()).isTrue()
+        assertThat(res.control.extensions.partialMessages).isTrue()
+    }
+
+    @Test
+    fun `extension control message works with message splitting`() {
+        val partsQueue = TestGossipQueue(gossipParamsWithLimits)
+
+        // Add enough messages to force splitting
+        (1..20).forEach {
+            partsQueue.addPublish(createRpcMessage("topic-$it", "data"))
+        }
+
+        // Add extension
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        partsQueue.addExtensionsControl(extension)
+
+        val merged = partsQueue.takeMerged()
+
+        // Should be split into multiple RPCs due to maxPublishedMessages limit
+        assertThat(merged.size).isGreaterThan(1)
+
+        // Extension should be in the last RPC (since it's added last)
+        val lastRpc = merged.last()
+        assertThat(lastRpc.hasControl()).isTrue()
+        assertThat(lastRpc.control.hasExtensions()).isTrue()
+        assertThat(lastRpc.control.extensions.partialMessages).isTrue()
+    }
+
+    @Test
+    fun `multiple extension control messages - last one wins`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        // Add first extension
+        val extension1 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .setTestExtension(false)
+            .build()
+        partsQueue.addExtensionsControl(extension1)
+
+        // Add second extension (should overwrite first)
+        val extension2 = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(false)
+            .setTestExtension(true)
+            .build()
+        partsQueue.addExtensionsControl(extension2)
+
+        val res = partsQueue.takeMerged().first()
+
+        // Verify only the last extension is present
+        assertThat(res.control.hasExtensions()).isTrue()
+        // Note: false flags may or may not be serialized depending on protobuf default behavior
+        // But testExtension should definitely be true
+        assertThat(res.control.extensions.testExtension).isTrue()
+    }
+
+    @Test
+    fun `extension control message does not count toward limits but may be split`() {
+        val partsQueue = TestGossipQueue(gossipParamsWithLimits)
+
+        // Add exactly maxPublishedMessages messages
+        (1..maxPublishedMessages).forEach {
+            partsQueue.addPublish(createRpcMessage("topic-$it", "data"))
+        }
+
+        // Add extension
+        val extension = Rpc.ControlExtensions.newBuilder()
+            .setPartialMessages(true)
+            .build()
+        partsQueue.addExtensionsControl(extension)
+
+        val merged = partsQueue.takeMerged()
+
+        // Extension doesn't count toward limits, but it may end up in a separate RPC
+        // if it comes after parts that exhaust a limit
+        assertThat(merged).hasSize(2)
+        assertThat(merged[0].publishList).hasSize(maxPublishedMessages)
+
+        // Extension should be in the second RPC
+        assertThat(merged[1].control.hasExtensions()).isTrue()
+        assertThat(merged[1].control.extensions.partialMessages).isTrue()
+    }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -308,14 +308,14 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `addExtensionsControl() sets testExtension flag in control message`() {
+    fun `addControlExtensions() sets testExtension flag in control message`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
 
         val extension = Rpc.ControlExtensions.newBuilder()
             .setTestExtension(true)
             .build()
 
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val res = partsQueue.takeMerged().first()
 
@@ -325,14 +325,14 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `addExtensionsControl() sets partialMessages flag in control message`() {
+    fun `addControlExtensions() sets partialMessages flag in control message`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
 
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
 
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val res = partsQueue.takeMerged().first()
 
@@ -342,7 +342,7 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `addExtensionsControl() sets all extension flags`() {
+    fun `addControlExtensions() sets all extension flags`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
 
         val extension = Rpc.ControlExtensions.newBuilder()
@@ -350,7 +350,7 @@ class GossipRpcPartsQueueTest {
             .setTestExtension(true)
             .build()
 
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val res = partsQueue.takeMerged().first()
 
@@ -361,7 +361,7 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `extension control message works with other control messages`() {
+    fun `control extensions message works with other control messages`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
 
         // Add various control messages
@@ -374,7 +374,7 @@ class GossipRpcPartsQueueTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val res = partsQueue.takeMerged().first()
 
@@ -391,7 +391,7 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `extension control message with subscriptions and publishes`() {
+    fun `control extensions message with subscriptions and publishes`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
 
         partsQueue.addSubscribe("topic1")
@@ -400,7 +400,7 @@ class GossipRpcPartsQueueTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val res = partsQueue.takeMerged().first()
 
@@ -414,7 +414,7 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `extension control message works with message splitting`() {
+    fun `control extensions message works with message splitting`() {
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
 
         // Add enough messages to force splitting
@@ -426,7 +426,7 @@ class GossipRpcPartsQueueTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val merged = partsQueue.takeMerged()
 
@@ -441,7 +441,7 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `multiple extension control messages - last one wins`() {
+    fun `multiple control extensions messages - last one wins`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
 
         // Add first extension
@@ -449,14 +449,14 @@ class GossipRpcPartsQueueTest {
             .setPartialMessages(true)
             .setTestExtension(false)
             .build()
-        partsQueue.addExtensionsControl(extension1)
+        partsQueue.addControlExtensions(extension1)
 
         // Add second extension (should overwrite first)
         val extension2 = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(false)
             .setTestExtension(true)
             .build()
-        partsQueue.addExtensionsControl(extension2)
+        partsQueue.addControlExtensions(extension2)
 
         val res = partsQueue.takeMerged().first()
 
@@ -468,7 +468,7 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `extension control message does not count toward limits but may be split`() {
+    fun `control extensions message does not count toward limits but may be split`() {
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
 
         // Add exactly maxPublishedMessages messages
@@ -480,7 +480,7 @@ class GossipRpcPartsQueueTest {
         val extension = Rpc.ControlExtensions.newBuilder()
             .setPartialMessages(true)
             .build()
-        partsQueue.addExtensionsControl(extension)
+        partsQueue.addControlExtensions(extension)
 
         val merged = partsQueue.takeMerged()
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -2,6 +2,7 @@ package io.libp2p.pubsub.gossip.extensions
 
 import io.libp2p.pubsub.PubsubProtocol
 import io.libp2p.pubsub.gossip.GossipTestsBase
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import pubsub.pb.Rpc
@@ -15,16 +16,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             protocol = PubsubProtocol.Gossip_V_1_2
         )
 
-        val rpcMessageWithControlExtensionAndTestExtensionMessages = Rpc.RPC.newBuilder()
-            .setControl(
-                Rpc.ControlMessage.newBuilder()
-                    .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true))
-                    .build()
-            )
-            .setTestExtension(Rpc.TestExtension.newBuilder().build())
-            .build()
-        test.mockRouter.sendToSingle(rpcMessageWithControlExtensionAndTestExtensionMessages)
-
+        test.mockRouter.sendToSingle(rpcMsgWithCtrlExtensionsAndTestExtension)
         assertNoResponseFromTestExtension(test)
     }
 
@@ -34,10 +26,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             protocol = PubsubProtocol.Gossip_V_1_3
         )
 
-        val rpcMessageWithTestExtension =
-            Rpc.RPC.newBuilder().setTestExtension(testExtensionMessage).build()
         test.mockRouter.sendToSingle(rpcMessageWithTestExtension)
-
         assertNoResponseFromTestExtension(test)
     }
 
@@ -47,15 +36,8 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             protocol = PubsubProtocol.Gossip_V_1_3
         )
 
-        val rpcMessageWithControl = Rpc.RPC.newBuilder().setControl(
-            Rpc.ControlMessage.newBuilder().setExtensions(controlExtensionMessage())
-        ).build()
-        test.mockRouter.sendToSingle(rpcMessageWithControl)
-
-        val rpcMessageWithTestExtension =
-            Rpc.RPC.newBuilder().setTestExtension(testExtensionMessage).build()
+        test.mockRouter.sendToSingle(rpcMessageWithControlExtensions)
         test.mockRouter.sendToSingle(rpcMessageWithTestExtension)
-
         test.mockRouter.waitForMessage { it.hasTestExtension() }
     }
 
@@ -65,31 +47,51 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             protocol = PubsubProtocol.Gossip_V_1_3
         )
 
-        val rpcMessageWithControlExtensionAndTestExtensionMessages = Rpc.RPC.newBuilder()
+        test.mockRouter.sendToSingle(rpcMsgWithCtrlExtensionsAndTestExtension)
+        test.mockRouter.waitForMessage { it.hasTestExtension() }
+    }
+
+    @Test
+    fun `remove peer extension control map when disconnecting`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        test.mockRouter.sendToSingle(rpcMsgWithCtrlExtensionsAndTestExtension)
+        test.mockRouter.waitForMessage { it.hasTestExtension() }
+
+        // Successfully registered peer2 extensions support
+        assertThat(test.gossipRouter.peerExtensionSupportMapView).containsKey(test.router2.peerId)
+
+        test.connection.disconnect()
+
+        // After disconnecting removes peer2 from extensions support map
+        assertThat(test.gossipRouter.peerExtensionSupportMapView).isEmpty()
+    }
+
+    companion object {
+        val testExtensionMessage: Rpc.TestExtension = Rpc.TestExtension.newBuilder().build()
+
+        val rpcMessageWithControlExtensions = Rpc.RPC.newBuilder().setControl(
+            Rpc.ControlMessage.newBuilder().setExtensions(controlExtensionMessage())
+        ).build()!!
+
+        val rpcMessageWithTestExtension =
+            Rpc.RPC.newBuilder().setTestExtension(testExtensionMessage).build()!!
+
+        // An RPC message with both ControlExtensions and TestExtension message (test extension enabled on control)
+        val rpcMsgWithCtrlExtensionsAndTestExtension = Rpc.RPC.newBuilder()
             .setControl(
                 Rpc.ControlMessage.newBuilder()
                     .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true))
                     .build()
             )
             .setTestExtension(Rpc.TestExtension.newBuilder().build())
-            .build()
-        test.mockRouter.sendToSingle(rpcMessageWithControlExtensionAndTestExtensionMessages)
-
-        test.mockRouter.waitForMessage { it.hasTestExtension() }
-    }
-
-    companion object {
-        val testExtensionControlEnabledMessage: Rpc.RPC = Rpc.RPC.newBuilder().setControl(
-            Rpc.ControlMessage.newBuilder()
-                .setExtensions(Rpc.ControlExtensions.newBuilder().setTestExtension(true).build())
-                .build()
-        ).build()
+            .build()!!
 
         fun controlExtensionMessage(testExtensionEnabled: Boolean = false): Rpc.ControlExtensions {
             return Rpc.ControlExtensions.newBuilder().setTestExtension(testExtensionEnabled).build()
         }
-
-        val testExtensionMessage: Rpc.TestExtension = Rpc.TestExtension.newBuilder().build()
 
         fun assertNoResponseFromTestExtension(test: TwoRoutersTest) {
             assertThrows<TimeoutException> {

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -37,6 +37,10 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
         )
 
         test.mockRouter.sendToSingle(rpcMessageWithControlExtensions)
+        assertThat(test.gossipRouter.gossipExtensionsState.peerSupportedExtensions(test.router2.peerId)).isEqualTo(
+            rpcMessageWithControlExtensions.control.extensions
+        )
+
         test.mockRouter.sendToSingle(rpcMessageWithTestExtension)
         test.mockRouter.waitForMessage { it.hasTestExtension() }
     }
@@ -58,15 +62,21 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
         )
 
         test.mockRouter.sendToSingle(rpcMsgWithCtrlExtensionsAndTestExtension)
+
+        assertThat(test.gossipRouter.gossipExtensionsState.peerSupportedExtensions(test.router2.peerId)).isEqualTo(
+            rpcMsgWithCtrlExtensionsAndTestExtension.control.extensions
+        )
+
         test.mockRouter.waitForMessage { it.hasTestExtension() }
 
         // Successfully registered peer2 extensions support
-        assertThat(test.gossipRouter.peerExtensionSupportMapView).containsKey(test.router2.peerId)
+
+        assertThat(test.gossipRouter.gossipExtensionsState.peerSupportedExtensions(test.router2.peerId)).isNotNull()
 
         test.connection.disconnect()
 
         // After disconnecting removes peer2 from extensions support map
-        assertThat(test.gossipRouter.peerExtensionSupportMapView).isEmpty()
+        assertThat(test.gossipRouter.gossipExtensionsState.peerSupportedExtensions(test.router2.peerId)).isNull()
     }
 
     companion object {
@@ -89,7 +99,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             .setTestExtension(Rpc.TestExtension.newBuilder().build())
             .build()!!
 
-        fun controlExtensionMessage(testExtensionEnabled: Boolean = false): Rpc.ControlExtensions {
+        fun controlExtensionMessage(testExtensionEnabled: Boolean = true): Rpc.ControlExtensions {
             return Rpc.ControlExtensions.newBuilder().setTestExtension(testExtensionEnabled).build()
         }
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -5,8 +5,12 @@ import io.libp2p.pubsub.gossip.GossipTestsBase
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import pubsub.pb.Rpc
 import java.util.concurrent.TimeoutException
+
+private const val DEFAULT_WAIT_TIMEOUT_IN_MILLIS = 500L
 
 class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
 
@@ -79,7 +83,104 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
         assertThat(test.gossipRouter.gossipExtensionsState.peerSupportedExtensions(test.router2.peerId)).isNull()
     }
 
+    @ParameterizedTest
+    @MethodSource("protocolVersionsWithExtensionSupport")
+    fun `control extension message sent to peer on connection with extension support`(protocol: PubsubProtocol) {
+        val test = TwoRoutersTest(protocol = protocol)
+
+        val receivedMessage = test.mockRouter.waitForMessage(
+            { it.hasControl() && it.control.hasExtensions() },
+            DEFAULT_WAIT_TIMEOUT_IN_MILLIS
+        )
+
+        assertThat(receivedMessage.control.extensions.partialMessages).isTrue()
+        assertThat(receivedMessage.control.extensions.testExtension).isTrue()
+    }
+
+    @ParameterizedTest
+    @MethodSource("protocolVersionsWithoutExtensionSupport")
+    fun `control extension message not sent to peer on connection without extension support`(protocol: PubsubProtocol) {
+        val test = TwoRoutersTest(protocol = protocol)
+
+        // Should not receive control extension message on versions without extension support
+        assertThrows<TimeoutException> {
+            test.mockRouter.waitForMessage(
+                { it.hasControl() && it.control.hasExtensions() },
+                DEFAULT_WAIT_TIMEOUT_IN_MILLIS
+            )
+        }
+    }
+
+    @Test
+    fun `control extension message contains all supported extensions flags`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        val receivedMessage = test.mockRouter.waitForMessage(
+            { it.hasControl() && it.control.hasExtensions() },
+            2000L
+        )
+
+        val extensions = receivedMessage.control.extensions
+
+        // Verify both extension flags are set
+        assertThat(extensions.hasPartialMessages()).isTrue()
+        assertThat(extensions.partialMessages).isTrue()
+        assertThat(extensions.hasTestExtension()).isTrue()
+        assertThat(extensions.testExtension).isTrue()
+    }
+
+    @Test
+    fun `extension state tracks that we sent control extension to peer`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        // Wait for control extension message to be sent
+        test.mockRouter.waitForMessage(
+            { it.hasControl() && it.control.hasExtensions() },
+            DEFAULT_WAIT_TIMEOUT_IN_MILLIS
+        )
+
+        // Should be tracked in state
+        assertThat(test.gossipRouter.gossipExtensionsState.hasSentExtensionControlTo(test.router2.peerId)).isTrue()
+    }
+
+    @Test
+    fun `control extension sent state cleared on peer disconnect`() {
+        val test = TwoRoutersTest(
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        // Wait for control extension message
+        test.mockRouter.waitForMessage(
+            { it.hasControl() && it.control.hasExtensions() },
+            DEFAULT_WAIT_TIMEOUT_IN_MILLIS
+        )
+
+        // Verify it's tracked
+        assertThat(test.gossipRouter.gossipExtensionsState.hasSentExtensionControlTo(test.router2.peerId)).isTrue()
+
+        // Disconnect
+        test.connection.disconnect()
+
+        // Should be cleared from sent tracking
+        assertThat(test.gossipRouter.gossipExtensionsState.hasSentExtensionControlTo(test.router2.peerId)).isFalse()
+    }
+
     companion object {
+        @JvmStatic
+        fun protocolVersionsWithExtensionSupport() = listOf(
+            PubsubProtocol.Gossip_V_1_3
+        )
+
+        @JvmStatic
+        fun protocolVersionsWithoutExtensionSupport() = listOf(
+            PubsubProtocol.Gossip_V_1_1,
+            PubsubProtocol.Gossip_V_1_2
+        )
+
         val testExtensionMessage: Rpc.TestExtension = Rpc.TestExtension.newBuilder().build()
 
         val rpcMessageWithControlExtensions = Rpc.RPC.newBuilder().setControl(
@@ -107,7 +208,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
             assertThrows<TimeoutException> {
                 test.mockRouter.waitForMessage(
                     { it.hasTestExtension() },
-                    500L
+                    DEFAULT_WAIT_TIMEOUT_IN_MILLIS
                 )
             }
         }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/GossipExtensionsMessageHandlingTest.kt
@@ -25,7 +25,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
     }
 
     @Test
-    fun `extension messages sent to peer prior to sending extension control messages are ignored`() {
+    fun `extension messages sent to peer prior to sending control extensions messages are ignored`() {
         val test = TwoRoutersTest(
             protocol = PubsubProtocol.Gossip_V_1_3
         )
@@ -35,7 +35,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
     }
 
     @Test
-    fun `extension message flow with extension control message before actual extension message`() {
+    fun `extension message flow with control extensions message before actual extension message`() {
         val test = TwoRoutersTest(
             protocol = PubsubProtocol.Gossip_V_1_3
         )
@@ -50,7 +50,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
     }
 
     @Test
-    fun `extension message flow with extension control and extension message in the same rpc message`() {
+    fun `extension message flow with control extensions and extension message in the same rpc message`() {
         val test = TwoRoutersTest(
             protocol = PubsubProtocol.Gossip_V_1_3
         )
@@ -60,7 +60,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
     }
 
     @Test
-    fun `remove peer extension control map when disconnecting`() {
+    fun `remove peer control extensions map when disconnecting`() {
         val test = TwoRoutersTest(
             protocol = PubsubProtocol.Gossip_V_1_3
         )
@@ -144,7 +144,7 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
         )
 
         // Should be tracked in state
-        assertThat(test.gossipRouter.gossipExtensionsState.hasSentExtensionControlTo(test.router2.peerId)).isTrue()
+        assertThat(test.gossipRouter.gossipExtensionsState.hasSentControlExtensionsTo(test.router2.peerId)).isTrue()
     }
 
     @Test
@@ -160,13 +160,13 @@ class GossipExtensionsMessageHandlingTest : GossipTestsBase() {
         )
 
         // Verify it's tracked
-        assertThat(test.gossipRouter.gossipExtensionsState.hasSentExtensionControlTo(test.router2.peerId)).isTrue()
+        assertThat(test.gossipRouter.gossipExtensionsState.hasSentControlExtensionsTo(test.router2.peerId)).isTrue()
 
         // Disconnect
         test.connection.disconnect()
 
         // Should be cleared from sent tracking
-        assertThat(test.gossipRouter.gossipExtensionsState.hasSentExtensionControlTo(test.router2.peerId)).isFalse()
+        assertThat(test.gossipRouter.gossipExtensionsState.hasSentControlExtensionsTo(test.router2.peerId)).isFalse()
     }
 
     companion object {


### PR DESCRIPTION
The overall logic for sending control extension messages to remote peers is simple:
- always report support for all extensions (finer-grained control to be implemented as part of https://github.com/libp2p/jvm-libp2p/issues/441)
- control extension message is sent whenever a new peer connects or when we are subscribing to a topic (to handle incoming and outgoing connections)
- `GossipExtensionsState` class was added to `GossipRouter` to help keep track of which peers our node has already sent a control extension message to, to avoid sending it again.
- When a peer disconnects, we clear the information associated with that peer from `GossipExtensionsState`
- Control extensions messages are only sent when the gossipsub protocol version supports it (1.3+)

part of #436