### PR TITLE
Close cancelled network dials

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
@@ -82,7 +82,7 @@ class NetworkImpl(
             transport.dial(addr, createHookedConnHandler(connectionHandler), preHandler)
         }
         return anyComplete(connectionFuts).also { firstConnection ->
-            firstConnection.thenAccept {
+            firstConnection.whenComplete { _, _ ->
                 connectionFuts.filter { !it.isDone }.forEach { it.cancel(true) }
             }
         }

--- a/libp2p/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/network/NetworkImpl.kt
@@ -73,7 +73,7 @@ class NetworkImpl(
 
         // 1. check that some transport can dial at least one addr.
         // 2. trigger dials in parallel via all transports.
-        // 3. when the first dial succeeds, cancel all pending dials and return the connection. // TODO cancel
+        // 3. when the first dial succeeds, cancel all pending dials and return the connection.
         // 4. if no emitted dial succeeds, or if we time out, fail the future. make sure to cancel
         //    pending dials to avoid leaking.
         val connectionFuts = addrsWithP2P.mapNotNull { addr ->
@@ -81,6 +81,10 @@ class NetworkImpl(
         }.map { (addr, transport) ->
             transport.dial(addr, createHookedConnHandler(connectionHandler), preHandler)
         }
-        return anyComplete(connectionFuts)
+        return anyComplete(connectionFuts).also { firstConnection ->
+            firstConnection.thenAccept {
+                connectionFuts.filter { !it.isDone }.forEach { it.cancel(true) }
+            }
+        }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/implementation/PlainNettyTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/implementation/PlainNettyTransport.kt
@@ -158,8 +158,14 @@ abstract class PlainNettyTransport(
             .connect(fromMultiaddr(addr))
             .also { registerChannel(it.channel()) }
 
-        return chanFuture.toCompletableFuture()
+        val connection = chanFuture.toCompletableFuture()
             .thenCompose { connectionBuilder.connectionEstablished }
+        connection.whenComplete { _, _ ->
+            if (connection.isCancelled) {
+                chanFuture.channel().close()
+            }
+        }
+        return connection
     } // dial
 
     protected abstract fun clientTransportBuilder(

--- a/libp2p/src/test/kotlin/io/libp2p/network/NetworkImplTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/network/NetworkImplTest.kt
@@ -1,0 +1,102 @@
+package io.libp2p.network
+
+import io.libp2p.core.ChannelVisitor
+import io.libp2p.core.Connection
+import io.libp2p.core.ConnectionHandler
+import io.libp2p.core.P2PChannel
+import io.libp2p.core.PeerId
+import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.multiformats.Protocol
+import io.libp2p.core.mux.StreamMuxer
+import io.libp2p.core.security.SecureChannel
+import io.libp2p.core.transport.Transport
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit.SECONDS
+
+class NetworkImplTest {
+
+    @Test
+    fun `connect cancels pending dials after first successful dial`() {
+        val peerId = PeerId.random()
+        val pendingDial = CompletableFuture<Connection>()
+        val successfulConnection = TestConnection()
+        val network = NetworkImpl(
+            listOf(
+                TestTransport(Protocol.IP6, pendingDial),
+                TestTransport(Protocol.IP4, CompletableFuture.completedFuture(successfulConnection))
+            ),
+            ConnectionHandler { }
+        )
+
+        val connection = network.connect(
+            peerId,
+            Multiaddr("/ip6/::1/tcp/4001"),
+            Multiaddr("/ip4/127.0.0.1/tcp/4001")
+        ).get(5, SECONDS)
+
+        assertSame(successfulConnection, connection)
+        assertTrue(pendingDial.isCancelled, "Pending IPv6 dial was not cancelled")
+    }
+
+    private class TestTransport(
+        private val protocol: Protocol,
+        private val dialResult: CompletableFuture<Connection>
+    ) : Transport {
+        override val activeListeners: Int = 0
+        override val activeConnections: Int = 0
+
+        override fun listenAddresses(): List<Multiaddr> = emptyList()
+
+        override fun handles(addr: Multiaddr): Boolean = addr.has(protocol)
+
+        override fun initialize() = Unit
+
+        override fun close(): CompletableFuture<Unit> = CompletableFuture.completedFuture(Unit)
+
+        override fun listen(
+            addr: Multiaddr,
+            connHandler: ConnectionHandler,
+            preHandler: ChannelVisitor<P2PChannel>?
+        ): CompletableFuture<Unit> = CompletableFuture.completedFuture(Unit)
+
+        override fun unlisten(addr: Multiaddr): CompletableFuture<Unit> = CompletableFuture.completedFuture(Unit)
+
+        override fun dial(
+            addr: Multiaddr,
+            connHandler: ConnectionHandler,
+            preHandler: ChannelVisitor<P2PChannel>?
+        ): CompletableFuture<Connection> = dialResult
+    }
+
+    private class TestConnection : Connection {
+        private val closeFuture = CompletableFuture<Unit>()
+
+        override val isInitiator: Boolean = true
+
+        override fun pushHandler(handler: io.netty.channel.ChannelHandler) = Unit
+
+        override fun pushHandler(name: String, handler: io.netty.channel.ChannelHandler) = Unit
+
+        override fun addHandlerBefore(baseName: String, name: String, handler: io.netty.channel.ChannelHandler) = Unit
+
+        override fun close(): CompletableFuture<Unit> {
+            closeFuture.complete(Unit)
+            return closeFuture
+        }
+
+        override fun closeFuture(): CompletableFuture<Unit> = closeFuture
+
+        override fun muxerSession(): StreamMuxer.Session = throw UnsupportedOperationException()
+
+        override fun secureSession(): SecureChannel.Session = throw UnsupportedOperationException()
+
+        override fun transport(): Transport = throw UnsupportedOperationException()
+
+        override fun localAddress(): Multiaddr = throw UnsupportedOperationException()
+
+        override fun remoteAddress(): Multiaddr = throw UnsupportedOperationException()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/network/NetworkImplTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/network/NetworkImplTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit.SECONDS
+import java.util.concurrent.TimeoutException
 
 class NetworkImplTest {
 
@@ -39,6 +40,54 @@ class NetworkImplTest {
 
         assertSame(successfulConnection, connection)
         assertTrue(pendingDial.isCancelled, "Pending IPv6 dial was not cancelled")
+    }
+
+    @Test
+    fun `connect cancels pending dials when aggregate future is cancelled`() {
+        val peerId = PeerId.random()
+        val pendingIpv6Dial = CompletableFuture<Connection>()
+        val pendingIpv4Dial = CompletableFuture<Connection>()
+        val network = NetworkImpl(
+            listOf(
+                TestTransport(Protocol.IP6, pendingIpv6Dial),
+                TestTransport(Protocol.IP4, pendingIpv4Dial)
+            ),
+            ConnectionHandler { }
+        )
+
+        val connect = network.connect(
+            peerId,
+            Multiaddr("/ip6/::1/tcp/4001"),
+            Multiaddr("/ip4/127.0.0.1/tcp/4001")
+        )
+
+        assertTrue(connect.cancel(true))
+        assertTrue(pendingIpv6Dial.isCancelled, "Pending IPv6 dial was not cancelled")
+        assertTrue(pendingIpv4Dial.isCancelled, "Pending IPv4 dial was not cancelled")
+    }
+
+    @Test
+    fun `connect cancels pending dials when aggregate future times out`() {
+        val peerId = PeerId.random()
+        val pendingIpv6Dial = CompletableFuture<Connection>()
+        val pendingIpv4Dial = CompletableFuture<Connection>()
+        val network = NetworkImpl(
+            listOf(
+                TestTransport(Protocol.IP6, pendingIpv6Dial),
+                TestTransport(Protocol.IP4, pendingIpv4Dial)
+            ),
+            ConnectionHandler { }
+        )
+
+        val connect = network.connect(
+            peerId,
+            Multiaddr("/ip6/::1/tcp/4001"),
+            Multiaddr("/ip4/127.0.0.1/tcp/4001")
+        )
+
+        assertTrue(connect.completeExceptionally(TimeoutException()))
+        assertTrue(pendingIpv6Dial.isCancelled, "Pending IPv6 dial was not cancelled")
+        assertTrue(pendingIpv4Dial.isCancelled, "Pending IPv4 dial was not cancelled")
     }
 
     private class TestTransport(

--- a/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -23,7 +23,6 @@ import java.net.BindException
 import java.net.Inet6Address
 import java.net.InetAddress
 import java.net.InetSocketAddress
-import java.net.StandardProtocolFamily.INET6
 import java.nio.channels.ServerSocketChannel
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit.SECONDS
@@ -134,7 +133,7 @@ class TcpTransportTest : TransportTests() {
     }
 
     private fun bindIpv6Loopback(loopback: Inet6Address, port: Int): ServerSocketChannel =
-        ServerSocketChannel.open(INET6).apply {
+        ServerSocketChannel.open().apply {
             bind(InetSocketAddress(loopback, port))
         }
 

--- a/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/tcp/TcpTransportTest.kt
@@ -1,13 +1,32 @@
 package io.libp2p.transport.tcp
 
 import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.multiformats.Protocol.TCP
+import io.libp2p.core.security.SecureChannel
 import io.libp2p.core.transport.Transport
 import io.libp2p.tools.DnsAvailability.Companion.ip4DnsAvailable
+import io.libp2p.transport.ConnectionUpgrader
 import io.libp2p.transport.NullConnectionUpgrader
+import io.libp2p.transport.NullMultistreamProtocol
 import io.libp2p.transport.TransportTests
+import io.libp2p.transport.implementation.PlainNettyTransport
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.io.IOException
+import java.net.BindException
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.StandardProtocolFamily.INET6
+import java.nio.channels.ServerSocketChannel
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit.SECONDS
 
 @Tag("tcp-transport")
 class TcpTransportTest : TransportTests() {
@@ -60,5 +79,79 @@ class TcpTransportTest : TransportTests() {
     @MethodSource("invalidMultiaddrs")
     fun `TcpTransport does not support`(addr: Multiaddr) {
         assert(!transportUnderTest.handles(addr))
+    }
+
+    @Test
+    fun `close releases ipv6 listener socket`() {
+        val loopback = InetAddress.getByName("::1") as Inet6Address
+        assumeIpv6LoopbackBindable(loopback)
+
+        transportUnderTest.listen(Multiaddr("/ip6/::1/tcp/0"), nullConnHandler).get(5, SECONDS)
+        val boundPort = requireNotNull(
+            transportUnderTest.listenAddresses().single().getFirstComponent(TCP)
+        ).let { requireNotNull(it.stringValue).toInt() }
+
+        assertThrows(BindException::class.java) {
+            bindIpv6Loopback(loopback, boundPort).use { }
+        }
+
+        transportUnderTest.close().get(5, SECONDS)
+
+        assertEquals(0, transportUnderTest.activeListeners, "IPv6 listener still tracked after close")
+        bindIpv6Loopback(loopback, boundPort).use { }
+    }
+
+    @Test
+    fun `cancelling pending ipv6 dial closes socket`() {
+        val loopback = InetAddress.getByName("::1") as Inet6Address
+        assumeIpv6LoopbackBindable(loopback)
+
+        bindIpv6Loopback(loopback, 0).use { server ->
+            val serverPort = (server.localAddress as InetSocketAddress).port
+            val transport = TcpTransport(PendingConnectionUpgrader())
+            try {
+                val dial = transport.dial(
+                    Multiaddr("/ip6/::1/tcp/$serverPort"),
+                    nullConnHandler
+                )
+                assertActiveConnectionsEventually(transport, 1)
+
+                assertTrue(dial.cancel(true))
+
+                assertActiveConnectionsEventually(transport, 0)
+            } finally {
+                transport.close().get(5, SECONDS)
+            }
+        }
+    }
+
+    private fun assumeIpv6LoopbackBindable(loopback: Inet6Address) {
+        try {
+            bindIpv6Loopback(loopback, 0).use { }
+        } catch (e: IOException) {
+            assumeTrue(false, "IPv6 loopback is not available: ${e.message}")
+        }
+    }
+
+    private fun bindIpv6Loopback(loopback: Inet6Address, port: Int): ServerSocketChannel =
+        ServerSocketChannel.open(INET6).apply {
+            bind(InetSocketAddress(loopback, port))
+        }
+
+    private fun assertActiveConnectionsEventually(transport: PlainNettyTransport, expected: Int) {
+        val deadline = System.nanoTime() + SECONDS.toNanos(5)
+        while (System.nanoTime() < deadline) {
+            if (transport.activeConnections == expected) {
+                return
+            }
+            Thread.sleep(10)
+        }
+        assertEquals(expected, transport.activeConnections)
+    }
+
+    private class PendingConnectionUpgrader :
+        ConnectionUpgrader(NullMultistreamProtocol(), emptyList(), NullMultistreamProtocol(), emptyList()) {
+        override fun establishSecureChannel(connection: io.libp2p.core.Connection): CompletableFuture<SecureChannel.Session> =
+            CompletableFuture()
     }
 }


### PR DESCRIPTION
## What changed

- Cancel pending dial attempts after `NetworkImpl.connect` gets the first successful connection.
- Close the underlying Netty channel when a `PlainNettyTransport` dial future is cancelled.
- Add regression tests covering:
  - pending IPv6 dial cancellation releasing the socket
  - IPv6 listener close releasing the bound port
  - `NetworkImpl` cancelling the losing IPv6 dial after IPv4 succeeds

## Why

Teku reported large numbers of lingering `TCPv6` sockets on older jvm-libp2p versions: https://github.com/Consensys/teku/issues/10735

The network layer already documented the intended behavior: once one address succeeds, pending dials should be cancelled to avoid leaking. That cancellation was not implemented, and cancellation of a transport dial did not close the associated Netty socket.

## Validation

Passed:

- `./gradlew :libp2p:test --tests "io.libp2p.network.NetworkImplTest" --tests "io.libp2p.transport.tcp.TcpTransportTest" --rerun-tasks`
  - 27 tests, 0 failures
- `./gradlew :libp2p:spotlessCheck`

Also checked:

- `./gradlew build`

The full build reached `:libp2p:test` but failed in environment-dependent tests:
- `QuicKuboTestJava.pingKubo()` could not connect to local Kubo.
- Three `MDnsDiscoveryTest` cases observed missing/unexpected peer ids.