### PR TITLE
Release ByteBuf on control frames and invalid stream tag

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexFrameCodec.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexFrameCodec.kt
@@ -73,7 +73,12 @@ class MplexFrameCodec(
             val streamId = header.shr(3)
             val data = msg.readSlice(lenData.toInt())
             data.retain() // MessageToMessageCodec releases original buffer, but it needs to be relayed
-            val flag = MplexFlag.getByValue(streamTag)
+            val flag = try {
+                MplexFlag.getByValue(streamTag)
+            } catch (e: IllegalArgumentException) {
+                data.release()
+                throw e
+            }
             val mplexFrame = MplexFrame(MplexId(ctx.channel().id(), streamId, !flag.isInitiator), flag, data)
             out.add(mplexFrame)
         }

--- a/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
@@ -26,9 +26,18 @@ open class MplexHandler(
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         msg as MplexFrame
         when (msg.flag.type) {
-            MplexFlag.Type.OPEN -> onRemoteOpen(msg.id)
-            MplexFlag.Type.CLOSE -> onRemoteDisconnect(msg.id)
-            MplexFlag.Type.RESET -> onRemoteClose(msg.id)
+            MplexFlag.Type.OPEN -> {
+                onRemoteOpen(msg.id)
+                msg.release()
+            }
+            MplexFlag.Type.CLOSE -> {
+                onRemoteDisconnect(msg.id)
+                msg.release()
+            }
+            MplexFlag.Type.RESET -> {
+                onRemoteClose(msg.id)
+                msg.release()
+            }
             MplexFlag.Type.DATA -> childRead(msg.id, msg.data)
         }
     }

--- a/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexFrameCodecTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexFrameCodecTest.kt
@@ -118,6 +118,29 @@ class MplexFrameCodecTest {
     }
 
     @Test
+    fun `invalid stream tag does not leak inbound buffer`() {
+        // streamTag = 7 (header & 0x07) is not mapped in MplexFlag, so
+        // MplexFlag.getByValue() throws AFTER data.retain() has been called.
+        // Without releasing the retained slice, the parent inbound buffer leaks.
+        val rawBytes = Unpooled.buffer()
+            .writeByte(0x07) // varint header: streamId=0, streamTag=7 (invalid)
+            .writeByte(0x05) // varint lenData = 5
+            .writeBytes(byteArrayOf(1, 2, 3, 4, 5))
+
+        rawBytes.retain() // keep an external ref to observe the codec's net effect
+        assertEquals(2, rawBytes.refCnt())
+
+        assertThrows<DecoderException> {
+            channel.writeInbound(rawBytes)
+        }
+
+        // Only our external ref should remain. Without the fix, the retained
+        // slice keeps an extra ref alive (refCnt == 2 instead of 1).
+        assertEquals(1, rawBytes.refCnt())
+        rawBytes.release()
+    }
+
+    @Test
     fun `check the frame underlying buffer is released after send`() {
         val frameDataBuf = "Hello-1".toByteArray().toByteBuf()
 

--- a/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/mplex/MplexHandlerTest.kt
@@ -10,8 +10,44 @@ import io.libp2p.mux.MuxHandlerAbstractTest.AbstractTestMuxFrame.Flag.*
 import io.libp2p.tools.readAllBytesAndRelease
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 class MplexHandlerTest : MuxHandlerAbstractTest() {
+
+    private fun writeInboundControlFrame(streamId: Long, type: MplexFlag.Type) {
+        // Simulate what MplexFrameCodec.decode() produces: a retained slice of the
+        // inbound buffer carried as the MplexFrame data, even for OPEN/CLOSE/RESET.
+        val data = allocateBuf()
+        val muxId = MplexId(parentChannelId, streamId, true)
+        ech.writeInbound(MplexFrame(muxId, MplexFlag.getByType(type, true), data))
+    }
+
+    @Test
+    fun `OPEN frame data buffer is released`() {
+        writeInboundControlFrame(1, MplexFlag.Type.OPEN)
+        // cleanUpAndCheck verifies the allocated buffer's refCnt was decremented.
+    }
+
+    @Test
+    fun `CLOSE frame data buffer is released`() {
+        val id = openStreamRemote()
+        writeInboundControlFrame(id, MplexFlag.Type.CLOSE)
+    }
+
+    @Test
+    fun `RESET frame data buffer is released`() {
+        val id = openStreamRemote()
+        writeInboundControlFrame(id, MplexFlag.Type.RESET)
+    }
+
+    @Test
+    fun `repeated OPEN frames do not leak buffers`() {
+        repeat(50) { i ->
+            writeInboundControlFrame(i.toLong(), MplexFlag.Type.OPEN)
+        }
+        assertThat(allocatedBufs).hasSize(50)
+    }
 
     override val maxFrameDataLength = 256
 


### PR DESCRIPTION
## Summary
- `MplexHandler.channelRead()` now releases the frame buffer for OPEN/CLOSE/RESET. Previously only DATA frames forwarded the buffer to a child channel, so the retained slice created by `MplexFrameCodec.decode()` leaked on every control frame.
- `MplexFrameCodec.decode()` now releases the retained data slice when the stream tag lookup throws. With `streamTag == 7` (invalid), `MplexFlag.getByValue()` threw after `data.retain()`, leaking the underlying inbound buffer.

## Test plan
- [x] New unit tests reproduce the leaks before the fixes and pass after:
  - `MplexHandlerTest`: OPEN/CLOSE/RESET frame data buffer is released, repeated OPEN frames do not leak.
  - `MplexFrameCodecTest`: invalid stream tag does not leak inbound buffer.
- [x] `./gradlew :libp2p:test --tests 'io.libp2p.mux.*' :libp2p:spotlessCheck` passes.