### PR TITLE
fix(quic): dial from ephemeral port instead of reusing listener port

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -215,61 +215,36 @@ class QuicTransport(
             .build()
 
         val targetAddr = fromMultiaddr(addr) as InetSocketAddress
-        val family = if (targetAddr.address is Inet6Address) AddressFamily.IPV6 else AddressFamily.IPV4
-        val existingListenerChannel = listenerChannelsByFamily[family]
 
-        // Attempt to bind the client socket to the same port as an active listener for
-        // consistent NAT mappings. Falls back to an ephemeral port if binding fails
-        // (SO_REUSEADDR alone may be insufficient for UDP port sharing on some platforms;
-        // TODO: add SO_REUSEPORT support for Linux/Epoll).
-        val bindAddr: InetSocketAddress = if (existingListenerChannel != null) {
-            val listenerPort = (existingListenerChannel.localAddress() as? InetSocketAddress)?.port ?: 0
-            val wildcard = if (family == AddressFamily.IPV6) "::" else "0.0.0.0"
-            InetSocketAddress(wildcard, listenerPort)
-        } else {
-            InetSocketAddress(0) // ephemeral port
-        }
-
-        fun connectViaBoundChannel(boundAddr: InetSocketAddress): CompletableFuture<QuicChannel> {
-            return client.clone()
-                .handler(requestsHandler)
-                .option(ChannelOption.SO_REUSEADDR, true)
-                .bind(boundAddr)
-                .toCompletableFuture()
-                .thenCompose { udpChannel ->
-                    QuicChannel.newBootstrap(udpChannel)
-                        .streamOption(ChannelOption.ALLOCATOR, allocator)
-                        .option(ChannelOption.AUTO_READ, true)
-                        .option(ChannelOption.ALLOCATOR, allocator)
-                        .remoteAddress(targetAddr)
-                        .handler(
-                            nettyInitializer {
-                                val quicCh = it.channel as QuicChannel
-                                val connection = ConnectionOverNetty(quicCh, this@QuicTransport, true)
-                                // ConnectionOverNetty.init sets quicCh.attr(CONNECTION) = connection,
-                                // so InboundStreamHandler can find it before thenApply runs.
-                                connection.setMuxerSession(QuicMuxerSession(quicCh, connection))
-                            }
-                        )
-                        .streamHandler(InboundStreamHandler(multistreamProtocol, protocols))
-                        .connect()
-                        .toCompletableFuture()
-                }
-        }
-
-        val quicConnFuture: CompletableFuture<QuicChannel> = if (existingListenerChannel != null) {
-            connectViaBoundChannel(bindAddr).handle { result, ex ->
-                if (ex != null) {
-                    // Port reuse failed (SO_REUSEADDR insufficient on this platform); fall back to ephemeral port.
-                    logger.debug("Could not reuse listener port {} for dial ({}), using ephemeral port", bindAddr, ex.message)
-                    connectViaBoundChannel(InetSocketAddress(0))
-                } else {
-                    CompletableFuture.completedFuture(result)
-                }
-            }.thenCompose { it }
-        } else {
-            connectViaBoundChannel(InetSocketAddress(0))
-        }
+        // Always bind the dial socket to an ephemeral port. We deliberately do NOT try to reuse an
+        // active listener's port: two UDP sockets cannot share a port without SO_REUSEPORT, and
+        // even with it the kernel may deliver a dial's response packets to the listener socket
+        // (which runs a QUIC *server* codec), silently breaking the handshake. NAT-consistent
+        // dialing for hole punching is handled separately by dialAsListener, which reuses the
+        // listener socket directly.
+        val quicConnFuture: CompletableFuture<QuicChannel> = client.clone()
+            .handler(requestsHandler)
+            .bind(InetSocketAddress(0))
+            .toCompletableFuture()
+            .thenCompose { udpChannel ->
+                QuicChannel.newBootstrap(udpChannel)
+                    .streamOption(ChannelOption.ALLOCATOR, allocator)
+                    .option(ChannelOption.AUTO_READ, true)
+                    .option(ChannelOption.ALLOCATOR, allocator)
+                    .remoteAddress(targetAddr)
+                    .handler(
+                        nettyInitializer {
+                            val quicCh = it.channel as QuicChannel
+                            val connection = ConnectionOverNetty(quicCh, this@QuicTransport, true)
+                            // ConnectionOverNetty.init sets quicCh.attr(CONNECTION) = connection,
+                            // so InboundStreamHandler can find it before thenApply runs.
+                            connection.setMuxerSession(QuicMuxerSession(quicCh, connection))
+                        }
+                    )
+                    .streamHandler(InboundStreamHandler(multistreamProtocol, protocols))
+                    .connect()
+                    .toCompletableFuture()
+            }
 
         return quicConnFuture
             .thenApply {

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -596,6 +596,60 @@ public class QuicServerTestJava {
   }
 
   /**
+   * Reproduces the broken outbound dial path: when the dialing transport ALSO has an active QUIC
+   * listener (as every real node does, e.g. Teku), {@code dial()} takes the port-reuse branch
+   * instead of the clean ephemeral path that all the other tests exercise. This must still complete
+   * a working outbound connection.
+   */
+  @Test
+  void dialWhileListeningCompletes() throws Exception {
+    String serverListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+    String dialerListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Pair<PrivKey, PubKey> serverKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    Pair<PrivKey, PubKey> dialerKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    PeerId serverPeerId = PeerId.fromPubKey(serverKeyPair.component2());
+
+    List<io.libp2p.core.multistream.ProtocolBinding<?>> emptyProtocols = new ArrayList<>();
+
+    QuicTransport serverTransport = QuicTransport.ECDSA(serverKeyPair.component1(), emptyProtocols);
+    QuicTransport dialerTransport = QuicTransport.ECDSA(dialerKeyPair.component1(), emptyProtocols);
+    serverTransport.initialize();
+    dialerTransport.initialize();
+
+    CompletableFuture<PeerId> serverSidePeerId = new CompletableFuture<>();
+    serverTransport
+        .listen(
+            new Multiaddr(serverListenAddress),
+            conn -> serverSidePeerId.complete(conn.secureSession().getRemoteId()),
+            null)
+        .get(5, TimeUnit.SECONDS);
+
+    // The dialer is ALSO listening on QUIC — this is what triggers the broken port-reuse branch.
+    dialerTransport
+        .listen(new Multiaddr(dialerListenAddress), conn -> {}, null)
+        .get(5, TimeUnit.SECONDS);
+
+    CompletableFuture<PeerId> dialerSidePeerId = new CompletableFuture<>();
+    Connection connection =
+        dialerTransport
+            .dial(
+                new Multiaddr(serverListenAddress),
+                conn -> dialerSidePeerId.complete(conn.secureSession().getRemoteId()),
+                null)
+            .get(10, TimeUnit.SECONDS);
+
+    Assertions.assertEquals(
+        serverPeerId,
+        dialerSidePeerId.get(5, TimeUnit.SECONDS),
+        "Outbound dial from a listening transport must complete the QUIC handshake");
+    Assertions.assertEquals(serverPeerId, connection.secureSession().getRemoteId());
+
+    dialerTransport.close().get(5, TimeUnit.SECONDS);
+    serverTransport.close().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
    * Verify that dialAsListener times out when no peer connects back. This tests the timeout path
    * without requiring a real hole punch.
    */


### PR DESCRIPTION
When the dialing transport had an active QUIC listener, dial() tried to bind a separate NioDatagramChannel to the listener's own port using only SO_REUSEADDR. On Linux two UDP sockets cannot share a port without SO_REUSEPORT (an Epoll-only option), so the bind threw BindException. The fallback then re-used the same non-@Sharable QUIC codec handler instance on a second channel, which also throws, so the outbound connection never completed and timed out — 0 successful outbound dials on listening nodes.

Always bind the dial socket to an ephemeral port (the path already exercised by every passing QUIC test). NAT-consistent dialing for hole punching is unaffected: dialAsListener reuses the listener socket directly.

Add QuicServerTestJava.dialWhileListeningCompletes regression test that dials while a listener is active — the previously-untested broken branch.