### PR TITLE
Fix quic close write logic

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStream.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStream.kt
@@ -3,8 +3,11 @@ package io.libp2p.transport.quic
 import io.libp2p.core.Connection
 import io.libp2p.etc.types.toVoidCompletableFuture
 import io.libp2p.transport.implementation.StreamOverNetty
+import io.netty.channel.socket.ChannelOutputShutdownException
 import io.netty.handler.codec.quic.QuicStreamChannel
+import java.nio.channels.ClosedChannelException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 
 class QuicStream(
     val quicStreamChannel: QuicStreamChannel,
@@ -17,6 +20,21 @@ class QuicStream(
     }
 
     override fun closeWrite(): CompletableFuture<Unit> {
+        // closeWrite must be idempotent and tolerate an already closed stream (e.g. when the
+        // connection was closed first), matching the muxer-based transports where this is a no-op.
+        // Netty fails shutdownOutput in both cases since closing a QUIC stream also sends the FIN.
+        if (!quicStreamChannel.isOpen || quicStreamChannel.isOutputShutdown) {
+            return CompletableFuture.completedFuture(Unit)
+        }
         return quicStreamChannel.shutdownOutput().toVoidCompletableFuture()
+            .exceptionally { t ->
+                val cause = if (t is CompletionException) t.cause ?: t else t
+                when (cause) {
+                    // FIN already sent or stream already closed concurrently: write side is
+                    // closed, which is all the caller asked for
+                    is ChannelOutputShutdownException, is ClosedChannelException -> Unit
+                    else -> throw t
+                }
+            }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverter.kt
@@ -4,9 +4,10 @@ import io.libp2p.etc.util.netty.mux.RemoteWriteClosed
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.socket.ChannelInputShutdownReadComplete
+import io.netty.handler.codec.quic.QuicStreamResetException
 
 /**
- * Convert QUIC library specific event on remote stream close to Libp2p specific event
+ * Convert QUIC library specific events on remote stream close to Libp2p specific behavior
  */
 class QuicStreamReadCloseEventConverter : ChannelInboundHandlerAdapter() {
 
@@ -15,6 +16,18 @@ class QuicStreamReadCloseEventConverter : ChannelInboundHandlerAdapter() {
             ctx.fireUserEventTriggered(RemoteWriteClosed)
         } else {
             super.userEventTriggered(ctx, evt)
+        }
+    }
+
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+        if (cause is QuicStreamResetException) {
+            // The remote peer reset the stream. The muxer-based transports close the
+            // stream quietly in this case (see AbstractMuxHandler.onRemoteClose) — match
+            // that instead of surfacing the exception. Netty also leaves the stream
+            // channel open after a reset, so close it here to not leak it.
+            ctx.close()
+        } else {
+            ctx.fireExceptionCaught(cause)
         }
     }
 }

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -18,16 +18,22 @@ import io.libp2p.protocol.BlobController;
 import io.libp2p.protocol.OneShotPing;
 import io.libp2p.protocol.OneShotPingController;
 import io.libp2p.protocol.Ping;
+import io.libp2p.protocol.PingBinding;
 import io.libp2p.protocol.PingController;
