### PR TITLE
Wire per-topic partial-messages SubOpts flags (step 1)

### DIFF
--- a/docs/partial-messages.md
+++ b/docs/partial-messages.md
@@ -1,0 +1,450 @@
+# Gossipsub Partial Messages — Design Document
+
+Status: **Draft / MVP design**
+Tracking issue: [libp2p/jvm-libp2p#435](https://github.com/libp2p/jvm-libp2p/issues/435)
+Last updated: see `git log -- docs/partial-messages.md`
+
+This document is the source of truth for the jvm-libp2p implementation of the
+gossipsub partial-messages extension. It captures the scope, the jvm-libp2p ↔
+client responsibility boundary, the public API, routing semantics, and the
+implementation plan. It is a **living document** — append to the decision log
+(§9) when we revise anything.
+
+---
+
+## 1. Scope and non-goals
+
+### In scope (MVP)
+
+- Full wire-level support for the `PartialMessagesExtension` RPC:
+  - Per-topic negotiation via `SubOpts.requestsPartial` / `SubOpts.supportsSendingPartial`.
+  - Inbound and outbound handling of `RPC.partial`.
+  - Both metadata-only and payload-only variants in both directions.
+- A Kotlin API that lets a client (Teku) plug in its own per-peer state,
+  metadata encoding, group-ID generation, part-level validation, and publish
+  decisions.
+- Integration with the existing gossipsub routing rules:
+  - Suppress full-message send to peers that requested partial on that topic.
+  - Suppress IDONTWANT to peers we request partial from.
+  - Replace IHAVE with an `onEmitGossip` callback for partial-capable peers
+    in the lazy-push loop.
+- Per-group lifecycle (TTL in heartbeats, DoS caps on peer-initiated groups).
+- A side-channel `peerFeedback` API so the client can drive peer scoring
+  explicitly instead of via callback return values.
+
+### Non-goals (deferred, but documented for future)
+
+- `interop-test-client` partial-messages support. Deferred; see §7 for notes.
+- Partial-specific peer-scoring rules beyond what the Extensions handshake
+  already enforces. Spec is silent; match go-libp2p (no scoring) for MVP.
+- Topic-level "partial-only" mode. Spec explicitly defers this to a future
+  extension.
+- Reassembling a full `Message` and re-entering the normal gossip flow. MVP
+  delivers parts upward to the application only; the application is free to
+  never republish a reconstructed full message (matches Ethereum PeerDAS).
+- New wire messages. Spec and go-libp2p use the single
+  `PartialMessagesExtension` for both lazy-push and payload delivery — no
+  `partialIHAVE` / `partialIWANT`.
+
+---
+
+## 2. Reference pins
+
+The partial-messages spec is **Lifecycle 1A (Working Draft)** and may change.
+When revising this document, update these pins.
+
+| Source | Pin | Location |
+|---|---|---|
+| libp2p/specs | merge commit `6b6203ee` (PR #685, merged 2026-02-26) | `pubsub/gossipsub/partial-messages.md` |
+| libp2p/go-libp2p-pubsub | `master` at time of MVP (note in decision log when pinned) | `extensions.go`, `partialmessages/partialmsgs.go`, `gossipsub.go`, `pubsub.go` |
+| libp2p/test-plans gossipsub-interop | `master` | `gossipsub-interop/go-libp2p/experiment.go`, `main.go` |
+| OffchainLabs/prysm | branch `prysm/partial-cells-current`, latest seen `e8480a86` (2026-03-31) | `beacon-chain/p2p/partialdatacolumnbroadcaster/`, `consensus-types/blocks/partialdatacolumn.go`, `proto/prysm/v1alpha1/partial_data_columns.proto` |
+
+### Related in-flight spec work (watch)
+
+- libp2p/specs#681 — Choke extension.
+- libp2p/specs#699 — Topic table.
+- libp2p/specs#706 — Gossipsub v1.4.
+- libp2p/specs#654 — Message preamble.
+
+None directly modify partial-messages, but v1.4 and message-preamble overlap
+in motivation.
+
+---
+
+## 3. Responsibility boundary (jvm-libp2p ↔ client)
+
+The one-line model:
+
+> **jvm-libp2p is a transport + per-peer bookkeeper for opaque partial-message
+> RPCs. The client (Teku) owns everything about what those bytes mean, when a
+> group is "complete", and who gets what.**
+
+| Concern | jvm-libp2p | Client (Teku) |
+|---|---|---|
+| v1.3 Control Extensions handshake | ✅ (done on this branch) | — |
+| `SubOpts.requestsPartial` / `supportsSendingPartial` wire handling | ✅ | — |
+| Per-peer partial-capability state (node-level and topic-level) | ✅ | — |
+| Per-`(topic, groupID)` state container, TTL GC, DoS caps | ✅ | — |
+| Routing: suppress full-msg send to partial-requesting peers | ✅ | — |
+| Routing: suppress IDONTWANT to peers we request partial from | ✅ | — |
+| Routing: replace IHAVE with `onEmitGossip` for partial peers | ✅ | — |
+| Wire framing of `PartialMessagesExtension` in/out | ✅ | — |
+| Spec MUST: omit `partialMessage` if peer supports-but-didn't-request | ✅ | — |
+| `partsMetadata` encoding (bitmap / Bloom / whatever) | ❌ opaque | ✅ |
+| `groupID` generation | ❌ opaque | ✅ |
+| Merging incoming `partsMetadata` into local per-peer view | ❌ | ✅ |
+| Deciding which parts to send to which peer | ❌ | ✅ (`PublishActionsFn`) |
+| Reassembling a full message | ❌ never | ✅ |
+| Validating individual parts (e.g. KZG) | ❌ | ✅ (inside `onIncomingRpc`) |
+| Detecting "group complete" and delivering upward | ❌ | ✅ |
+| Per-part peer scoring (spammy parts, etc.) | ❌ MVP | Future, in coordination |
+
+Rationale for each line is grounded in go-libp2p's and Prysm's current
+behaviour — see §9 and the research notes that produced this document.
+
+---
+
+## 4. Public API (jvm-libp2p surface)
+
+### 4.1 Builder wiring
+
+```kotlin
+GossipRouterBuilder().apply {
+    enabledGossipExtensions(GossipExtension.PARTIAL_MESSAGES)
+    partialMessagesHandler = MyTekuPartialMessagesHandler()  // new
+}
+```
+
+- The `GossipExtension.PARTIAL_MESSAGES` feature flag stays as the capability
+  switch (already wired).
+- `partialMessagesHandler: PartialMessagesHandler<*>?` is a new optional
+  field on the builder. Null + flag enabled = build-time error.
+
+### 4.2 Client-supplied handler
+
+```kotlin
+interface PartialMessagesHandler<PeerState> {
+
+    /**
+     * Called on every inbound PartialMessagesExtension RPC on the pubsub
+     * event thread. MUST be fast and non-blocking: dispatch heavy work
+     * (decoding, validation) to your own executor.
+     *
+     * Any of rpc.partialMessage and rpc.partsMetadata may be absent; all
+     * four combinations are valid.
+     */
+    fun onIncomingRpc(
+        from: PeerId,
+        peerStates: Map<PeerId, PeerState>,
+        rpc: Rpc.PartialMessagesExtension
+    )
+
+    /**
+     * Called once per group during the gossipsub heartbeat, for gossip
+     * targets that are partial-capable. The client typically responds by
+     * calling publishPartial(...) for the same (topic, groupId).
+     */
+    fun onEmitGossip(
+        topic: Topic,
+        groupId: ByteArray,
+        gossipPeers: Collection<PeerId>,
+        peerStates: Map<PeerId, PeerState>
+    )
+}
+```
+
+Notes:
+- `PeerState` is fully generic. The library stores it per
+  `(topic, groupId, peerId)` and never interprets it.
+- Both callbacks run on the pubsub event thread. Document prominently.
+
+### 4.3 Publishing
+
+```kotlin
+fun interface PublishActionsFn<PeerState> {
+    fun decide(
+        peerStates: Map<PeerId, PeerState>,
+        peerRequestsPartial: (PeerId) -> Boolean
+    ): Sequence<Pair<PeerId, PublishAction<PeerState>>>
+}
+
+data class PublishAction<PeerState>(
+    val partialMessage: ByteArray? = null,
+    val partsMetadata: ByteArray? = null,
+    val nextPeerState: PeerState? = null,   // library applies atomically
+    val error: Throwable? = null
+)
+
+// Entry point on the Gossip facade
+fun Gossip.publishPartial(
+    topic: Topic,
+    groupId: ByteArray,
+    actions: PublishActionsFn<*>
+): CompletableFuture<Unit>
+```
+
+Key API differences vs. go-libp2p (deliberate):
+
+1. **No in-place map mutation.** `PublishAction.nextPeerState` is applied
+   atomically by the library per peer, instead of asking the client to
+   mutate `Map<PeerId, PeerState>` inside the iterator. Prysm has fixed race
+   bugs in the in-place pattern (see commits on `prysm/partial-cells-current`,
+   Mar 31 2026); Kotlin's single-threaded event loop makes the atomic-return
+   shape natural.
+2. **`Unit`-returning callbacks.** Errors do not drive scoring; see §4.4.
+
+### 4.4 Peer feedback (scoring side-channel)
+
+```kotlin
+interface PartialMessagesPeerFeedback {
+    fun reportFeedback(topic: Topic, peer: PeerId, kind: FeedbackKind)
+}
+
+enum class FeedbackKind { USEFUL, INVALID, IGNORED }
+```
+
+The handler receives a `PartialMessagesPeerFeedback` instance (via
+constructor or context object — TBD during implementation) and uses it to
+drive peer score adjustments. This mirrors Prysm's `peerFeedback` pattern.
+`INVALID` hooks into the existing `notifyRouterMisbehavior` path.
+
+### 4.5 Topic options
+
+Subscribing to a topic with partial-message flags:
+
+```kotlin
+gossip.subscribe(topic, handler,
+    requestsPartial = true,
+    supportsSendingPartial = true)   // implied if requestsPartial = true
+```
+
+Go-libp2p exposes `RequestPartialMessages()` and `SupportsPartialMessages()`
+as separate topic options. In Prysm's real integration, only
+`RequestPartialMessages()` is ever used; the "supports-but-doesn't-request"
+half is currently unexercised. MVP supports both flags in the API but only
+the `requests` path needs end-to-end testing.
+
+---
+
+## 5. Routing rules (inside `GossipRouter`)
+
+Three modifications to the existing routing, all behind
+`partialMessagesEnabled()` and the per-peer handshake state.
+
+### 5.1 Full-message suppression
+
+When broadcasting a `Message` for topic `T` to peer `P`:
+- If `gossipExtensionsState.peerSupportsPartialMessages(P)` **and**
+  `partialTopicState.peerRequestsPartial(P, T)` → **do not** send the full
+  message to `P`. The client is responsible for pushing parts via
+  `publishPartial(...)`.
+- This filter applies in `broadcastInbound` and `broadcastOutbound`, before
+  messages are queued into `GossipRpcPartsQueue`.
+- Spec MUST (§Wire rules): if peer supports sending partial but did *not*
+  request, we still send the full message, but when we send a
+  `PartialMessagesExtension` to that peer we MUST omit `partialMessage`.
+
+### 5.2 IDONTWANT suppression
+
+When emitting IDONTWANT for a message on topic `T`:
+- If, for peer `P`, we `iRequestPartial(T)` **and**
+  `peerSupportsSendingPartial(P, T)` → skip IDONTWANT to `P`.
+- go-libp2p: `gossipsub.go:892-904`.
+
+### 5.3 IHAVE replacement with `onEmitGossip`
+
+During gossipsub heartbeat lazy-push:
+- Partition the selected IHAVE targets into `fullPeers` and
+  `partialPeers = { p | iSupportSendingPartial(T) ∧ peerRequestsPartial(p, T) }`.
+- Do not enqueue IHAVE for `partialPeers`.
+- After the normal loop, for every locally-initiated group under `T`, call
+  `handler.onEmitGossip(T, groupId, partialPeers, peerStatesForGroup)` once.
+- go-libp2p: `gossipsub.go:2018-2074`.
+
+---
+
+## 6. State and lifecycle
+
+### 6.1 Per-topic-per-peer partial-capability state
+
+Per-peer flags per topic, updated from every inbound `SubOpts` (where
+`subscribe = true`):
+
+- `requestsPartial: Boolean`
+- `supportsSendingPartial: Boolean`
+
+Spec + go-libp2p coercion: on receive, store
+`supportsSendingPartial := requestsPartial || supportsSendingPartial`.
+
+MUST ignore both flags on `SubOpts` with `subscribe = false`.
+
+### 6.2 Per-`(topic, groupID)` group state
+
+```
+GroupState {
+    ttlInHeartbeats: Int     // counts down each heartbeat, GC at 0
+    peerInitiated: Boolean   // true if first seen from a peer, not us
+    peerStates: Map<PeerId, PeerState>   // app-opaque
+}
+```
+
+- Stored in a plain `HashMap` — not thread-safe; access is serialised on the
+  pubsub event loop (per the project-wide invariant; do **not** use
+  `ConcurrentHashMap`).
+- TTL reset whenever `publishPartial(topic, groupId, …)` is called for the
+  group.
+- GC on `ttl == 0` **or** `peerStates` empty.
+
+### 6.3 DoS caps (match go-libp2p defaults)
+
+Applies only to **peer-initiated** groups (first touched from an inbound
+RPC, not via `publishPartial`).
+
+| Cap | Default | Where |
+|---|---|---|
+| `peerInitiatedGroupLimitPerTopic` | 255 | Across all peers, per topic |
+| `peerInitiatedGroupLimitPerTopicPerPeer` | 8 | Per (topic, peer) |
+
+Over-cap: log and drop the RPC. No disconnect. No score penalty (match go;
+revise if spec adds guidance).
+
+### 6.4 Cleanup hooks
+
+- Peer disconnect → remove all `peerStates[peer]` entries across groups.
+- Unsubscribe (we leave a topic) → drop all group state for that topic.
+- Heartbeat → decrement TTLs, GC expired groups.
+
+---
+
+## 7. Known gaps vs. full spec
+
+Explicitly deferred in MVP; listed here so future work can pick them up.
+
+1. **Validator pipeline for partial RPCs** — bypassed entirely (matches
+   go-libp2p). Client validates inside `onIncomingRpc`.
+2. **Scoring rules for partial misbehaviour** — spec silent, go silent. MVP
+   only scores via the existing `notifyRouterMisbehavior` path plus the
+   client's `peerFeedback` calls.
+3. **Message-ID of reassembled full messages** — spec silent. MVP does not
+   reassemble at all; the reconstructed message never re-enters gossip.
+4. **Topic-level "partial-only" mode** — spec explicitly defers; no
+   implementation.
+5. **`SupportsPartialMessages()`-only (support without request) path** —
+   supported by the API, but Prysm doesn't exercise it and we don't have an
+   end-to-end test for it. Flag if we ship without coverage.
+6. **Fanout peers in publish** — MVP does mesh peers (+ fanout fallback if
+   mesh empty), mirroring go-libp2p's `MeshPeers`. Fanout specifically for
+   partial is not independently exercised.
+7. **`interop-test-client`** — deferred. Future work should:
+   - Implement `PartialMessagesHandler<TrivialBitmapState>` with SSZ-like
+     bitlists for `partsMetadata`.
+   - Test the 4-combo matrix (payload+meta / meta-only / payload-only /
+     neither) on both send and receive.
+   - Test mixed-peer topic: one partial-enabled node, one full-only; verify
+     full-only path still works end-to-end.
+   - Test `ControlExtensions` handshake ordering: extension RPCs arriving
+     before the handshake completes must be ignored.
+
+---
+
+## 8. Implementation plan
+
+Order chosen so an end-to-end partial round-trip works before any of the
+fragile routing rules are touched. Each step is independently testable and
+mergeable.
+
+Mirror this checklist in issue #435.
+
+- [ ] **Step 1** — Per-topic `SubOpts` flag plumbing. Outbound: flags added
+      to subscribe announce RPCs. Inbound: parse flags into a
+      `PartialTopicState` (`Map<Topic, Map<PeerId, PartialSubFlags>>`).
+      Coercion rule applied on receive. Flags ignored on `subscribe=false`.
+- [ ] **Step 2** — `PartialMessagesHandler<PeerState>` interface,
+      `PublishAction<PeerState>` (with `nextPeerState`),
+      `PublishActionsFn<PeerState>`, `PartialMessagesPeerFeedback`, and
+      `GroupState` container with TTL + DoS caps. No routing yet.
+- [ ] **Step 3** — Inbound `RPC.partial` dispatch: replace the stub at
+      `GossipRouter.kt:476` with the full flow (validate caps, create/update
+      group state, call `onIncomingRpc`).
+- [ ] **Step 4** — Outbound `publishPartial(...)` on the `Gossip` facade;
+      route through `GossipRpcPartsQueue` (do **not** bypass — PR #433 got
+      this wrong). Enforce the "omit `partialMessage` when peer supports but
+      didn't request" MUST.
+- [ ] **Step 5** — End-to-end integration test with a trivial bitmap-based
+      handler. Exercises Steps 1-4 before any routing changes.
+- [ ] **Step 6** — Routing: full-message suppression (§5.1).
+- [ ] **Step 7** — Routing: IDONTWANT suppression (§5.2).
+- [ ] **Step 8** — Heartbeat tick + TTL GC + cleanup hooks (§6.4).
+- [ ] **Step 9** — Routing: IHAVE replacement with `onEmitGossip` (§5.3).
+- [ ] **Step 10** — Simulator scenario + mixed-peer interop test (partial +
+      non-partial nodes on the same topic).
+
+---
+
+## 9. Decision log
+
+Append entries here when design choices change. Keep most-recent on top.
+
+### 2026-04-20 — Initial design
+
+- Scope, boundary, and API agreed per research summarised in this document.
+- `PublishAction` returns `nextPeerState` rather than asking the client to
+  mutate a shared map in place. Motivation: cleaner Kotlin ergonomics,
+  avoids the category of race that Prysm's
+  `prysm/partial-cells-current` fixed on 2026-03-31.
+- Peer scoring feedback lives on a side-channel
+  `PartialMessagesPeerFeedback`, not on callback return values. Matches
+  Prysm's `peerFeedback` pattern.
+- MVP does not ship `interop-test-client` support; see §7.7 for the future
+  checklist.
+- DoS caps pinned to go-libp2p defaults (255 / 8).
+- Spec pinned to libp2p/specs#685 merge `6b6203ee`. Spec is lifecycle 1A;
+  revise this document when spec revisions land.
+
+### Open questions to resolve during implementation
+
+- Exact wiring of `PartialMessagesPeerFeedback` — constructor arg on the
+  handler, or a context object passed to each callback? Decide during
+  Step 2.
+- Whether `publishPartial` on the `Gossip` facade takes a single
+  `(topic, groupId)` or supports batched `Seq<(topic, groupId)>`. Prysm
+  calls per-topic and iterates; MVP will match.
+- Exact return type of `publishPartial` — `CompletableFuture<Unit>` follows
+  jvm-libp2p convention; finalise during Step 4.
+
+---
+
+## 10. References
+
+### Spec
+
+- [libp2p/specs — Gossipsub Partial Messages spec (PR #685)](https://github.com/libp2p/specs/pull/685)
+- [libp2p/specs — partial-messages.md @ 6b6203ee](https://github.com/libp2p/specs/blob/6b6203ee16ef2e01e6b86fc8f6c3fae0d1c6490e/pubsub/gossipsub/partial-messages.md)
+
+### Related in-flight spec work
+
+- [libp2p/specs#681 — Choke extension](https://github.com/libp2p/specs/pull/681)
+- [libp2p/specs#699 — Topic table](https://github.com/libp2p/specs/pull/699)
+- [libp2p/specs#706 — Gossipsub v1.4](https://github.com/libp2p/specs/pull/706)
+- [libp2p/specs#654 — Message preamble](https://github.com/libp2p/specs/pull/654)
+
+### Implementations
+
+- [go-libp2p-pubsub — extensions.go](https://github.com/libp2p/go-libp2p-pubsub/blob/master/extensions.go)
+- [go-libp2p-pubsub — partialmessages/partialmsgs.go](https://github.com/libp2p/go-libp2p-pubsub/blob/master/partialmessages/partialmsgs.go)
+- [go-libp2p-pubsub — gossipsub.go](https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go)
+- [go-libp2p-pubsub — pubsub.go](https://github.com/libp2p/go-libp2p-pubsub/blob/master/pubsub.go)
+- [OffchainLabs/prysm — branch `prysm/partial-cells-current`](https://github.com/OffchainLabs/prysm/tree/prysm/partial-cells-current)
+  - [`beacon-chain/p2p/partialdatacolumnbroadcaster/`](https://github.com/OffchainLabs/prysm/tree/prysm/partial-cells-current/beacon-chain/p2p/partialdatacolumnbroadcaster)
+  - [`consensus-types/blocks/partialdatacolumn.go`](https://github.com/OffchainLabs/prysm/blob/prysm/partial-cells-current/consensus-types/blocks/partialdatacolumn.go)
+  - [`proto/prysm/v1alpha1/partial_data_columns.proto`](https://github.com/OffchainLabs/prysm/blob/prysm/partial-cells-current/proto/prysm/v1alpha1/partial_data_columns.proto)
+
+### Interop testing
+
+- [libp2p/test-plans — gossipsub-interop experiment.go](https://github.com/libp2p/test-plans/blob/master/gossipsub-interop/go-libp2p/experiment.go)
+- [libp2p/test-plans — gossipsub-interop main.go](https://github.com/libp2p/test-plans/blob/master/gossipsub-interop/go-libp2p/main.go)
+
+### Tracking
+
+- [libp2p/jvm-libp2p#435 — Partial messages tracking issue](https://github.com/libp2p/jvm-libp2p/issues/435)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -186,6 +186,7 @@ abstract class AbstractRouter(
             val subscriptions = msg.subscriptionsList.map {
                 // Per partial-messages spec: flags MUST be ignored on subscribe=false, and the
                 // receiving side coerces supportsSendingPartial := requestsPartial || supportsSendingPartial.
+                // The coercion rule is also applied on the outbound side by GossipRouter.
                 PubsubSubscription(
                     topic = it.topicid,
                     subscribe = it.subscribe,
@@ -321,6 +322,19 @@ abstract class AbstractRouter(
         }
     }
 
+    /**
+     * Applies a single filtered inbound subscription to the router's state.
+     *
+     * Called once per `SubOpts` on the pubsub event loop, after
+     * [SubscriptionFilter.filterIncomingSubscriptions] has run. Subclasses may
+     * override to react to subscription state changes (for example, to track
+     * per-topic capability flags). Overrides MUST call `super` so that
+     * [peersTopics] stays in sync.
+     *
+     * [msg] carries the protocol-level flags already normalised by the caller:
+     * for `subscribe=false` frames, extension flags are zeroed before reaching
+     * this method.
+     */
     protected open fun handleMessageSubscriptions(peer: PeerHandler, msg: PubsubSubscription) {
         if (msg.subscribe) {
             peersTopics.add(peer, msg.topic)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -147,9 +147,20 @@ abstract class AbstractRouter(
     override fun onPeerActive(peer: PeerHandler) {
         val partsQueue = pendingRpcParts.getQueue(peer)
         subscribedTopics.forEach {
-            partsQueue.addSubscribe(it)
+            enqueueSubscribe(partsQueue, it)
         }
         flushPending(peer)
+    }
+
+    /**
+     * Enqueues a subscribe announcement for [topic] onto [partsQueue].
+     *
+     * The default implementation emits a bare subscribe with no per-topic options.
+     * Subclasses (e.g. GossipRouter) override this to attach per-topic options
+     * such as partial-message flags.
+     */
+    protected open fun enqueueSubscribe(partsQueue: RpcPartsQueue, topic: Topic) {
+        partsQueue.addSubscribe(topic)
     }
 
     protected open fun notifyMalformedMessage(peer: PeerHandler) {}
@@ -172,7 +183,16 @@ abstract class AbstractRouter(
         }
 
         try {
-            val subscriptions = msg.subscriptionsList.map { PubsubSubscription(it.topicid, it.subscribe) }
+            val subscriptions = msg.subscriptionsList.map {
+                // Per partial-messages spec: flags MUST be ignored on subscribe=false, and the
+                // receiving side coerces supportsSendingPartial := requestsPartial || supportsSendingPartial.
+                PubsubSubscription(
+                    topic = it.topicid,
+                    subscribe = it.subscribe,
+                    requestsPartial = it.subscribe && it.requestsPartial,
+                    supportsSendingPartial = it.subscribe && (it.supportsSendingPartial || it.requestsPartial)
+                )
+            }
             subscriptionFilter
                 .filterIncomingSubscriptions(subscriptions, peersTopics.getByFirst(peer))
                 .forEach { handleMessageSubscriptions(peer, it) }
@@ -301,7 +321,7 @@ abstract class AbstractRouter(
         }
     }
 
-    private fun handleMessageSubscriptions(peer: PeerHandler, msg: PubsubSubscription) {
+    protected open fun handleMessageSubscriptions(peer: PeerHandler, msg: PubsubSubscription) {
         if (msg.subscribe) {
             peersTopics.add(peer, msg.topic)
         } else {
@@ -319,7 +339,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun subscribe(topic: Topic) {
-        activePeers.forEach { pendingRpcParts.getQueue(it).addSubscribe(topic) }
+        activePeers.forEach { enqueueSubscribe(pendingRpcParts.getQueue(it), topic) }
         subscribedTopics += topic
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRouter.kt
@@ -13,7 +13,12 @@ typealias Topic = String
 typealias MessageId = WBytes
 typealias PubsubMessageFactory = (Rpc.Message) -> PubsubMessage
 
-data class PubsubSubscription(val topic: Topic, val subscribe: Boolean)
+data class PubsubSubscription(
+    val topic: Topic,
+    val subscribe: Boolean,
+    val requestsPartial: Boolean = false,
+    val supportsSendingPartial: Boolean = false
+)
 
 interface PubsubMessage {
     val protobufMessage: Rpc.Message

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -9,14 +9,27 @@ interface RpcPartsQueue {
     fun addPublish(message: Rpc.Message)
 
     fun addSubscribe(topic: Topic) {
-        addSubscription(topic, SubscriptionStatus.Subscribed)
+        addSubscribe(topic, requestsPartial = false, supportsSendingPartial = false)
+    }
+
+    fun addSubscribe(topic: Topic, requestsPartial: Boolean, supportsSendingPartial: Boolean) {
+        addSubscription(topic, SubscriptionStatus.Subscribed, requestsPartial, supportsSendingPartial)
     }
 
     fun addUnsubscribe(topic: Topic) {
-        addSubscription(topic, SubscriptionStatus.Unsubscribed)
+        addSubscription(topic, SubscriptionStatus.Unsubscribed, requestsPartial = false, supportsSendingPartial = false)
     }
 
-    fun addSubscription(topic: Topic, status: SubscriptionStatus)
+    fun addSubscription(topic: Topic, status: SubscriptionStatus) {
+        addSubscription(topic, status, requestsPartial = false, supportsSendingPartial = false)
+    }
+
+    fun addSubscription(
+        topic: Topic,
+        status: SubscriptionStatus,
+        requestsPartial: Boolean,
+        supportsSendingPartial: Boolean
+    )
 
     fun takeMerged(): List<Rpc.RPC>
 }
@@ -38,11 +51,20 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         }
     }
 
-    protected data class SubscriptionPart(val topic: Topic, val status: RpcPartsQueue.SubscriptionStatus) : AbstractPart {
+    protected data class SubscriptionPart(
+        val topic: Topic,
+        val status: RpcPartsQueue.SubscriptionStatus,
+        val requestsPartial: Boolean = false,
+        val supportsSendingPartial: Boolean = false
+    ) : AbstractPart {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
-            builder.addSubscriptionsBuilder().apply {
-                setTopicid(topic)
-                setSubscribe(status == RpcPartsQueue.SubscriptionStatus.Subscribed)
+            val subBuilder = builder.addSubscriptionsBuilder()
+            subBuilder.topicid = topic
+            subBuilder.subscribe = status == RpcPartsQueue.SubscriptionStatus.Subscribed
+            // Per spec: partial flags MUST NOT be sent on unsubscribe (subscribe=false).
+            if (status == RpcPartsQueue.SubscriptionStatus.Subscribed) {
+                if (requestsPartial) subBuilder.requestsPartial = true
+                if (supportsSendingPartial) subBuilder.supportsSendingPartial = true
             }
         }
     }
@@ -57,8 +79,13 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         addPart(PublishPart(message))
     }
 
-    override fun addSubscription(topic: Topic, status: RpcPartsQueue.SubscriptionStatus) {
-        addPart(SubscriptionPart(topic, status))
+    override fun addSubscription(
+        topic: Topic,
+        status: RpcPartsQueue.SubscriptionStatus,
+        requestsPartial: Boolean,
+        supportsSendingPartial: Boolean
+    ) {
+        addPart(SubscriptionPart(topic, status, requestsPartial, supportsSendingPartial))
     }
 
     override fun takeMerged(): List<Rpc.RPC> {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -20,10 +20,6 @@ interface RpcPartsQueue {
         addSubscription(topic, SubscriptionStatus.Unsubscribed, requestsPartial = false, supportsSendingPartial = false)
     }
 
-    fun addSubscription(topic: Topic, status: SubscriptionStatus) {
-        addSubscription(topic, status, requestsPartial = false, supportsSendingPartial = false)
-    }
-
     fun addSubscription(
         topic: Topic,
         status: SubscriptionStatus,

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -153,13 +153,11 @@ open class GossipRouter(
      */
     fun setTopicPartialFlags(topic: Topic, requestsPartial: Boolean, supportsSendingPartial: Boolean) {
         runOnEventThread {
-            if (!requestsPartial && !supportsSendingPartial) {
+            val coerced = PartialSubFlags.coerce(requestsPartial, supportsSendingPartial)
+            if (coerced == PartialSubFlags.NONE) {
                 localTopicPartialFlags -= topic
             } else {
-                localTopicPartialFlags[topic] = PartialSubFlags(
-                    requestsPartial = requestsPartial,
-                    supportsSendingPartial = requestsPartial || supportsSendingPartial
-                )
+                localTopicPartialFlags[topic] = coerced
             }
         }
     }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -134,6 +134,35 @@ open class GossipRouter(
     override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
     val gossipExtensionsState = GossipExtensionsState(gossipExtensionsConfig)
+    val partialSubscriptionState = PartialSubscriptionState()
+
+    /**
+     * Local per-topic subscription options that affect outbound subscribe announcements.
+     * Accessed only on the pubsub event loop.
+     */
+    private val localTopicPartialFlags: MutableMap<Topic, PartialSubFlags> = mutableMapOf()
+
+    /**
+     * Configures the partial-messages flags advertised on this node's subscribe
+     * announcements for [topic]. Must be called before [subscribe] for the flags
+     * to take effect on the initial announcement; a subsequent call will affect
+     * later re-announcements (e.g. on new peer activation).
+     *
+     * Per spec, the send-side also applies the coercion
+     * `supportsSendingPartial := requestsPartial || supportsSendingPartial`.
+     */
+    fun setTopicPartialFlags(topic: Topic, requestsPartial: Boolean, supportsSendingPartial: Boolean) {
+        runOnEventThread {
+            if (!requestsPartial && !supportsSendingPartial) {
+                localTopicPartialFlags -= topic
+            } else {
+                localTopicPartialFlags[topic] = PartialSubFlags(
+                    requestsPartial = requestsPartial,
+                    supportsSendingPartial = requestsPartial || supportsSendingPartial
+                )
+            }
+        }
+    }
 
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
@@ -161,7 +190,26 @@ open class GossipRouter(
         acceptRequestsWhitelist -= peer
         pendingRpcParts.popQueue(peer) // discard them
         gossipExtensionsState.onPeerDisconnected(peer.peerId)
+        partialSubscriptionState.onPeerDisconnected(peer.peerId)
         super.onPeerDisconnected(peer)
+    }
+
+    override fun enqueueSubscribe(partsQueue: RpcPartsQueue, topic: Topic) {
+        val flags = localTopicPartialFlags[topic] ?: PartialSubFlags.NONE
+        partsQueue.addSubscribe(topic, flags.requestsPartial, flags.supportsSendingPartial)
+    }
+
+    override fun handleMessageSubscriptions(peer: PeerHandler, msg: PubsubSubscription) {
+        super.handleMessageSubscriptions(peer, msg)
+        if (msg.subscribe) {
+            partialSubscriptionState.setPeerFlags(
+                msg.topic,
+                peer.peerId,
+                PartialSubFlags(msg.requestsPartial, msg.supportsSendingPartial)
+            )
+        } else {
+            partialSubscriptionState.removePeerFlags(msg.topic, peer.peerId)
+        }
     }
 
     override fun onPeerActive(peer: PeerHandler) {
@@ -615,6 +663,8 @@ open class GossipRouter(
         super.unsubscribe(topic)
         mesh[topic]?.copy()?.forEach { prune(it, topic) }
         mesh -= topic
+        localTopicPartialFlags -= topic
+        partialSubscriptionState.removeTopic(topic)
     }
 
     private fun catchingHeartbeat() {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionState.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionState.kt
@@ -1,0 +1,66 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.PeerId
+import io.libp2p.pubsub.Topic
+
+data class PartialSubFlags(
+    val requestsPartial: Boolean,
+    val supportsSendingPartial: Boolean
+) {
+    companion object {
+        val NONE = PartialSubFlags(requestsPartial = false, supportsSendingPartial = false)
+    }
+}
+
+/**
+ * Per-topic, per-peer partial-messages subscription state.
+ *
+ * Tracks, for each `(topic, peer)`, the remote peer's `requestsPartial` /
+ * `supportsSendingPartial` flags as most recently announced via a subscribe
+ * `SubOpts`. Unsubscribes and peer disconnects drop the corresponding state.
+ *
+ * NOT thread-safe: accessed only on the pubsub event loop.
+ */
+class PartialSubscriptionState {
+
+    private val byTopic: MutableMap<Topic, MutableMap<PeerId, PartialSubFlags>> = mutableMapOf()
+
+    fun setPeerFlags(topic: Topic, peer: PeerId, flags: PartialSubFlags) {
+        if (flags == PartialSubFlags.NONE) {
+            removePeerFlags(topic, peer)
+            return
+        }
+        byTopic.getOrPut(topic) { mutableMapOf() }[peer] = flags
+    }
+
+    fun removePeerFlags(topic: Topic, peer: PeerId) {
+        val peers = byTopic[topic] ?: return
+        peers.remove(peer)
+        if (peers.isEmpty()) byTopic.remove(topic)
+    }
+
+    fun removeTopic(topic: Topic) {
+        byTopic.remove(topic)
+    }
+
+    fun onPeerDisconnected(peer: PeerId) {
+        val emptied = mutableListOf<Topic>()
+        for ((topic, peers) in byTopic) {
+            peers.remove(peer)
+            if (peers.isEmpty()) emptied += topic
+        }
+        emptied.forEach { byTopic.remove(it) }
+    }
+
+    fun peerFlags(topic: Topic, peer: PeerId): PartialSubFlags =
+        byTopic[topic]?.get(peer) ?: PartialSubFlags.NONE
+
+    fun peerRequestsPartial(topic: Topic, peer: PeerId) =
+        peerFlags(topic, peer).requestsPartial
+
+    fun peerSupportsSendingPartial(topic: Topic, peer: PeerId) =
+        peerFlags(topic, peer).supportsSendingPartial
+
+    internal fun snapshot(): Map<Topic, Map<PeerId, PartialSubFlags>> =
+        byTopic.mapValues { (_, v) -> v.toMap() }
+}

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionState.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionState.kt
@@ -9,6 +9,21 @@ data class PartialSubFlags(
 ) {
     companion object {
         val NONE = PartialSubFlags(requestsPartial = false, supportsSendingPartial = false)
+
+        /**
+         * Applies the partial-messages spec coercion
+         * `supportsSendingPartial := requestsPartial || supportsSendingPartial`.
+         *
+         * Per the spec, this rule MUST be applied by both the sender (when
+         * advertising flags outbound) and the receiver (when parsing inbound
+         * `SubOpts`). Callers are expected to have already zeroed the flags
+         * for `subscribe=false` frames before calling this helper.
+         */
+        fun coerce(requestsPartial: Boolean, supportsSendingPartial: Boolean): PartialSubFlags =
+            PartialSubFlags(
+                requestsPartial = requestsPartial,
+                supportsSendingPartial = supportsSendingPartial || requestsPartial
+            )
     }
 }
 
@@ -25,6 +40,14 @@ class PartialSubscriptionState {
 
     private val byTopic: MutableMap<Topic, MutableMap<PeerId, PartialSubFlags>> = mutableMapOf()
 
+    /**
+     * Stores [flags] for `(topic, peer)`.
+     *
+     * Passing [PartialSubFlags.NONE] (or any equivalent `PartialSubFlags(false, false)`)
+     * is treated as a removal: the peer's entry is dropped and, if it was the
+     * last peer for the topic, the topic entry is GC'd. This keeps the snapshot
+     * invariant "present ⇔ non-default flags".
+     */
     fun setPeerFlags(topic: Topic, peer: PeerId, flags: PartialSubFlags) {
         if (flags == PartialSubFlags.NONE) {
             removePeerFlags(topic, peer)

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionStateTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionStateTest.kt
@@ -1,0 +1,153 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.PeerId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PartialSubscriptionStateTest {
+
+    private lateinit var state: PartialSubscriptionState
+    private lateinit var peer1: PeerId
+    private lateinit var peer2: PeerId
+    private lateinit var peer3: PeerId
+
+    private val topicA = "topic-a"
+    private val topicB = "topic-b"
+
+    @BeforeEach
+    fun setup() {
+        state = PartialSubscriptionState()
+        peer1 = PeerId.random()
+        peer2 = PeerId.random()
+        peer3 = PeerId.random()
+    }
+
+    @Test
+    fun `unknown peer returns NONE`() {
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.peerRequestsPartial(topicA, peer1)).isFalse()
+        assertThat(state.peerSupportsSendingPartial(topicA, peer1)).isFalse()
+    }
+
+    @Test
+    fun `setPeerFlags stores and peerFlags reads back`() {
+        val flags = PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        state.setPeerFlags(topicA, peer1, flags)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(flags)
+        assertThat(state.peerRequestsPartial(topicA, peer1)).isTrue()
+        assertThat(state.peerSupportsSendingPartial(topicA, peer1)).isTrue()
+    }
+
+    @Test
+    fun `setPeerFlags with NONE removes entry`() {
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = false))
+        state.setPeerFlags(topicA, peer1, PartialSubFlags.NONE)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.snapshot()).doesNotContainKey(topicA)
+    }
+
+    @Test
+    fun `setPeerFlags overwrites previous flags for same peer and topic`() {
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = false, supportsSendingPartial = true))
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(
+            PartialSubFlags(requestsPartial = false, supportsSendingPartial = true)
+        )
+    }
+
+    @Test
+    fun `removePeerFlags drops the peer's entry and GCs empty topic`() {
+        val flags = PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        state.setPeerFlags(topicA, peer1, flags)
+
+        state.removePeerFlags(topicA, peer1)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.snapshot()).doesNotContainKey(topicA)
+    }
+
+    @Test
+    fun `removePeerFlags on unknown peer or topic is a no-op`() {
+        state.removePeerFlags(topicA, peer1) // nothing stored yet
+        assertThat(state.snapshot()).isEmpty()
+
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+        state.removePeerFlags(topicB, peer1) // topic mismatch
+        state.removePeerFlags(topicA, peer2) // peer mismatch
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(
+            PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        )
+    }
+
+    @Test
+    fun `removeTopic drops all peers for that topic, leaves other topics intact`() {
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+        state.setPeerFlags(topicA, peer2, PartialSubFlags(requestsPartial = false, supportsSendingPartial = true))
+        state.setPeerFlags(topicB, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        state.removeTopic(topicA)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.peerFlags(topicA, peer2)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.peerFlags(topicB, peer1)).isEqualTo(
+            PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        )
+    }
+
+    @Test
+    fun `onPeerDisconnected clears the peer across all topics, leaves other peers intact`() {
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+        state.setPeerFlags(topicA, peer2, PartialSubFlags(requestsPartial = false, supportsSendingPartial = true))
+        state.setPeerFlags(topicB, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+        state.setPeerFlags(topicB, peer3, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        state.onPeerDisconnected(peer1)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.peerFlags(topicB, peer1)).isEqualTo(PartialSubFlags.NONE)
+        assertThat(state.peerFlags(topicA, peer2)).isEqualTo(
+            PartialSubFlags(requestsPartial = false, supportsSendingPartial = true)
+        )
+        assertThat(state.peerFlags(topicB, peer3)).isEqualTo(
+            PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        )
+    }
+
+    @Test
+    fun `onPeerDisconnected GCs topics that become empty`() {
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+        state.setPeerFlags(topicB, peer2, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        state.onPeerDisconnected(peer1)
+
+        assertThat(state.snapshot()).doesNotContainKey(topicA)
+        assertThat(state.snapshot()).containsKey(topicB)
+    }
+
+    @Test
+    fun `onPeerDisconnected on unknown peer is a no-op`() {
+        state.setPeerFlags(topicA, peer1, PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        state.onPeerDisconnected(peer2)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(
+            PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        )
+    }
+
+    @Test
+    fun `peer independence on same topic`() {
+        val flags1 = PartialSubFlags(requestsPartial = true, supportsSendingPartial = true)
+        val flags2 = PartialSubFlags(requestsPartial = false, supportsSendingPartial = true)
+        state.setPeerFlags(topicA, peer1, flags1)
+        state.setPeerFlags(topicA, peer2, flags2)
+
+        assertThat(state.peerFlags(topicA, peer1)).isEqualTo(flags1)
+        assertThat(state.peerFlags(topicA, peer2)).isEqualTo(flags2)
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/PartialSubscriptionWireTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/PartialSubscriptionWireTest.kt
@@ -1,6 +1,8 @@
 package io.libp2p.pubsub.gossip.extensions
 
+import io.libp2p.core.PeerId
 import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.Topic
 import io.libp2p.pubsub.gossip.GossipExtension
 import io.libp2p.pubsub.gossip.GossipTestsBase
 import io.libp2p.pubsub.gossip.PartialSubFlags
@@ -23,6 +25,23 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
 
     private fun Rpc.RPC.firstUnsubscribeFor(topic: String): Rpc.RPC.SubOpts? =
         subscriptionsList.firstOrNull { it.topicid == topic && !it.subscribe }
+
+    /**
+     * Reads `partialSubscriptionState.peerFlags` on the pubsub event loop so the
+     * test thread establishes a happens-before with any pending event-loop
+     * mutations. The state container is documented as not thread-safe; direct
+     * access from the test thread risks `ConcurrentModificationException` and
+     * stale reads.
+     */
+    private fun TwoRoutersTest.peerFlagsOnEventLoop(topic: Topic, peer: PeerId): PartialSubFlags =
+        gossipRouter.submitOnEventThread {
+            gossipRouter.partialSubscriptionState.peerFlags(topic, peer)
+        }.join()
+
+    private fun TwoRoutersTest.snapshotPartialStateOnEventLoop(): Map<Topic, Map<PeerId, PartialSubFlags>> =
+        gossipRouter.submitOnEventThread {
+            gossipRouter.partialSubscriptionState.snapshot()
+        }.join()
 
     @Test
     fun `outbound subscribe carries configured partial flags with send-side coercion`() {
@@ -88,7 +107,7 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
 
         val peerId = test.router2.peerId
         // Receive-side coercion: supportsSendingPartial := requestsPartial || supportsSendingPartial
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
     }
 
@@ -99,7 +118,7 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
         val rpc = subscribeRpc(topicA, requestsPartial = false, supportsSendingPartial = true)
         test.mockRouter.sendToSingle(rpc)
 
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, test.router2.peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, test.router2.peerId))
             .isEqualTo(PartialSubFlags(requestsPartial = false, supportsSendingPartial = true))
     }
 
@@ -110,9 +129,9 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
         val rpc = subscribeRpc(topicA, requestsPartial = false, supportsSendingPartial = false)
         test.mockRouter.sendToSingle(rpc)
 
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, test.router2.peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, test.router2.peerId))
             .isEqualTo(PartialSubFlags.NONE)
-        assertThat(test.gossipRouter.partialSubscriptionState.snapshot()).doesNotContainKey(topicA)
+        assertThat(test.snapshotPartialStateOnEventLoop()).doesNotContainKey(topicA)
     }
 
     @Test
@@ -121,7 +140,7 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
         val peerId = test.router2.peerId
 
         test.mockRouter.sendToSingle(subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = true))
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
 
         // Unsubscribe with malicious flags set: flags MUST be ignored, state MUST be cleared.
@@ -134,7 +153,7 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
         ).build()
         test.mockRouter.sendToSingle(unsub)
 
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags.NONE)
     }
 
@@ -144,12 +163,12 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
         val peerId = test.router2.peerId
 
         test.mockRouter.sendToSingle(subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = true))
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
 
         test.connection.disconnect()
 
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags.NONE)
     }
 
@@ -162,15 +181,15 @@ class PartialSubscriptionWireTest : GossipTestsBase() {
         test.mockRouter.sendToSingle(subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = true))
         test.mockRouter.sendToSingle(subscribeRpc(topicB, requestsPartial = true, supportsSendingPartial = true))
 
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
 
         test.gossipRouter.unsubscribe(topicA)
 
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicA, peerId))
             .isEqualTo(PartialSubFlags.NONE)
         // Other topic state preserved
-        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicB, peerId))
+        assertThat(test.peerFlagsOnEventLoop(topicB, peerId))
             .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/PartialSubscriptionWireTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/PartialSubscriptionWireTest.kt
@@ -1,0 +1,185 @@
+package io.libp2p.pubsub.gossip.extensions
+
+import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.gossip.GossipExtension
+import io.libp2p.pubsub.gossip.GossipTestsBase
+import io.libp2p.pubsub.gossip.PartialSubFlags
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+
+class PartialSubscriptionWireTest : GossipTestsBase() {
+
+    private val topicA = "topic-a"
+    private val topicB = "topic-b"
+
+    private fun newTest() = TwoRoutersTest(
+        protocol = PubsubProtocol.Gossip_V_1_3,
+        enabledGossipExtensions = listOf(GossipExtension.PARTIAL_MESSAGES)
+    )
+
+    private fun Rpc.RPC.firstSubscribeFor(topic: String): Rpc.RPC.SubOpts? =
+        subscriptionsList.firstOrNull { it.topicid == topic && it.subscribe }
+
+    private fun Rpc.RPC.firstUnsubscribeFor(topic: String): Rpc.RPC.SubOpts? =
+        subscriptionsList.firstOrNull { it.topicid == topic && !it.subscribe }
+
+    @Test
+    fun `outbound subscribe carries configured partial flags with send-side coercion`() {
+        val test = newTest()
+
+        test.gossipRouter.setTopicPartialFlags(topicA, requestsPartial = true, supportsSendingPartial = false)
+        test.gossipRouter.subscribe(topicA)
+
+        val received = test.mockRouter.waitForMessage({ it.firstSubscribeFor(topicA) != null })
+        val sub = received.firstSubscribeFor(topicA)!!
+        assertThat(sub.requestsPartial).isTrue()
+        // spec coercion: supportsSendingPartial := requestsPartial || supportsSendingPartial
+        assertThat(sub.supportsSendingPartial).isTrue()
+    }
+
+    @Test
+    fun `outbound subscribe with only supportsSendingPartial carries only that flag`() {
+        val test = newTest()
+
+        test.gossipRouter.setTopicPartialFlags(topicA, requestsPartial = false, supportsSendingPartial = true)
+        test.gossipRouter.subscribe(topicA)
+
+        val received = test.mockRouter.waitForMessage({ it.firstSubscribeFor(topicA) != null })
+        val sub = received.firstSubscribeFor(topicA)!!
+        assertThat(sub.requestsPartial).isFalse()
+        assertThat(sub.supportsSendingPartial).isTrue()
+    }
+
+    @Test
+    fun `outbound subscribe without configured flags has both flags absent`() {
+        val test = newTest()
+
+        test.gossipRouter.subscribe(topicA)
+
+        val received = test.mockRouter.waitForMessage({ it.firstSubscribeFor(topicA) != null })
+        val sub = received.firstSubscribeFor(topicA)!!
+        assertThat(sub.hasRequestsPartial()).isFalse()
+        assertThat(sub.hasSupportsSendingPartial()).isFalse()
+    }
+
+    @Test
+    fun `outbound unsubscribe never carries partial flags`() {
+        val test = newTest()
+
+        test.gossipRouter.setTopicPartialFlags(topicA, requestsPartial = true, supportsSendingPartial = true)
+        test.gossipRouter.subscribe(topicA)
+        test.mockRouter.waitForMessage({ it.firstSubscribeFor(topicA) != null })
+
+        test.gossipRouter.unsubscribe(topicA)
+
+        val received = test.mockRouter.waitForMessage({ it.firstUnsubscribeFor(topicA) != null })
+        val unsub = received.firstUnsubscribeFor(topicA)!!
+        assertThat(unsub.hasRequestsPartial()).isFalse()
+        assertThat(unsub.hasSupportsSendingPartial()).isFalse()
+    }
+
+    @Test
+    fun `inbound subscribe with requestsPartial only stores coerced flags`() {
+        val test = newTest()
+
+        val rpc = subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = false)
+        test.mockRouter.sendToSingle(rpc)
+
+        val peerId = test.router2.peerId
+        // Receive-side coercion: supportsSendingPartial := requestsPartial || supportsSendingPartial
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+    }
+
+    @Test
+    fun `inbound subscribe with supportsSendingPartial only stores that flag verbatim`() {
+        val test = newTest()
+
+        val rpc = subscribeRpc(topicA, requestsPartial = false, supportsSendingPartial = true)
+        test.mockRouter.sendToSingle(rpc)
+
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, test.router2.peerId))
+            .isEqualTo(PartialSubFlags(requestsPartial = false, supportsSendingPartial = true))
+    }
+
+    @Test
+    fun `inbound subscribe with both flags false leaves state empty`() {
+        val test = newTest()
+
+        val rpc = subscribeRpc(topicA, requestsPartial = false, supportsSendingPartial = false)
+        test.mockRouter.sendToSingle(rpc)
+
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, test.router2.peerId))
+            .isEqualTo(PartialSubFlags.NONE)
+        assertThat(test.gossipRouter.partialSubscriptionState.snapshot()).doesNotContainKey(topicA)
+    }
+
+    @Test
+    fun `inbound unsubscribe ignores flags and clears any prior peer state`() {
+        val test = newTest()
+        val peerId = test.router2.peerId
+
+        test.mockRouter.sendToSingle(subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = true))
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        // Unsubscribe with malicious flags set: flags MUST be ignored, state MUST be cleared.
+        val unsub = Rpc.RPC.newBuilder().addSubscriptions(
+            Rpc.RPC.SubOpts.newBuilder()
+                .setTopicid(topicA)
+                .setSubscribe(false)
+                .setRequestsPartial(true)
+                .setSupportsSendingPartial(true)
+        ).build()
+        test.mockRouter.sendToSingle(unsub)
+
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags.NONE)
+    }
+
+    @Test
+    fun `peer disconnect clears stored partial subscription state`() {
+        val test = newTest()
+        val peerId = test.router2.peerId
+
+        test.mockRouter.sendToSingle(subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = true))
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        test.connection.disconnect()
+
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags.NONE)
+    }
+
+    @Test
+    fun `local unsubscribe clears stored partial subscription state for that topic`() {
+        val test = newTest()
+        val peerId = test.router2.peerId
+
+        test.gossipRouter.subscribe(topicA)
+        test.mockRouter.sendToSingle(subscribeRpc(topicA, requestsPartial = true, supportsSendingPartial = true))
+        test.mockRouter.sendToSingle(subscribeRpc(topicB, requestsPartial = true, supportsSendingPartial = true))
+
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+
+        test.gossipRouter.unsubscribe(topicA)
+
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicA, peerId))
+            .isEqualTo(PartialSubFlags.NONE)
+        // Other topic state preserved
+        assertThat(test.gossipRouter.partialSubscriptionState.peerFlags(topicB, peerId))
+            .isEqualTo(PartialSubFlags(requestsPartial = true, supportsSendingPartial = true))
+    }
+
+    private fun subscribeRpc(topic: String, requestsPartial: Boolean, supportsSendingPartial: Boolean): Rpc.RPC =
+        Rpc.RPC.newBuilder().addSubscriptions(
+            Rpc.RPC.SubOpts.newBuilder()
+                .setTopicid(topic)
+                .setSubscribe(true)
+                .setRequestsPartial(requestsPartial)
+                .setSupportsSendingPartial(supportsSendingPartial)
+        ).build()
+}


### PR DESCRIPTION
## Summary

Step 1 of the [gossipsub partial-messages extension](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/partial-messages.md) under #435.

Plumbs `SubOpts.requestsPartial` / `SubOpts.supportsSendingPartial` through subscribe announcements in both directions, and tracks the per-peer-per-topic receive state. **No routing behaviour changes yet** — handler, RPC dispatch, publish, and routing rules are later steps.

Addresses #444.

## Scope

- `AbstractRouter` parses the flags on inbound `SubOpts` and applies the spec coercion `supportsSendingPartial := requestsPartial || supportsSendingPartial`. Flags are zeroed when `subscribe=false`.
- New `AbstractRouter.enqueueSubscribe(queue, topic)` hook unifies outbound subscribe enqueueing so `GossipRouter` can attach per-topic flags in a single override (used by both `subscribe()` and the `onPeerActive` re-announce).
- `GossipRouter`:
  - `setTopicPartialFlags(topic, requestsPartial, supportsSendingPartial)` — configures flags advertised for a locally-subscribed topic (router-level API; public `Gossip` / `PubsubApi` surface intentionally untouched until Step 2 / #446).
  - New `PartialSubscriptionState` field stores inbound flags per `(topic, peer)`. Plain `HashMap` — single-threaded pubsub event loop invariant.
  - Cleanup on peer disconnect, local topic unsubscribe, and per-peer topic unsubscribe.
- Outbound unsubscribe MUST NOT carry partial flags; enforced at the `SubscriptionPart` wire-build site.

Design reference: [`docs/partial-messages.md`](../blob/develop/docs/partial-messages.md) §4.5, §5, §6.1.

## Out of scope (later steps)

- `PartialMessagesHandler` interface (#446, Step 2).
- `Rpc.PartialMessagesExtension` dispatch / `publishPartial` (#445).
- Routing rules — full-message suppression, IDONTWANT, IHAVE → `onEmitGossip` (#456).
- `GroupState`, TTL, DoS caps (#449).

## Test plan

- [x] `libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/PartialSubscriptionStateTest.kt` — 10 unit tests for the new state container (set/remove/disconnect/topic-gc semantics).
- [x] `libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/extensions/PartialSubscriptionWireTest.kt` — 9 integration tests via `TwoRoutersTest`:
  - outbound: configured flags carried with send-side coercion; `supportsSendingPartial`-only; no flags when none configured; unsubscribe strips flags.
  - inbound: receive-side coercion; `supportsSendingPartial`-only stored verbatim; both-false leaves state empty; unsubscribe ignores flags and clears prior state; disconnect clears state; local unsubscribe clears state for that topic only.
- [x] `./gradlew :libp2p:test --tests "io.libp2p.pubsub.*"` — all pubsub tests green (no regressions in `GossipExtensionsMessageHandlingTest`, `GossipExtensionsStateTest`, floodsub, etc.).
- [x] `./gradlew :libp2p:spotlessCheck` — clean.

## Stacking note

This PR stacks on #457 (design-doc-only). Until that merges, the diff here will show the `docs/partial-messages.md` commit as well; it will drop out after rebasing on `develop` post-#457.