### PR TITLE
Filter backoff peers in subscribe() and make v1.3 honour backoff/IDONTWANT

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubProtocol.kt
@@ -19,14 +19,14 @@ enum class PubsubProtocol(val announceStr: ProtocolId) {
      * https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange
      */
     fun supportsBackoffAndPX(): Boolean {
-        return this == Gossip_V_1_1 || this == Gossip_V_1_2
+        return this == Gossip_V_1_1 || this == Gossip_V_1_2 || this == Gossip_V_1_3
     }
 
     /**
      * https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.2.md#idontwant-message
      */
     fun supportsIDontWant(): Boolean {
-        return this == Gossip_V_1_2
+        return this == Gossip_V_1_2 || this == Gossip_V_1_3
     }
 
     /**

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -589,11 +589,16 @@ open class GossipRouter(
 
     override fun subscribe(topic: Topic) {
         super.subscribe(topic)
+        // Peers that are still within their PRUNE backoff window must be excluded when
+        // seeding the mesh on (re-)subscribe; grafting them during backoff is a P7
+        // behaviour-penalty violation in go-libp2p-pubsub scorers and matches the JOIN
+        // path of the reference implementation. Heartbeat-driven mesh maintenance has
+        // always filtered by isBackOff; this path historically did not.
         val fanoutPeers = (fanout[topic] ?: mutableSetOf())
-            .filter { score.score(it.peerId) >= 0 && !isDirect(it) }
+            .filter { score.score(it.peerId) >= 0 && !isDirect(it) && !isBackOff(it, topic) }
         val meshPeers = mesh.getOrPut(topic) { mutableSetOf() }
         val otherPeers = (getTopicPeers(topic) - meshPeers - fanoutPeers)
-            .filter { score.score(it.peerId) >= 0 && !isDirect(it) }
+            .filter { score.score(it.peerId) >= 0 && !isDirect(it) && !isBackOff(it, topic) }
 
         if (meshPeers.size < params.D) {
             val addFromFanout = fanoutPeers.shuffled(random)

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubProtocolTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubProtocolTest.kt
@@ -1,0 +1,34 @@
+package io.libp2p.pubsub
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PubsubProtocolTest {
+
+    @Test
+    fun `supportsBackoffAndPX is true for all GossipSub versions from v1_1 onwards`() {
+        assertThat(PubsubProtocol.Gossip_V_1_0.supportsBackoffAndPX()).isFalse()
+        assertThat(PubsubProtocol.Gossip_V_1_1.supportsBackoffAndPX()).isTrue()
+        assertThat(PubsubProtocol.Gossip_V_1_2.supportsBackoffAndPX()).isTrue()
+        assertThat(PubsubProtocol.Gossip_V_1_3.supportsBackoffAndPX()).isTrue()
+        assertThat(PubsubProtocol.Floodsub.supportsBackoffAndPX()).isFalse()
+    }
+
+    @Test
+    fun `supportsIDontWant is true for all GossipSub versions from v1_2 onwards`() {
+        assertThat(PubsubProtocol.Gossip_V_1_0.supportsIDontWant()).isFalse()
+        assertThat(PubsubProtocol.Gossip_V_1_1.supportsIDontWant()).isFalse()
+        assertThat(PubsubProtocol.Gossip_V_1_2.supportsIDontWant()).isTrue()
+        assertThat(PubsubProtocol.Gossip_V_1_3.supportsIDontWant()).isTrue()
+        assertThat(PubsubProtocol.Floodsub.supportsIDontWant()).isFalse()
+    }
+
+    @Test
+    fun `supportsExtensions is true only for GossipSub v1_3`() {
+        assertThat(PubsubProtocol.Gossip_V_1_0.supportsExtensions()).isFalse()
+        assertThat(PubsubProtocol.Gossip_V_1_1.supportsExtensions()).isFalse()
+        assertThat(PubsubProtocol.Gossip_V_1_2.supportsExtensions()).isFalse()
+        assertThat(PubsubProtocol.Gossip_V_1_3.supportsExtensions()).isTrue()
+        assertThat(PubsubProtocol.Floodsub.supportsExtensions()).isFalse()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -259,6 +259,57 @@ class GossipV1_1Tests : GossipTestsBase() {
     }
 
     @Test
+    fun testSubscribeRespectsBackoff() {
+        // Regression test for the subscribe()-bypasses-backoff bug.
+        //
+        // Reproduces the production failure mode where Teku, after being PRUNEd by a peer,
+        // re-subscribes to a topic (e.g., attestation subnet rotation) and immediately
+        // GRAFTs back onto peers that are still within their backoff window — accumulating
+        // P7 behaviour penalties on the remote scorer until disconnect.
+        //
+        // The heartbeat-driven mesh maintenance paths correctly filter by isBackOff;
+        // the subscribe() path historically did not.
+        val test = TwoRoutersTest()
+
+        test.mockRouter.subscribe("topic1")
+
+        // Let the mock peer's subscription propagate so it appears in topicPeers.
+        test.fuzz.timeController.addTime(1.seconds)
+
+        // Mock peer pre-emptively PRUNEs us with a 30-second backoff before we subscribe.
+        val pruneMsg = Rpc.RPC.newBuilder().setControl(
+            Rpc.ControlMessage.newBuilder().addPrune(
+                Rpc.ControlPrune.newBuilder()
+                    .setTopicID("topic1")
+                    .setBackoff(30)
+            )
+        ).build()
+        test.mockRouter.sendToSingle(pruneMsg)
+        test.fuzz.timeController.addTime(100.millis)
+        test.mockRouter.inboundMessages.clear()
+
+        // Now subscribe locally — this is the path that historically grafted without
+        // checking backoff.
+        test.gossipRouter.subscribe("topic1")
+        test.fuzz.timeController.addTime(15.seconds)
+
+        // No GRAFT should have been sent while the backoff is active.
+        assertEquals(
+            0,
+            test.mockRouter.inboundMessages
+                .count { it.hasControl() && it.control.graftCount > 0 },
+            "subscribe() must not GRAFT a peer that is in backoff"
+        )
+
+        // After the backoff expires, the next heartbeat is allowed to GRAFT.
+        test.fuzz.timeController.addTime(20.seconds)
+        test.mockRouter.waitForMessage {
+            it.hasControl() &&
+                it.control.graftCount > 0 && it.control.getGraft(0).topicID == "topic1"
+        }
+    }
+
+    @Test
     fun testGraftFloodPenalty() {
         val test = TwoRoutersTest()
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_3Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_3Tests.kt
@@ -2,8 +2,11 @@
 
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.etc.types.seconds
 import io.libp2p.pubsub.PubsubProtocol
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
 
 class GossipV1_3Tests : GossipTestsBase() {
 
@@ -15,5 +18,46 @@ class GossipV1_3Tests : GossipTestsBase() {
         val msg = newMessage("topic1", 0L, "Hello".toByteArray())
         test.gossipRouter.publish(msg)
         test.mockRouter.waitForMessage { it.publishCount > 0 }
+    }
+
+    @Test
+    fun testBackoffTimeoutOnV1_3() {
+        // Regression test: v1.3 must honor PRUNE backoff (inherited from v1.1).
+        // Previously `supportsBackoffAndPX()` only returned true for v1.1/v1.2,
+        // causing v1.3 routers to ignore the Backoff field and immediately re-GRAFT.
+        val test = TwoRoutersTest(protocol = PubsubProtocol.Gossip_V_1_3)
+
+        test.mockRouter.subscribe("topic1")
+        test.gossipRouter.subscribe("topic1")
+
+        // 2 heartbeats - the topic should be GRAFTed
+        test.fuzz.timeController.addTime(2.seconds)
+        test.mockRouter.waitForMessage { it.hasControl() && it.control.graftCount > 0 }
+        test.mockRouter.inboundMessages.clear()
+
+        val pruneMsg = Rpc.RPC.newBuilder().setControl(
+            Rpc.ControlMessage.newBuilder().addPrune(
+                Rpc.ControlPrune.newBuilder()
+                    .setTopicID("topic1")
+                    .setBackoff(30)
+            )
+        ).build()
+        test.mockRouter.sendToSingle(pruneMsg)
+
+        // No GRAFT should be sent during the backoff window
+        test.fuzz.timeController.addTime(15.seconds)
+        assertEquals(
+            0,
+            test.mockRouter.inboundMessages
+                .count { it.hasControl() && it.control.graftCount > 0 }
+        )
+        test.mockRouter.inboundMessages.clear()
+
+        // Expecting GRAFT after backoff expires
+        test.fuzz.timeController.addTime(20.seconds)
+        test.mockRouter.waitForMessage {
+            it.hasControl() &&
+                it.control.graftCount > 0 && it.control.getGraft(0).topicID == "topic1"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two correctness fixes in the GossipSub router, both surfaced while debugging a reproducible Teku ↔ Prysm disconnect on Ethereum Gloas/ePBS devnets.

### 1. `GossipRouter.subscribe()` ignored PRUNE backoff (production bug)

`subscribe()` seeded the new mesh from `fanoutPeers` and `otherPeers` filtered by `score >= 0 && !isDirect` only — without the `!isBackOff(peer, topic)` check that all heartbeat-driven mesh maintenance paths apply. When a local `subscribe()` ran shortly after a remote PRUNE (e.g. attestation-subnet rotation right after the remote pruned us), the router immediately GRAFTed the still-backed-off peer.

In go-libp2p-pubsub, every such GRAFT during the backoff window is a P7 behaviour-penalty violation:

```
gossipsub.go:928  GRAFT: ignoring backed off peer <teku-peer>
```

Each violation adds to `behaviourPenalty`. With Prysm's default scoring (`BehaviourPenaltyWeight = -15.92`, `BehaviourPenaltyThreshold = 6`), ~10 violations are enough to push the peer score below Prysm's `-100` disconnect threshold, causing permanent disconnection within minutes. The affected topics in production were `beacon_attestation_0/1/2/3` — exactly the rotating attestation subnets, which is the trigger condition for re-`subscribe()`.

Fix: filter `fanoutPeers` and `otherPeers` by `!isBackOff(it, topic)` in `GossipRouter.subscribe()`, mirroring `JOIN` in the go-libp2p-pubsub reference.

### 2. `supportsBackoffAndPX()` and `supportsIDontWant()` were not cumulative across versions

GossipSub versions are additive: v1.3 ⊃ v1.2 ⊃ v1.1. The exact-match checks meant a router negotiating `/meshsub/1.3.0` silently:
- skipped storing the `Backoff` field from incoming PRUNEs (`GossipRouter.kt:315`)
- omitted `Backoff`/PX from outgoing PRUNEs (`GossipRouter.kt:779`)
- short-circuited `handleIDontWant` (`GossipRouter.kt:367`)

This is the same class of bug as #1, but only triggers once a router (Teku or otherwise) advertises v1.3. Made the support methods cumulative so v1.3 inherits all v1.1/v1.2 behaviour.

## Test plan

- [x] `GossipV1_1Tests.testSubscribeRespectsBackoff` — new regression test. Fails on `develop`: 1 GRAFT sent within the 30 s backoff window. Passes after the `subscribe()` fix.
- [x] `GossipV1_3Tests.testBackoffTimeoutOnV1_3` — new regression test mirroring the existing v1.1 backoff test, exercising a v1.3-negotiated router.
- [x] `PubsubProtocolTest` — pins the cumulative semantics of all three feature-support methods.
- [x] All existing `io.libp2p.pubsub.*` tests pass.
- [x] `./gradlew spotlessApply` and `./gradlew :libp2p:detekt` clean.