+import io.libp2p.protocol.PingProtocol;
 import io.libp2p.security.noise.NoiseXXSecureChannel;
 import io.libp2p.security.tls.TlsSecureChannel;
 import io.libp2p.transport.tcp.TcpTransport;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.quic.QuicStreamResetException;
 import io.netty.handler.logging.LogLevel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -689,6 +695,79 @@ public class QuicServerTestJava {
 
     // Must complete without exception even though the stream is already gone
     pingStream.closeWrite().get(5, TimeUnit.SECONDS);
+
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * A remote STREAM_RESET must close the local stream quietly, matching the muxer-based transports
+   * where a remote RST closes the child channel (see AbstractMuxHandler.onRemoteClose) without
+   * surfacing an exception to application handlers. Without this, Netty fires
+   * QuicStreamResetException into the app pipeline (Teku logs "Unhandled error while processes
+   * req/response") and leaves the stream channel open.
+   */
+  @Test
+  void remoteStreamResetClosesStreamQuietly() throws Exception {
+    String localListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    List<Throwable> serverStreamExceptions = new CopyOnWriteArrayList<>();
+    CompletableFuture<Stream> serverStreamFuture = new CompletableFuture<>();
+    // Stream visitors are not wired into the QUIC transport, so capture the server-side
+    // stream (and any exception reaching application handlers) via the protocol handler
+    PingProtocol capturingPing =
+        new PingProtocol(32) {
+          @Override
+          protected CompletableFuture<PingController> onStartResponder(@NotNull Stream stream) {
+            stream.pushHandler(
+                new ChannelInboundHandlerAdapter() {
+                  @Override
+                  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    serverStreamExceptions.add(cause);
+                    ctx.fireExceptionCaught(cause);
+                  }
+                });
+            serverStreamFuture.complete(stream);
+            return super.onStartResponder(stream);
+          }
+        };
+
+    Host clientHost =
+        new HostBuilder().keyType(KeyType.ED25519).secureTransport(QuicTransport::ECDSA).build();
+
+    Host serverHost =
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::ECDSA)
+            .protocol(new PingBinding(capturingPing))
+            .listen(localListenAddress)
+            .build();
+
+    clientHost.start().get(5, TimeUnit.SECONDS);
+    serverHost.start().get(5, TimeUnit.SECONDS);
+
+    Connection connection =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .get(10, TimeUnit.SECONDS);
+
+    StreamPromise<PingController> ping = connection.muxerSession().createStream(new Ping());
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    PingController pingCtr = ping.getController().get(5, TimeUnit.SECONDS);
+    pingCtr.ping().get(5, TimeUnit.SECONDS);
+
+    Stream serverStream = serverStreamFuture.get(5, TimeUnit.SECONDS);
+
+    // Reset the stream from the client side: quiche sends a RESET_STREAM frame
+    ((QuicStream) pingStream).getQuicStreamChannel().shutdownOutput(1).sync();
+
+    serverStream.closeFuture().get(5, TimeUnit.SECONDS);
+    Assertions.assertTrue(
+        serverStreamExceptions.stream().noneMatch(t -> t instanceof QuicStreamResetException),
+        "Remote stream reset must not surface QuicStreamResetException to application handlers,"
+            + " got: "
+            + serverStreamExceptions);
 
     clientHost.stop().get(5, TimeUnit.SECONDS);
     serverHost.stop().get(5, TimeUnit.SECONDS);

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -650,6 +650,87 @@ public class QuicServerTestJava {
   }
 
   /**
+   * Closing the write side of a stream whose connection was already closed must not fail. Mirrors
+   * Teku's Goodbye flow: the peer is disconnected (closing the QUIC connection and all its
+   * streams), then the RPC layer half-closes the stream it was responding on. The muxer-based
+   * transports tolerate this silently; QUIC must too instead of failing with
+   * "ChannelOutputShutdownException: Fin was sent already".
+   */
+  @Test
+  void closeWriteAfterConnectionCloseSucceeds() throws Exception {
+    String localListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Host clientHost =
+        new HostBuilder().keyType(KeyType.ED25519).secureTransport(QuicTransport::ECDSA).build();
+
+    Host serverHost =
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::ECDSA)
+            .protocol(new Ping())
+            .listen(localListenAddress)
+            .build();
+
+    clientHost.start().get(5, TimeUnit.SECONDS);
+    serverHost.start().get(5, TimeUnit.SECONDS);
+
+    Connection connection =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .get(10, TimeUnit.SECONDS);
+
+    StreamPromise<PingController> ping = connection.muxerSession().createStream(new Ping());
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    ping.getController().get(5, TimeUnit.SECONDS);
+
+    connection.close().get(5, TimeUnit.SECONDS);
+    pingStream.closeFuture().get(5, TimeUnit.SECONDS);
+
+    // Must complete without exception even though the stream is already gone
+    pingStream.closeWrite().get(5, TimeUnit.SECONDS);
+
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+  }
+
+  /** Calling closeWrite twice must be idempotent: the first call already sent the FIN. */
+  @Test
+  void closeWriteIsIdempotent() throws Exception {
+    String localListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Host clientHost =
+        new HostBuilder().keyType(KeyType.ED25519).secureTransport(QuicTransport::ECDSA).build();
+
+    Host serverHost =
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::ECDSA)
+            .protocol(new Ping())
+            .listen(localListenAddress)
+            .build();
+
+    clientHost.start().get(5, TimeUnit.SECONDS);
+    serverHost.start().get(5, TimeUnit.SECONDS);
+
+    Connection connection =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .get(10, TimeUnit.SECONDS);
+
+    StreamPromise<PingController> ping = connection.muxerSession().createStream(new Ping());
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    ping.getController().get(5, TimeUnit.SECONDS);
+
+    pingStream.closeWrite().get(5, TimeUnit.SECONDS);
+    pingStream.closeWrite().get(5, TimeUnit.SECONDS);
+
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
    * Verify that dialAsListener times out when no peer connects back. This tests the timeout path
    * without requiring a real hole punch.
    */


### PR DESCRIPTION
Two fixes to bring QUIC streams handling closer to how we handle when using the muxer on TCP.

 1. Close quietly on remote STREAM_RESET — when a peer resets a stream (happens a lot on disconnects and cancelled RPCs), avoid Netty firing QuicStreamResetException and leaving the stream open.
  2. Make closeWrite accept already-closed streams beacuse of how Teku's Goodbye flow closes the connection (and its streams).