### PR TITLE
Fix ConnectionClosedException propagating uncaught to Netty event loop

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
@@ -32,13 +32,20 @@ class MuxChannel<TData>(
         initializer(this)
     }
 
+    @Suppress("SwallowedException")
     override fun doWrite(buf: ChannelOutboundBuffer) {
         while (true) {
             val msg = buf.current() ?: break
+            if (localDisconnected) {
+                // Must not throw from doWrite — exceptions escape uncaught to the Netty event loop.
+                // Wrap buf.remove() defensively: in some Netty versions promise listeners triggered
+                // by buf.remove() can propagate back through it.
+                try {
+                    buf.remove(ConnectionClosedException("The stream was closed for writing locally: $id"))
+                } catch (e: Throwable) { }
+                continue
+            }
             try {
-                if (localDisconnected) {
-                    throw ConnectionClosedException("The stream was closed for writing locally: $id")
-                }
                 // the msg is released by both onChildWrite and buf.remove() so we need to retain
                 // however it is still to be confirmed that no buf leaks happen here TODO
                 ReferenceCountUtil.retain(msg)

--- a/libp2p/src/test/kotlin/io/libp2p/mux/MuxHandlerAbstractTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/MuxHandlerAbstractTest.kt
@@ -6,6 +6,7 @@ import io.libp2p.core.StreamHandler
 import io.libp2p.etc.types.fromHex
 import io.libp2p.etc.types.getX
 import io.libp2p.etc.types.toHex
+import io.libp2p.etc.util.netty.mux.MuxChannel
 import io.libp2p.etc.util.netty.mux.RemoteWriteClosed
 import io.libp2p.etc.util.netty.nettyInitializer
 import io.libp2p.mux.MuxHandlerAbstractTest.AbstractTestMuxFrame.Flag.*
@@ -439,6 +440,26 @@ abstract class MuxHandlerAbstractTest {
 
         assertThrows(Exception::class.java) {
             handler.ctx.writeAndFlush(allocateMessage("42")).sync()
+        }
+    }
+
+    @Test
+    fun `write with localDisconnected should fail promise without throwing from doWrite`() {
+        val handler = openStreamLocal()
+        readFrameOrThrow()
+
+        // Simulate the state between localDisconnected=true and deactivate() in doDisconnect(),
+        // which is when a queued WriteTask can reach doWrite with localDisconnected=true while
+        // the channel is still active (flush0 would take the "not-yet-connected" path otherwise).
+        @Suppress("UNCHECKED_CAST")
+        (handler.ctx.channel() as MuxChannel<ByteBuf>).localDisconnected = true
+
+        val writeFuture = handler.ctx.writeAndFlush(allocateMessage("42"))
+        ech.runPendingTasks()
+
+        assertTrue(writeFuture.isDone)
+        assertThrows(ConnectionClosedException::class.java) {
+            writeFuture.sync()
         }
     }
 


### PR DESCRIPTION
## Summary

- In Netty 4.2.x, writing to a locally-disconnected stream caused a `ConnectionClosedException` to escape `MuxChannel.doWrite()` uncaught, surfacing as spurious `PLEASE FIX OR REPORT` noise in Teku logs.
- The original `throw`+`catch` pattern caught the exception locally, but the subsequent `buf.remove(cause)` call — sitting outside any try/catch — can propagate exceptions back through promise-listener callbacks in certain Netty versions.
- Fix: move the `localDisconnected` check outside the try/catch and wrap `buf.remove(cause)` defensively so nothing can escape `doWrite()`. Pending write promises are still properly failed with `ConnectionClosedException`.

## Test plan

- [x] Added regression test in `MuxHandlerAbstractTest` that sets `localDisconnected = true` while the channel is still active (simulating the window between flag assignment and `deactivate()` in `doDisconnect()`), calls `writeAndFlush`, and asserts the write future is failed with `ConnectionClosedException` — no uncaught exception
- [x] Run `./gradlew :libp2p:test --tests "io.libp2p.mux.*"` — all 34 mux tests pass