### PR TITLE
Improve yamux write backpressure

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
@@ -4,6 +4,7 @@ import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.mux.mplex.MplexStreamMuxer
 import io.libp2p.mux.yamux.DEFAULT_ACK_BACKLOG_LIMIT
+import io.libp2p.mux.yamux.DEFAULT_MAX_BUFFERED_CONNECTION_WRITES
 import io.libp2p.mux.yamux.YamuxStreamMuxer
 
 fun interface StreamMuxerProtocol {
@@ -22,17 +23,24 @@ fun interface StreamMuxerProtocol {
         }
 
         /**
+         * @param maxBufferedConnectionWrites the maximum amount of bytes which may be buffered (pending)
+         * across the write buffers of all streams of a single connection. When the limit is overflowed,
+         * the stream attempting to write is reset
          * @param ackBacklogLimit the maximum amount of opened streams per connection which have not been acknowledged
          */
         @JvmStatic
         @JvmOverloads
-        fun getYamux(ackBacklogLimit: Int = DEFAULT_ACK_BACKLOG_LIMIT): StreamMuxerProtocol {
+        fun getYamux(
+            maxBufferedConnectionWrites: Int = DEFAULT_MAX_BUFFERED_CONNECTION_WRITES,
+            ackBacklogLimit: Int = DEFAULT_ACK_BACKLOG_LIMIT
+        ): StreamMuxerProtocol {
             return StreamMuxerProtocol { multistreamProtocol, protocols ->
                 YamuxStreamMuxer(
                     multistreamProtocol.createMultistream(
                         protocols
                     ).toStreamHandler(),
                     multistreamProtocol,
+                    maxBufferedConnectionWrites,
                     ackBacklogLimit
                 )
             }

--- a/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/mux/StreamMuxerProtocol.kt
@@ -4,7 +4,6 @@ import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.multistream.ProtocolBinding
 import io.libp2p.mux.mplex.MplexStreamMuxer
 import io.libp2p.mux.yamux.DEFAULT_ACK_BACKLOG_LIMIT
-import io.libp2p.mux.yamux.DEFAULT_MAX_BUFFERED_CONNECTION_WRITES
 import io.libp2p.mux.yamux.YamuxStreamMuxer
 
 fun interface StreamMuxerProtocol {
@@ -23,22 +22,17 @@ fun interface StreamMuxerProtocol {
         }
 
         /**
-         * @param maxBufferedConnectionWrites the maximum amount of bytes in the write buffer per connection
          * @param ackBacklogLimit the maximum amount of opened streams per connection which have not been acknowledged
          */
         @JvmStatic
         @JvmOverloads
-        fun getYamux(
-            maxBufferedConnectionWrites: Int = DEFAULT_MAX_BUFFERED_CONNECTION_WRITES,
-            ackBacklogLimit: Int = DEFAULT_ACK_BACKLOG_LIMIT
-        ): StreamMuxerProtocol {
+        fun getYamux(ackBacklogLimit: Int = DEFAULT_ACK_BACKLOG_LIMIT): StreamMuxerProtocol {
             return StreamMuxerProtocol { multistreamProtocol, protocols ->
                 YamuxStreamMuxer(
                     multistreamProtocol.createMultistream(
                         protocols
                     ).toStreamHandler(),
                     multistreamProtocol,
-                    maxBufferedConnectionWrites,
                     ackBacklogLimit
                 )
             }

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
@@ -17,11 +17,6 @@ private val log = LoggerFactory.getLogger(AbstractMuxHandler::class.java)
 abstract class AbstractMuxHandler<TData>() :
     ChannelInboundHandlerAdapter() {
 
-    private companion object {
-        const val PARENT_CHANNEL_WRITABILITY_INDEX = 1
-        const val MUXER_WRITABILITY_INDEX = 2
-    }
-
     private val streamMap: MutableMap<MuxId, MuxChannel<TData>> = mutableMapOf()
     var ctx: ChannelHandlerContext? = null
     private val activeFuture = CompletableFuture<Void>()
@@ -89,11 +84,12 @@ abstract class AbstractMuxHandler<TData>() :
      */
     abstract fun releaseMessage(msg: TData)
 
-    protected open fun isChildWritable(child: MuxChannel<TData>): Boolean = true
-
-    fun canWriteChild(child: MuxChannel<TData>): Boolean =
-        getChannelHandlerContext().channel().isWritable && isChildWritable(child)
-
+    /**
+     * Writes the child channel data to the underlying connection.
+     * Returns the number of consumed bytes which may be less than the readable bytes of [data]
+     * (including 0) when the muxer can't write at the moment (e.g. flow control window exhausted).
+     * Unconsumed data remains buffered in the child channel and is written again on [retryChildWrite]
+     */
     abstract fun onChildWrite(child: MuxChannel<TData>, data: TData): Int
 
     fun flushChildWrites() {
@@ -108,32 +104,22 @@ abstract class AbstractMuxHandler<TData>() :
         streamMap.values.forEach { it.retryWrite() }
     }
 
-    protected fun refreshChildWritability(id: MuxId) {
-        streamMap[id]?.let { refreshChildWritability(it) }
+    protected fun setChildMuxWritability(id: MuxId, index: Int, writable: Boolean) {
+        streamMap[id]?.setMuxWritability(index, writable)
     }
 
-    protected open fun onChildRegistered(child: MuxChannel<TData>) {
-        refreshChildWritability(child)
+    protected fun setAllChildMuxWritability(index: Int, writable: Boolean) {
+        streamMap.values.forEach { it.setMuxWritability(index, writable) }
     }
 
-    private fun refreshChildWritability(child: MuxChannel<TData>) {
-        child.setMuxWritability(
-            PARENT_CHANNEL_WRITABILITY_INDEX,
-            getChannelHandlerContext().channel().isWritable
-        )
-        child.setMuxWritability(MUXER_WRITABILITY_INDEX, isChildWritable(child))
-    }
+    /**
+     * Total bytes (including a small per-message accounting overhead) buffered
+     * in the outbound buffers of all child channels
+     */
+    protected fun totalChildPendingWriteBytes(): Long =
+        streamMap.values.sumOf { it.pendingWriteBytes() }
 
-    override fun channelWritabilityChanged(ctx: ChannelHandlerContext) {
-        val parentWritable = ctx.channel().isWritable
-        streamMap.values.forEach {
-            it.setMuxWritability(PARENT_CHANNEL_WRITABILITY_INDEX, parentWritable)
-        }
-        if (parentWritable) {
-            retryAllChildWrites()
-        }
-        super.channelWritabilityChanged(ctx)
-    }
+    protected open fun onChildRegistered(child: MuxChannel<TData>) {}
 
     protected fun onRemoteOpen(id: MuxId) {
         val initializer = inboundInitializer

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/AbstractMuxHandler.kt
@@ -17,6 +17,11 @@ private val log = LoggerFactory.getLogger(AbstractMuxHandler::class.java)
 abstract class AbstractMuxHandler<TData>() :
     ChannelInboundHandlerAdapter() {
 
+    private companion object {
+        const val PARENT_CHANNEL_WRITABILITY_INDEX = 1
+        const val MUXER_WRITABILITY_INDEX = 2
+    }
+
     private val streamMap: MutableMap<MuxId, MuxChannel<TData>> = mutableMapOf()
     var ctx: ChannelHandlerContext? = null
     private val activeFuture = CompletableFuture<Void>()
@@ -84,7 +89,51 @@ abstract class AbstractMuxHandler<TData>() :
      */
     abstract fun releaseMessage(msg: TData)
 
-    abstract fun onChildWrite(child: MuxChannel<TData>, data: TData)
+    protected open fun isChildWritable(child: MuxChannel<TData>): Boolean = true
+
+    fun canWriteChild(child: MuxChannel<TData>): Boolean =
+        getChannelHandlerContext().channel().isWritable && isChildWritable(child)
+
+    abstract fun onChildWrite(child: MuxChannel<TData>, data: TData): Int
+
+    fun flushChildWrites() {
+        getChannelHandlerContext().flush()
+    }
+
+    protected fun retryChildWrite(id: MuxId) {
+        streamMap[id]?.retryWrite()
+    }
+
+    protected fun retryAllChildWrites() {
+        streamMap.values.forEach { it.retryWrite() }
+    }
+
+    protected fun refreshChildWritability(id: MuxId) {
+        streamMap[id]?.let { refreshChildWritability(it) }
+    }
+
+    protected open fun onChildRegistered(child: MuxChannel<TData>) {
+        refreshChildWritability(child)
+    }
+
+    private fun refreshChildWritability(child: MuxChannel<TData>) {
+        child.setMuxWritability(
+            PARENT_CHANNEL_WRITABILITY_INDEX,
+            getChannelHandlerContext().channel().isWritable
+        )
+        child.setMuxWritability(MUXER_WRITABILITY_INDEX, isChildWritable(child))
+    }
+
+    override fun channelWritabilityChanged(ctx: ChannelHandlerContext) {
+        val parentWritable = ctx.channel().isWritable
+        streamMap.values.forEach {
+            it.setMuxWritability(PARENT_CHANNEL_WRITABILITY_INDEX, parentWritable)
+        }
+        if (parentWritable) {
+            retryAllChildWrites()
+        }
+        super.channelWritabilityChanged(ctx)
+    }
 
     protected fun onRemoteOpen(id: MuxId) {
         val initializer = inboundInitializer
@@ -138,6 +187,7 @@ abstract class AbstractMuxHandler<TData>() :
         val child = MuxChannel(this, id, initializer, initiator)
         streamMap[id] = child
         ctx!!.channel().eventLoop().register(child).sync()
+        onChildRegistered(child)
         return child
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
@@ -5,7 +5,6 @@ import io.libp2p.etc.util.netty.AbstractChildChannel
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelMetadata
 import io.netty.channel.ChannelOutboundBuffer
-import io.netty.util.ReferenceCountUtil
 import java.net.SocketAddress
 
 /**
@@ -21,8 +20,7 @@ class MuxChannel<TData>(
     var remoteDisconnected = false
     var localDisconnected = false
     private var localDisconnectSent = false
-    private var disconnectFlushedMessages = 0
-    private var retainedPendingWrite: Any? = null
+    private var pendingDisconnectWrites = 0
 
     override fun metadata(): ChannelMetadata = ChannelMetadata(true)
     override fun localAddress0() =
@@ -46,63 +44,67 @@ class MuxChannel<TData>(
         unsafe().outboundBuffer()?.setUserDefinedWritability(index, writable)
     }
 
+    fun pendingWriteBytes(): Long = unsafe().outboundBuffer()?.totalPendingWriteBytes() ?: 0L
+
     @Suppress("SwallowedException")
     override fun doWrite(buf: ChannelOutboundBuffer) {
         while (true) {
             val msg = buf.current() ?: break
-            if (localDisconnected && disconnectFlushedMessages == 0) {
+            if (localDisconnected && pendingDisconnectWrites == 0) {
                 // Must not throw from doWrite — exceptions escape uncaught to the Netty event loop.
                 // Wrap buf.remove() defensively: in some Netty versions promise listeners triggered
                 // by buf.remove() can propagate back through it.
                 try {
                     buf.remove(ConnectionClosedException("The stream was closed for writing locally: $id"))
                 } catch (e: Throwable) { }
-                releaseRetainedPendingWrite(msg)
                 continue
-            }
-            if (!parent.canWriteChild(this)) {
-                retainPendingWrite(msg)
-                break
             }
             try {
                 @Suppress("UNCHECKED_CAST")
-                val consumedBytes = parent.onChildWrite(this, msg as TData)
-                if (consumedBytes <= 0) {
-                    retainPendingWrite(msg)
-                    break
-                }
-                val currentMessageComplete = msg !is ByteBuf || consumedBytes >= msg.readableBytes()
-                if (!currentMessageComplete) {
-                    retainPendingWrite(msg)
-                }
-                if (msg is ByteBuf) {
+                msg as TData
+                val complete: Boolean
+                if (msg is ByteBuf && msg.isReadable) {
+                    val consumedBytes = parent.onChildWrite(this, msg)
+                    if (consumedBytes <= 0) {
+                        // the muxer can't write at the moment: the message stays buffered
+                        // (the outbound buffer owns it) until the parent retries this write
+                        break
+                    }
+                    complete = consumedBytes >= msg.readableBytes()
                     buf.removeBytes(consumedBytes.toLong())
                 } else {
+                    parent.onChildWrite(this, msg)
+                    complete = true
                     buf.remove()
                 }
                 parent.flushChildWrites()
-                if (currentMessageComplete) {
-                    releaseRetainedPendingWrite(msg)
+                if (!complete) {
+                    // partially written: wait for a retry before sending the rest
+                    break
                 }
-                if (localDisconnected && currentMessageComplete) {
-                    disconnectFlushedMessages--
-                    if (disconnectFlushedMessages == 0) {
-                        finishLocalDisconnect()
-                        continue
-                    }
-                }
+                onPendingDisconnectWriteCompleted()
             } catch (cause: Throwable) {
                 buf.remove(cause)
-                releaseRetainedPendingWrite(msg)
+                onPendingDisconnectWriteCompleted()
             }
         }
     }
 
     override fun doDisconnect() {
         localDisconnected = true
-        disconnectFlushedMessages = unsafe().outboundBuffer()?.size() ?: 0
-        if (disconnectFlushedMessages == 0) {
+        // delay the local disconnect until all writes flushed before the disconnect are sent
+        pendingDisconnectWrites = unsafe().outboundBuffer()?.size() ?: 0
+        if (pendingDisconnectWrites == 0) {
             finishLocalDisconnect()
+        }
+    }
+
+    private fun onPendingDisconnectWriteCompleted() {
+        if (localDisconnected && pendingDisconnectWrites > 0) {
+            pendingDisconnectWrites--
+            if (pendingDisconnectWrites == 0) {
+                finishLocalDisconnect()
+            }
         }
     }
 
@@ -113,10 +115,6 @@ class MuxChannel<TData>(
     }
 
     override fun doClose() {
-        retainedPendingWrite?.let {
-            retainedPendingWrite = null
-            ReferenceCountUtil.release(it)
-        }
         super.doClose()
         parent.onClosed(this)
     }
@@ -137,20 +135,6 @@ class MuxChannel<TData>(
         parent.localDisconnect(this)
         deactivate()
         closeIfBothDisconnected()
-    }
-
-    private fun retainPendingWrite(msg: Any) {
-        if (retainedPendingWrite !== msg) {
-            retainedPendingWrite = msg
-            ReferenceCountUtil.retain(msg)
-        }
-    }
-
-    private fun releaseRetainedPendingWrite(msg: Any) {
-        if (retainedPendingWrite === msg) {
-            retainedPendingWrite = null
-            ReferenceCountUtil.release(msg)
-        }
     }
 }
 

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/netty/mux/MuxChannel.kt
@@ -2,6 +2,7 @@ package io.libp2p.etc.util.netty.mux
 
 import io.libp2p.core.ConnectionClosedException
 import io.libp2p.etc.util.netty.AbstractChildChannel
+import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelMetadata
 import io.netty.channel.ChannelOutboundBuffer
 import io.netty.util.ReferenceCountUtil
@@ -19,6 +20,9 @@ class MuxChannel<TData>(
 
     var remoteDisconnected = false
     var localDisconnected = false
+    private var localDisconnectSent = false
+    private var disconnectFlushedMessages = 0
+    private var retainedPendingWrite: Any? = null
 
     override fun metadata(): ChannelMetadata = ChannelMetadata(true)
     override fun localAddress0() =
@@ -32,37 +36,74 @@ class MuxChannel<TData>(
         initializer(this)
     }
 
+    fun retryWrite() {
+        if (isActive) {
+            flush()
+        }
+    }
+
+    fun setMuxWritability(index: Int, writable: Boolean) {
+        unsafe().outboundBuffer()?.setUserDefinedWritability(index, writable)
+    }
+
     @Suppress("SwallowedException")
     override fun doWrite(buf: ChannelOutboundBuffer) {
         while (true) {
             val msg = buf.current() ?: break
-            if (localDisconnected) {
+            if (localDisconnected && disconnectFlushedMessages == 0) {
                 // Must not throw from doWrite — exceptions escape uncaught to the Netty event loop.
                 // Wrap buf.remove() defensively: in some Netty versions promise listeners triggered
                 // by buf.remove() can propagate back through it.
                 try {
                     buf.remove(ConnectionClosedException("The stream was closed for writing locally: $id"))
                 } catch (e: Throwable) { }
+                releaseRetainedPendingWrite(msg)
                 continue
             }
+            if (!parent.canWriteChild(this)) {
+                retainPendingWrite(msg)
+                break
+            }
             try {
-                // the msg is released by both onChildWrite and buf.remove() so we need to retain
-                // however it is still to be confirmed that no buf leaks happen here TODO
-                ReferenceCountUtil.retain(msg)
                 @Suppress("UNCHECKED_CAST")
-                parent.onChildWrite(this, msg as TData)
-                buf.remove()
+                val consumedBytes = parent.onChildWrite(this, msg as TData)
+                if (consumedBytes <= 0) {
+                    retainPendingWrite(msg)
+                    break
+                }
+                val currentMessageComplete = msg !is ByteBuf || consumedBytes >= msg.readableBytes()
+                if (!currentMessageComplete) {
+                    retainPendingWrite(msg)
+                }
+                if (msg is ByteBuf) {
+                    buf.removeBytes(consumedBytes.toLong())
+                } else {
+                    buf.remove()
+                }
+                parent.flushChildWrites()
+                if (currentMessageComplete) {
+                    releaseRetainedPendingWrite(msg)
+                }
+                if (localDisconnected && currentMessageComplete) {
+                    disconnectFlushedMessages--
+                    if (disconnectFlushedMessages == 0) {
+                        finishLocalDisconnect()
+                        continue
+                    }
+                }
             } catch (cause: Throwable) {
                 buf.remove(cause)
+                releaseRetainedPendingWrite(msg)
             }
         }
     }
 
     override fun doDisconnect() {
         localDisconnected = true
-        parent.localDisconnect(this)
-        deactivate()
-        closeIfBothDisconnected()
+        disconnectFlushedMessages = unsafe().outboundBuffer()?.size() ?: 0
+        if (disconnectFlushedMessages == 0) {
+            finishLocalDisconnect()
+        }
     }
 
     fun onRemoteDisconnected() {
@@ -72,6 +113,10 @@ class MuxChannel<TData>(
     }
 
     override fun doClose() {
+        retainedPendingWrite?.let {
+            retainedPendingWrite = null
+            ReferenceCountUtil.release(it)
+        }
         super.doClose()
         parent.onClosed(this)
     }
@@ -81,7 +126,31 @@ class MuxChannel<TData>(
     }
 
     private fun closeIfBothDisconnected() {
-        if (remoteDisconnected && localDisconnected) closeImpl()
+        if (remoteDisconnected && localDisconnectSent) closeImpl()
+    }
+
+    private fun finishLocalDisconnect() {
+        if (localDisconnectSent) {
+            return
+        }
+        localDisconnectSent = true
+        parent.localDisconnect(this)
+        deactivate()
+        closeIfBothDisconnected()
+    }
+
+    private fun retainPendingWrite(msg: Any) {
+        if (retainedPendingWrite !== msg) {
+            retainedPendingWrite = msg
+            ReferenceCountUtil.retain(msg)
+        }
+    }
+
+    private fun releaseRetainedPendingWrite(msg: Any) {
+        if (retainedPendingWrite === msg) {
+            retainedPendingWrite = null
+            ReferenceCountUtil.release(msg)
+        }
     }
 }
 

--- a/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/mplex/MplexHandler.kt
@@ -3,7 +3,6 @@ package io.libp2p.mux.mplex
 import io.libp2p.core.StreamHandler
 import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.mux.StreamMuxer
-import io.libp2p.etc.types.sliceMaxSize
 import io.libp2p.etc.util.netty.mux.MuxChannel
 import io.libp2p.mux.MuxHandler
 import io.netty.buffer.ByteBuf
@@ -42,15 +41,19 @@ open class MplexHandler(
         }
     }
 
-    override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf) {
+    override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf): Int {
         val ctx = getChannelHandlerContext()
-        data.sliceMaxSize(maxFrameDataLength)
-            .map { frameSliceBuf ->
-                MplexFrame.createDataFrame(child.id, frameSliceBuf)
-            }.forEach { muxFrame ->
-                ctx.write(muxFrame)
-            }
-        ctx.flush()
+        var written = 0
+        while (written < data.readableBytes()) {
+            val frameLength = minOf(
+                data.readableBytes() - written,
+                maxFrameDataLength
+            )
+            val frameSliceBuf = data.retainedSlice(data.readerIndex() + written, frameLength)
+            ctx.write(MplexFrame.createDataFrame(child.id, frameSliceBuf))
+            written += frameLength
+        }
+        return written
     }
 
     override fun onLocalOpen(child: MuxChannel<ByteBuf>) {

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.properties.Delegates
 
+const val DEFAULT_MAX_BUFFERED_CONNECTION_WRITES = 10 * 1024 * 1024 // 10 MiB
 const val DEFAULT_MAX_BUFFERED_STREAM_WRITES = 64 * 1024
 const val DEFAULT_ACK_BACKLOG_LIMIT = 256
 
@@ -29,9 +30,15 @@ open class YamuxHandler(
     ready: CompletableFuture<StreamMuxer.Session>?,
     inboundStreamHandler: StreamHandler<*>,
     private val connectionInitiator: Boolean,
+    private val maxBufferedConnectionWrites: Int,
     private val ackBacklogLimit: Int,
     private val initialWindowSize: Int = INITIAL_WINDOW_SIZE
 ) : MuxHandler(ready, inboundStreamHandler) {
+
+    private companion object {
+        const val PARENT_WRITABILITY_INDEX = 1
+        const val SEND_WINDOW_WRITABILITY_INDEX = 2
+    }
 
     private val childWriteBufferWaterMark =
         WriteBufferWaterMark(DEFAULT_MAX_BUFFERED_STREAM_WRITES / 2, DEFAULT_MAX_BUFFERED_STREAM_WRITES)
@@ -45,9 +52,9 @@ open class YamuxHandler(
         val receiveWindowSize = AtomicInteger(initialWindowSize)
         var closedForWriting by Delegates.writeOnce(false)
 
-        fun dispose() {}
-
-        fun isWritable(): Boolean = sendWindowSize.get() > 0
+        fun refreshSendWindowWritability() {
+            setChildMuxWritability(id, SEND_WINDOW_WRITABILITY_INDEX, sendWindowSize.get() > 0)
+        }
 
         fun handleFrameRead(msg: YamuxFrame) {
             handleFlags(msg)
@@ -78,8 +85,13 @@ open class YamuxHandler(
 
         private fun handleWindowUpdate(msg: YamuxFrame) {
             val delta = msg.length.toInt()
-            sendWindowSize.addAndGet(delta)
-            refreshChildWritability(id)
+            // clamp the result so a misbehaving remote can't overflow the window counter
+            sendWindowSize.getAndUpdate { current ->
+                (current.toLong() + delta)
+                    .coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+                    .toInt()
+            }
+            refreshSendWindowWritability()
             retryChildWrite(id)
         }
 
@@ -129,7 +141,7 @@ open class YamuxHandler(
                 ctx.write(YamuxFrame(id, YamuxType.DATA, YamuxFlag.NONE, length.toLong(), slicedData))
                 written += length
             }
-            refreshChildWritability(id)
+            refreshSendWindowWritability()
             return written
         }
 
@@ -173,8 +185,6 @@ open class YamuxHandler(
         }
 
     override fun channelUnregistered(ctx: ChannelHandlerContext?) {
-        streamHandlers.values.forEach { it.dispose() }
-
         if (!goAwayPromise.isDone) {
             goAwayPromise.completeExceptionally(ConnectionClosedException("Connection was closed without Go Away message"))
         }
@@ -215,16 +225,46 @@ open class YamuxHandler(
         }
     }
 
-    override fun isChildWritable(child: MuxChannel<ByteBuf>): Boolean =
-        streamHandlers[child.id]?.isWritable() == true
-
     override fun onChildRegistered(child: MuxChannel<ByteBuf>) {
         child.config().setWriteBufferWaterMark(childWriteBufferWaterMark)
-        super.onChildRegistered(child)
+        child.setMuxWritability(PARENT_WRITABILITY_INDEX, getChannelHandlerContext().channel().isWritable)
+        streamHandlers[child.id]?.refreshSendWindowWritability()
+    }
+
+    override fun channelWritabilityChanged(ctx: ChannelHandlerContext) {
+        val parentWritable = ctx.channel().isWritable
+        setAllChildMuxWritability(PARENT_WRITABILITY_INDEX, parentWritable)
+        if (parentWritable) {
+            retryAllChildWrites()
+        }
+        super.channelWritabilityChanged(ctx)
     }
 
     override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf): Int {
-        return getStreamHandlerOrThrow(child.id).sendData(data)
+        val streamHandler = getStreamHandlerOrThrow(child.id)
+        if (!getChannelHandlerContext().channel().isWritable) {
+            // propagate the connection backpressure to the stream:
+            // don't queue more frames on the parent channel
+            verifyBufferedWritesLimit(child, 0)
+            return 0
+        }
+        val written = streamHandler.sendData(data)
+        if (written < data.readableBytes()) {
+            verifyBufferedWritesLimit(child, written)
+        }
+        return written
+    }
+
+    private fun verifyBufferedWritesLimit(child: MuxChannel<ByteBuf>, justWrittenBytes: Int) {
+        val bufferedBytes = totalChildPendingWriteBytes() - justWrittenBytes
+        if (bufferedBytes > maxBufferedConnectionWrites) {
+            onLocalClose(child)
+            // close the channel after the pending writes have been failed by the throw below
+            child.eventLoop().execute { child.closeImpl() }
+            throw WriteBufferOverflowMuxerException(
+                "Overflowed send buffer ($bufferedBytes/$maxBufferedConnectionWrites). Last stream attempting to write: ${child.id}"
+            )
+        }
     }
 
     override fun onLocalOpen(child: MuxChannel<ByteBuf>) {
@@ -261,7 +301,7 @@ open class YamuxHandler(
     }
 
     override fun onChildClosed(child: MuxChannel<ByteBuf>) {
-        streamHandlers.remove(child.id)?.dispose()
+        streamHandlers.remove(child.id)
     }
 
     private fun handlePing(msg: YamuxFrame) {

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxHandler.kt
@@ -5,22 +5,20 @@ import io.libp2p.core.Libp2pException
 import io.libp2p.core.StreamHandler
 import io.libp2p.core.multistream.MultistreamProtocol
 import io.libp2p.core.mux.StreamMuxer
-import io.libp2p.etc.types.sliceMaxSize
 import io.libp2p.etc.types.writeOnce
-import io.libp2p.etc.util.netty.ByteBufQueue
 import io.libp2p.etc.util.netty.mux.MuxChannel
 import io.libp2p.etc.util.netty.mux.MuxId
 import io.libp2p.mux.*
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.WriteBufferWaterMark
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.math.max
 import kotlin.properties.Delegates
 
-const val DEFAULT_MAX_BUFFERED_CONNECTION_WRITES = 10 * 1024 * 1024 // 10 MiB
+const val DEFAULT_MAX_BUFFERED_STREAM_WRITES = 64 * 1024
 const val DEFAULT_ACK_BACKLOG_LIMIT = 256
 
 const val INITIAL_WINDOW_SIZE = 256 * 1024
@@ -31,10 +29,12 @@ open class YamuxHandler(
     ready: CompletableFuture<StreamMuxer.Session>?,
     inboundStreamHandler: StreamHandler<*>,
     private val connectionInitiator: Boolean,
-    private val maxBufferedConnectionWrites: Int,
     private val ackBacklogLimit: Int,
     private val initialWindowSize: Int = INITIAL_WINDOW_SIZE
 ) : MuxHandler(ready, inboundStreamHandler) {
+
+    private val childWriteBufferWaterMark =
+        WriteBufferWaterMark(DEFAULT_MAX_BUFFERED_STREAM_WRITES / 2, DEFAULT_MAX_BUFFERED_STREAM_WRITES)
 
     private inner class YamuxStreamHandler(
         val id: MuxId,
@@ -43,12 +43,11 @@ open class YamuxHandler(
         val acknowledged = AtomicBoolean(false)
         val sendWindowSize = AtomicInteger(initialWindowSize)
         val receiveWindowSize = AtomicInteger(initialWindowSize)
-        val sendBuffer = ByteBufQueue()
         var closedForWriting by Delegates.writeOnce(false)
 
-        fun dispose() {
-            sendBuffer.dispose()
-        }
+        fun dispose() {}
+
+        fun isWritable(): Boolean = sendWindowSize.get() > 0
 
         fun handleFrameRead(msg: YamuxFrame) {
             handleFlags(msg)
@@ -80,8 +79,8 @@ open class YamuxHandler(
         private fun handleWindowUpdate(msg: YamuxFrame) {
             val delta = msg.length.toInt()
             sendWindowSize.addAndGet(delta)
-            // try to send any buffered messages after the window update
-            drainBufferAndMaybeClose()
+            refreshChildWritability(id)
+            retryChildWrite(id)
         }
 
         private fun handleFlags(msg: YamuxFrame) {
@@ -112,39 +111,26 @@ open class YamuxHandler(
             }
         }
 
-        private fun fillBuffer(data: ByteBuf) {
-            sendBuffer.push(data)
-            val totalBufferedWrites = calculateTotalBufferedWrites()
-            if (totalBufferedWrites > maxBufferedConnectionWrites + sendWindowSize.get()) {
-                onLocalClose()
-                throw WriteBufferOverflowMuxerException(
-                    "Overflowed send buffer ($totalBufferedWrites/$maxBufferedConnectionWrites). Last stream attempting to write: $id"
-                )
-            }
-        }
-
-        private fun drainBufferAndMaybeClose() {
-            val maxSendLength = max(0, sendWindowSize.get())
-            val data = sendBuffer.take(maxSendLength)
-            sendWindowSize.addAndGet(-data.readableBytes())
-            data.sliceMaxSize(maxFrameDataLength)
-                .forEach { slicedData ->
-                    val length = slicedData.readableBytes()
-                    writeAndFlushFrame(YamuxFrame(id, YamuxType.DATA, YamuxFlag.NONE, length.toLong(), slicedData))
-                }
-
-            if (closedForWriting && sendBuffer.readableBytes() == 0) {
-                writeAndFlushFrame(YamuxFrame(id, YamuxType.DATA, YamuxFlag.FIN.asSet, 0))
-            }
-        }
-
-        fun sendData(data: ByteBuf) {
+        fun sendData(data: ByteBuf): Int {
             if (closedForWriting) {
                 throw ClosedForWritingMuxerException(id)
             }
             acknowledgeInboundStreamIfNeeded()
-            fillBuffer(data)
-            drainBufferAndMaybeClose()
+            val ctx = getChannelHandlerContext()
+            var written = 0
+            while (written < data.readableBytes() && sendWindowSize.get() > 0) {
+                val length = minOf(
+                    data.readableBytes() - written,
+                    maxFrameDataLength,
+                    sendWindowSize.get()
+                )
+                val slicedData = data.retainedSlice(data.readerIndex() + written, length)
+                sendWindowSize.addAndGet(-length)
+                ctx.write(YamuxFrame(id, YamuxType.DATA, YamuxFlag.NONE, length.toLong(), slicedData))
+                written += length
+            }
+            refreshChildWritability(id)
+            return written
         }
 
         fun onLocalOpen() {
@@ -157,12 +143,11 @@ open class YamuxHandler(
 
         fun onLocalDisconnect() {
             closedForWriting = true
-            drainBufferAndMaybeClose()
+            writeAndFlushFrame(YamuxFrame(id, YamuxType.DATA, YamuxFlag.FIN.asSet, 0))
         }
 
         fun onLocalClose() {
             // close stream immediately so not transferring buffered data
-            sendBuffer.dispose()
             writeAndFlushFrame(YamuxFrame(id, YamuxType.DATA, YamuxFlag.RST.asSet, 0))
         }
     }
@@ -230,8 +215,16 @@ open class YamuxHandler(
         }
     }
 
-    override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf) {
-        getStreamHandlerOrReleaseAndThrow(child.id, data).sendData(data)
+    override fun isChildWritable(child: MuxChannel<ByteBuf>): Boolean =
+        streamHandlers[child.id]?.isWritable() == true
+
+    override fun onChildRegistered(child: MuxChannel<ByteBuf>) {
+        child.config().setWriteBufferWaterMark(childWriteBufferWaterMark)
+        super.onChildRegistered(child)
+    }
+
+    override fun onChildWrite(child: MuxChannel<ByteBuf>, data: ByteBuf): Int {
+        return getStreamHandlerOrThrow(child.id).sendData(data)
     }
 
     override fun onLocalOpen(child: MuxChannel<ByteBuf>) {
@@ -292,10 +285,6 @@ open class YamuxHandler(
             throw InvalidFrameMuxerException("Invalid StreamId for GoAway frame type: ${msg.id}")
         }
         goAwayPromise.complete(msg.length)
-    }
-
-    private fun calculateTotalBufferedWrites(): Int {
-        return streamHandlers.values.sumOf { it.sendBuffer.readableBytes() }
     }
 
     override fun generateNextId() =

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture
 class YamuxStreamMuxer(
     val inboundStreamHandler: StreamHandler<*>,
     private val multistreamProtocol: MultistreamProtocol,
+    private val maxBufferedConnectionWrites: Int,
     private val ackBacklogLimit: Int
 ) : StreamMuxer, StreamMuxerDebug {
 
@@ -32,6 +33,7 @@ class YamuxStreamMuxer(
                 muxSessionReady,
                 inboundStreamHandler,
                 ch.isInitiator,
+                maxBufferedConnectionWrites,
                 ackBacklogLimit
             )
         )

--- a/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/mux/yamux/YamuxStreamMuxer.kt
@@ -13,7 +13,6 @@ import java.util.concurrent.CompletableFuture
 class YamuxStreamMuxer(
     val inboundStreamHandler: StreamHandler<*>,
     private val multistreamProtocol: MultistreamProtocol,
-    private val maxBufferedConnectionWrites: Int,
     private val ackBacklogLimit: Int
 ) : StreamMuxer, StreamMuxerDebug {
 
@@ -33,7 +32,6 @@ class YamuxStreamMuxer(
                 muxSessionReady,
                 inboundStreamHandler,
                 ch.isInitiator,
-                maxBufferedConnectionWrites,
                 ackBacklogLimit
             )
         )

--- a/libp2p/src/main/kotlin/io/libp2p/protocol/Ping.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/protocol/Ping.kt
@@ -53,7 +53,7 @@ open class PingProtocol(var pingSize: Int) : ProtocolHandler<PingController>(Lon
 
     open inner class PingResponder : ProtocolMessageHandler<ByteBuf>, PingController {
         override fun onMessage(stream: Stream, msg: ByteBuf) {
-            stream.writeAndFlush(msg)
+            stream.writeAndFlush(msg.retain())
         }
 
         override fun ping(): CompletableFuture<Long> {

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -9,6 +9,8 @@ import io.libp2p.mux.AckBacklogLimitExceededMuxerException
 import io.libp2p.mux.MuxHandler
 import io.libp2p.mux.MuxHandlerAbstractTest
 import io.libp2p.mux.MuxHandlerAbstractTest.AbstractTestMuxFrame.Flag.*
+import io.libp2p.mux.UnknownStreamIdMuxerException
+import io.libp2p.mux.WriteBufferOverflowMuxerException
 import io.libp2p.tools.readAllBytesAndRelease
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
@@ -22,6 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class YamuxHandlerTest : MuxHandlerAbstractTest() {
 
     override val maxFrameDataLength = 256
+    private val maxBufferedConnectionWrites = 100 * 1024
     private val ackBacklogLimit = 42
     private val initialWindowSize = 300
     override val localMuxIdGenerator = YamuxStreamIdGenerator(isLocalConnectionInitiator).toIterator()
@@ -37,6 +40,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             null,
             streamHandler,
             true,
+            maxBufferedConnectionWrites,
             ackBacklogLimit,
             initialWindowSize
         ) {
@@ -285,6 +289,120 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             .joinToString(separator = "")
 
         assertThat(receivedData).isEqualTo("B".repeat(messageSize * 6))
+    }
+
+    @Test
+    fun `overflowing buffered writes when send window is exhausted sends RST and fails the writes`() {
+        val handler = openStreamLocal()
+        val muxId = readFrameOrThrow().streamId.toMuxId()
+
+        // shrink the window to 0 so all writes stay pending
+        ech.writeInbound(
+            YamuxFrame(
+                muxId,
+                YamuxType.WINDOW_UPDATE,
+                YamuxFlag.ACK.asSet,
+                -initialWindowSize.toLong()
+            )
+        )
+
+        val messageSize = 60 * 1024
+        val createMessage: () -> ByteBuf =
+            { "42".repeat(messageSize).fromHex().toByteBuf(allocateBuf()) }
+
+        val writeResult1 = handler.ctx.writeAndFlush(createMessage())
+        assertThat(writeResult1.isDone).isFalse()
+
+        // the second write overflows maxBufferedConnectionWrites
+        val writeResult2 = handler.ctx.writeAndFlush(createMessage())
+
+        assertThat(writeResult1.isDone).isTrue()
+        assertThat(writeResult1.cause()).isInstanceOf(WriteBufferOverflowMuxerException::class.java)
+        assertThat(writeResult2.isDone).isTrue()
+        assertThat(writeResult2.cause()).isInstanceOf(UnknownStreamIdMuxerException::class.java)
+
+        val frame = readYamuxFrameOrThrow()
+        assertThat(frame.flags).containsExactly(YamuxFlag.RST)
+
+        // the stream channel is closed and its buffered writes are released
+        ech.runPendingTasks()
+        assertThat(handler.ctx.channel().isOpen).isFalse()
+    }
+
+    @Test
+    fun `overflowing buffered writes when parent channel is not writable sends RST and fails the writes`() {
+        val handler = openStreamLocal()
+        readFrameOrThrow()
+
+        ech.unsafe().outboundBuffer().setUserDefinedWritability(1, false)
+        ech.runPendingTasks()
+        assertThat(handler.ctx.channel().isWritable).isFalse()
+
+        val messageSize = 60 * 1024
+        val createMessage: () -> ByteBuf =
+            { "42".repeat(messageSize).fromHex().toByteBuf(allocateBuf()) }
+
+        val writeResult1 = handler.ctx.writeAndFlush(createMessage())
+        assertThat(writeResult1.isDone).isFalse()
+
+        // the second write overflows maxBufferedConnectionWrites
+        val writeResult2 = handler.ctx.writeAndFlush(createMessage())
+
+        assertThat(writeResult1.cause()).isInstanceOf(WriteBufferOverflowMuxerException::class.java)
+        assertThat(writeResult2.cause()).isInstanceOf(UnknownStreamIdMuxerException::class.java)
+
+        val frame = readYamuxFrameOrThrow()
+        assertThat(frame.flags).containsExactly(YamuxFlag.RST)
+
+        ech.runPendingTasks()
+        assertThat(handler.ctx.channel().isOpen).isFalse()
+    }
+
+    @Test
+    fun `child channel should be unwritable when send window is exhausted and writable after window update`() {
+        val handler = openStreamLocal()
+        val muxId = readFrameOrThrow().streamId.toMuxId()
+
+        assertThat(handler.ctx.channel().isWritable).isTrue()
+
+        // writing 1 byte more than the send window allows
+        val writeResult = handler.ctx.writeAndFlush(
+            "42".repeat(initialWindowSize + 1).fromHex().toByteBuf(allocateBuf())
+        )
+
+        // the window is exhausted: the child should be unwritable even though
+        // its pending bytes are far below the write buffer watermark
+        assertThat(handler.ctx.channel().isWritable).isFalse()
+        assertThat(writeResult.isDone).isFalse()
+
+        ech.writeInbound(YamuxFrame(muxId, YamuxType.WINDOW_UPDATE, YamuxFlag.ACK.asSet, 1000))
+
+        assertThat(handler.ctx.channel().isWritable).isTrue()
+        assertThat(writeResult.isSuccess).isTrue()
+
+        generateSequence { readYamuxFrame() }.forEach { it.data?.release() }
+    }
+
+    @Test
+    fun `huge cumulative window updates should not overflow the send window`() {
+        val handler = openStreamLocal()
+        val muxId = readFrameOrThrow().streamId.toMuxId()
+
+        repeat(3) {
+            ech.writeInbound(
+                YamuxFrame(
+                    muxId,
+                    YamuxType.WINDOW_UPDATE,
+                    YamuxFlag.ACK.asSet,
+                    Int.MAX_VALUE.toLong()
+                )
+            )
+        }
+
+        val writeResult = handler.ctx.writeAndFlush("1984".fromHex().toByteBuf(allocateBuf()))
+
+        assertThat(writeResult.isSuccess).isTrue()
+        assertThat(readFrameOrThrow().data).isEqualTo("1984")
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/mux/yamux/YamuxHandlerTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.ValueSource
 class YamuxHandlerTest : MuxHandlerAbstractTest() {
 
     override val maxFrameDataLength = 256
-    private val maxBufferedConnectionWrites = 512
     private val ackBacklogLimit = 42
     private val initialWindowSize = 300
     override val localMuxIdGenerator = YamuxStreamIdGenerator(isLocalConnectionInitiator).toIterator()
@@ -38,7 +37,6 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             null,
             streamHandler,
             true,
-            maxBufferedConnectionWrites,
             ackBacklogLimit,
             initialWindowSize
         ) {
@@ -153,13 +151,38 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             )
         )
 
-        handler.ctx.writeAndFlush("1984".fromHex().toByteBuf(allocateBuf()))
+        val writeResult = handler.ctx.writeAndFlush("1984".fromHex().toByteBuf(allocateBuf()))
 
         assertThat(readFrame()).isNull()
+        assertThat(writeResult.isDone).isFalse()
 
         ech.writeInbound(YamuxFrame(streamId.toMuxId(), YamuxType.WINDOW_UPDATE, YamuxFlag.ACK.asSet, 5000))
         val frame = readFrameOrThrow()
         assertThat(frame.data).isEqualTo("1984")
+        assertThat(writeResult.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `data should stay pending while parent channel is not writable`() {
+        val handler = openStreamLocal()
+        readFrameOrThrow()
+
+        ech.unsafe().outboundBuffer().setUserDefinedWritability(1, false)
+        ech.runPendingTasks()
+
+        assertThat(handler.ctx.channel().isWritable).isFalse()
+
+        val writeResult = handler.ctx.writeAndFlush("1984".fromHex().toByteBuf(allocateBuf()))
+
+        assertThat(readFrame()).isNull()
+        assertThat(writeResult.isDone).isFalse()
+
+        ech.unsafe().outboundBuffer().setUserDefinedWritability(1, true)
+        ech.runPendingTasks()
+
+        val frame = readFrameOrThrow()
+        assertThat(frame.data).isEqualTo("1984")
+        assertThat(writeResult.isSuccess).isTrue()
     }
 
     @Test
@@ -222,7 +245,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
     }
 
     @Test
-    fun `overflowing buffer sends RST flag and throws an exception`() {
+    fun `writes remain pending and make child unwritable when send window is exhausted`() {
         val handler = openStreamLocal()
         val muxId = readFrameOrThrow().streamId.toMuxId()
 
@@ -235,23 +258,33 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
             )
         )
 
+        val messageSize = DEFAULT_MAX_BUFFERED_STREAM_WRITES / 5
         val createMessage: () -> ByteBuf =
-            { "42".repeat(maxBufferedConnectionWrites / 5).fromHex().toByteBuf(allocateBuf()) }
+            { "42".repeat(messageSize).fromHex().toByteBuf(allocateBuf()) }
 
-        for (i in 1..5) {
-            val writeResult = handler.ctx.writeAndFlush(createMessage())
-            assertThat(writeResult.isSuccess).isTrue()
+        val writeResults = (1..6).map {
+            handler.ctx.writeAndFlush(createMessage())
         }
 
-        // next message will overflow the configured buffer
-        val writeResult = handler.ctx.writeAndFlush(createMessage())
-        assertThat(writeResult.isSuccess).isFalse()
-        assertThat(writeResult.cause())
-            .isInstanceOf(Libp2pException::class.java)
-            .hasMessage("Overflowed send buffer (612/512). Last stream attempting to write: $muxId")
+        assertThat(readYamuxFrame()).isNull()
+        assertThat(handler.ctx.channel().isWritable).isFalse()
+        assertThat(writeResults).allMatch { !it.isDone }
 
-        val frame = readYamuxFrameOrThrow()
-        assertThat(frame.flags).containsExactly(YamuxFlag.RST)
+        ech.writeInbound(YamuxFrame(muxId, YamuxType.WINDOW_UPDATE, YamuxFlag.ACK.asSet, (messageSize * 6).toLong()))
+
+        assertThat(handler.ctx.channel().isWritable).isFalse()
+        assertThat(writeResults).allMatch { it.isSuccess }
+
+        val receivedData = generateSequence {
+            readYamuxFrame()
+        }
+            .map {
+                assertThat(it.data).isNotNull()
+                String(it.data!!.readAllBytesAndRelease())
+            }
+            .joinToString(separator = "")
+
+        assertThat(receivedData).isEqualTo("B".repeat(messageSize * 6))
     }
 
     @Test
@@ -281,7 +314,7 @@ class YamuxHandlerTest : MuxHandlerAbstractTest() {
         val range = 1..messagesToSend
 
         // 100 window updates should be sent to ensure buffer is flushed and all messages are sent
-        // so will send them at random times ensuring maxBufferedConnectionWrites can never be reached
+        // so will send them at random times and never exhaust the child channel write buffer
         val windowUpdatesIndices = (range).chunked(100).flatMap {
             it.shuffled().take(20)
         }


### PR DESCRIPTION
## Summary

  This PR improves yamux write backpressure by removing yamux’s private outbound data buffer and routing blocked writes
  through Netty stream-channel backpressure instead.

  Previously, yamux buffered blocked stream writes internally in `ByteBufQueue`, controlled by
  `maxBufferedConnectionWrites`. Downstream users had to tune that value, and in Teku it needed to be set as high as 150
  MiB to avoid write-buffer overflow. That made yamux unexpectedly memory intensive.

  With this change, `maxBufferedConnectionWrites` is removed. Yamux no longer exposes a connection-level buffered-write
  knob. When a stream cannot send because its yamux send window is exhausted, data remains pending in the stream
  `MuxChannel` outbound buffer, the stream becomes unwritable, and the write futures remain pending. Writes resume when
  a `WINDOW_UPDATE` is received.

  ## Changes

  - Remove `maxBufferedConnectionWrites` from the yamux API.
  - Remove yamux’s internal `ByteBufQueue` send buffer.
  - Make muxed stream channels reflect:
    - parent Netty channel writability
    - yamux stream send-window availability
    - stream write-buffer watermarks
  - Keep stream writes pending while yamux cannot consume data due to flow control.
  - Retry pending writes on yamux `WINDOW_UPDATE` and parent channel writability changes.
  - Delay local FIN until already-flushed stream data has drained.
  - Preserve correct `ByteBuf` ownership for pending partial writes and ping echo responses.
  - Update yamux tests for pending writes, parent backpressure, and exhausted send-window behavior.

  ## Notes

  This should address the main yamux memory/backpressure issue that forced Teku to configure very large
  `maxBufferedConnectionWrites` values. Applications should no longer need to choose a yamux buffered-write limit.

  This also substantially addresses stream-level `Channel.isWritable` support for muxed streams, related to #282. It
  does not fully implement the stricter #316 behavior of completing stream write futures only after bytes are written to
  the underlying transport, but write futures now remain pending while yamux cannot consume data due to flow-control.