### PR TITLE
Skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,23 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE-APACHE'
+      - 'LICENSE-MIT'
+      - 'funding.json'
+      - '.github/ISSUE_TEMPLATE/**'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE-APACHE'
+      - 'LICENSE-MIT'
+      - 'funding.json'
+      - '.github/ISSUE_TEMPLATE/**'
 jobs:
   gradle:
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,14 @@ on:
   push:
     branches:
       - "develop"
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - 'LICENSE-APACHE'
+      - 'LICENSE-MIT'
+      - 'funding.json'
+      - '.github/ISSUE_TEMPLATE/**'
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `paths-ignore` filters to `build.yml` and `publish.yml` so CI is skipped when only non-code files change
- Covered patterns: `**/*.md`, `docs/**`, `.gitignore`, `LICENSE-APACHE`, `LICENSE-MIT`, `funding.json`, `.github/ISSUE_TEMPLATE/**`

## Test plan

- [ ] Verify a PR that only changes a `.md` file shows the build workflow as skipped
- [ ] Verify a PR that changes source code still triggers the full build
- [ ] Confirm `publish` workflow still fires on code pushes to `develop`