### PR TITLE
fix(quic): close leaked dial datagram channels; harden NoiseXXCodec OOM handling

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/OtherExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/OtherExt.kt
@@ -44,3 +44,9 @@ fun <T : Throwable> Throwable.hasCauseOfType(clazz: KClass<T>) =
     Throwables.getCausalChain(this)
         .filter(clazz::isInstance)
         .any()
+
+fun <T : Throwable> Throwable.findCauseOfType(clazz: KClass<T>): T? =
+    Throwables.getCausalChain(this)
+        .filter(clazz::isInstance)
+        .map { clazz.java.cast(it) }
+        .firstOrNull()

--- a/libp2p/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
@@ -49,8 +49,16 @@ class NoiseXXCodec(val aliceCipher: CipherState, val bobCipher: CipherState) :
         } else if (cause.hasCauseOfType(SecureChannelError::class)) {
             logger.debug("Invalid Noise content", cause)
             closeAbruptly(ctx)
+        } else if (cause.hasCauseOfType(Error::class)) {
+            // A fatal JVM error (e.g. OutOfMemoryError) must never be swallowed: close the
+            // channel to release resources, then rethrow so the failure is surfaced rather
+            // than downgraded to a single log line while the event loop keeps running.
+            logger.error("Fatal error in Noise channel, closing", cause)
+            closeAbruptly(ctx)
+            throw cause
         } else {
             logger.error("Unexpected error in Noise channel", cause)
+            closeAbruptly(ctx)
         }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/security/noise/NoiseXXCodec.kt
@@ -1,6 +1,7 @@
 package io.libp2p.security.noise
 
 import com.southernstorm.noise.protocol.CipherState
+import io.libp2p.etc.types.findCauseOfType
 import io.libp2p.etc.types.hasCauseOfType
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.security.CantDecryptInboundException
@@ -49,13 +50,17 @@ class NoiseXXCodec(val aliceCipher: CipherState, val bobCipher: CipherState) :
         } else if (cause.hasCauseOfType(SecureChannelError::class)) {
             logger.debug("Invalid Noise content", cause)
             closeAbruptly(ctx)
-        } else if (cause.hasCauseOfType(Error::class)) {
+        } else if (cause.findCauseOfType(Error::class) != null) {
             // A fatal JVM error (e.g. OutOfMemoryError) must never be swallowed: close the
             // channel to release resources, then rethrow so the failure is surfaced rather
             // than downgraded to a single log line while the event loop keeps running.
-            logger.error("Fatal error in Noise channel, closing", cause)
+            // Netty wraps throwables from encode()/decode() (e.g. in EncoderException), so we
+            // extract and rethrow the actual Error rather than the runtime wrapper, which would
+            // otherwise downgrade the fatal JVM signal.
+            val fatal = cause.findCauseOfType(Error::class)!!
+            logger.error("Fatal error in Noise channel, closing", fatal)
             closeAbruptly(ctx)
-            throw cause
+            throw fatal
         } else {
             logger.error("Unexpected error in Noise channel", cause)
             closeAbruptly(ctx)

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -252,14 +252,18 @@ class QuicTransport(
                         if (ex != null || quicCh == null) {
                             udpChannel.close()
                         } else {
+                            // Register as soon as the connection is established — before the dependent
+                            // thenApply runs — so that a dial cancelled mid-race (whose thenApply is
+                            // skipped) still has its channel tracked, closeable on transport shutdown,
+                            // and counted in activeConnections.
+                            registerChannel(quicCh)
                             quicCh.closeFuture().addListener { udpChannel.close() }
                         }
                     }
             }
 
-        return quicConnFuture
+        val connectionFuture: CompletableFuture<Connection> = quicConnFuture
             .thenApply {
-                registerChannel(it)
                 try {
                     val connection = it.attr(CONNECTION).get() as ConnectionOverNetty
 
@@ -306,6 +310,18 @@ class QuicTransport(
                     throw e
                 }
             }
+
+        // NetworkImpl.connect() cancels losing dial futures in the multi-address race. Cancelling
+        // this dependent future does NOT propagate upstream to quicConnFuture, so if the handshake
+        // later completes, the thenApply body above is skipped and the established QuicChannel is
+        // never registered, handed to the caller, nor closed. Close it explicitly on cancellation
+        // so neither it nor its underlying datagram channel is leaked (mirrors the TCP transport).
+        connectionFuture.whenComplete { _, _ ->
+            if (connectionFuture.isCancelled) {
+                quicConnFuture.thenAccept { it.close() }
+            }
+        }
+        return connectionFuture
     }
 
     private fun registerChannel(ch: Channel) {

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -244,49 +244,67 @@ class QuicTransport(
                     .streamHandler(InboundStreamHandler(multistreamProtocol, protocols))
                     .connect()
                     .toCompletableFuture()
+                    .whenComplete { quicCh, ex ->
+                        // The QuicChannel rides on its own ephemeral datagram socket. Closing a
+                        // QuicChannel does NOT close its parent datagram channel, so we must tie the
+                        // two lifecycles together. Otherwise every dial leaks a NioDatagramChannel
+                        // (plus its codec, native quiche config and queued direct buffers).
+                        if (ex != null || quicCh == null) {
+                            udpChannel.close()
+                        } else {
+                            quicCh.closeFuture().addListener { udpChannel.close() }
+                        }
+                    }
             }
 
         return quicConnFuture
             .thenApply {
                 registerChannel(it)
-                val connection = it.attr(CONNECTION).get() as ConnectionOverNetty
+                try {
+                    val connection = it.attr(CONNECTION).get() as ConnectionOverNetty
 
-                val peerCerts = it.sslEngine()?.session?.peerCertificates
-                    ?: throw Libp2pException("No peer certificates available after QUIC handshake with $addr")
+                    val peerCerts = it.sslEngine()?.session?.peerCertificates
+                        ?: throw Libp2pException("No peer certificates available after QUIC handshake with $addr")
 
-                val expectedPeerId = addr.getPeerId()
-                val remotePeerId: PeerId
-                val remotePubKey: io.libp2p.core.crypto.PubKey
+                    val expectedPeerId = addr.getPeerId()
+                    val remotePeerId: PeerId
+                    val remotePubKey: io.libp2p.core.crypto.PubKey
 
-                if (expectedPeerId != null) {
-                    // PeerId was pre-validated by trustManager during TLS handshake.
-                    // For inline-key peerIds (identity multihash), extract pubkey from the multihash.
-                    val pubHash = Multihash.of(expectedPeerId.bytes.toByteBuf())
-                    remotePubKey = if (pubHash.desc.digest == Multihash.Digest.Identity) {
-                        unmarshalPublicKey(pubHash.bytes.toByteArray())
+                    if (expectedPeerId != null) {
+                        // PeerId was pre-validated by trustManager during TLS handshake.
+                        // For inline-key peerIds (identity multihash), extract pubkey from the multihash.
+                        val pubHash = Multihash.of(expectedPeerId.bytes.toByteBuf())
+                        remotePubKey = if (pubHash.desc.digest == Multihash.Digest.Identity) {
+                            unmarshalPublicKey(pubHash.bytes.toByteArray())
+                        } else {
+                            getPublicKeyFromCert(peerCerts)
+                        }
+                        remotePeerId = expectedPeerId
                     } else {
-                        getPublicKeyFromCert(peerCerts)
+                        // No PeerId known upfront — extract from TLS certificate post-handshake.
+                        remotePubKey = getPublicKeyFromCert(peerCerts)
+                        remotePeerId = verifyAndExtractPeerId(peerCerts)
                     }
-                    remotePeerId = expectedPeerId
-                } else {
-                    // No PeerId known upfront — extract from TLS certificate post-handshake.
-                    remotePubKey = getPublicKeyFromCert(peerCerts)
-                    remotePeerId = verifyAndExtractPeerId(peerCerts)
-                }
 
-                connection.setSecureSession(
-                    SecureChannel.Session(
-                        PeerId.fromPubKey(localKey.publicKey()),
-                        remotePeerId,
-                        remotePubKey,
-                        null
+                    connection.setSecureSession(
+                        SecureChannel.Session(
+                            PeerId.fromPubKey(localKey.publicKey()),
+                            remotePeerId,
+                            remotePubKey,
+                            null
+                        )
                     )
-                )
 
-                preHandler?.also { visitor -> visitor.visit(connection) }
-                connHandler.handleConnection(connection)
+                    preHandler?.also { visitor -> visitor.visit(connection) }
+                    connHandler.handleConnection(connection)
 
-                connection
+                    connection
+                } catch (e: Throwable) {
+                    // Post-handshake setup failed — close the established QuicChannel so neither it
+                    // nor its underlying datagram channel is leaked.
+                    it.close()
+                    throw e
+                }
             }
     }
 

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -789,4 +789,52 @@ public class QuicServerTestJava {
     clientTransport.close().get(5, TimeUnit.SECONDS);
     serverTransport.close().get(5, TimeUnit.SECONDS);
   }
+
+  /**
+   * NetworkImpl.connect() races dials across multiple addresses and cancels the losing dial futures
+   * once the first one completes. For QUIC, dial() returns the dependent {@code thenApply} future;
+   * cancelling it does not propagate upstream to the QUIC connect. If the handshake then completes,
+   * the {@code thenApply} body is skipped, so the established QuicChannel is never registered,
+   * handed to the caller, nor closed — it (and its underlying datagram channel) leaks until the
+   * idle timeout. A cancelled dial must promptly close the established QUIC connection.
+   */
+  @Test
+  void cancelledDialClosesEstablishedQuicConnection() throws Exception {
+    String serverListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Pair<PrivKey, PubKey> serverKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    Pair<PrivKey, PubKey> clientKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    List<io.libp2p.core.multistream.ProtocolBinding<?>> emptyProtocols = new ArrayList<>();
+
+    QuicTransport serverTransport = QuicTransport.ECDSA(serverKeyPair.component1(), emptyProtocols);
+    QuicTransport clientTransport = QuicTransport.ECDSA(clientKeyPair.component1(), emptyProtocols);
+    serverTransport.initialize();
+    clientTransport.initialize();
+
+    serverTransport
+        .listen(new Multiaddr(serverListenAddress), conn -> {}, null)
+        .get(5, TimeUnit.SECONDS);
+
+    CompletableFuture<Connection> dial =
+        clientTransport.dial(new Multiaddr(serverListenAddress), conn -> {}, null);
+    // Cancel synchronously, before the async handshake completes — the same situation a losing dial
+    // in NetworkImpl.connect() hits.
+    dial.cancel(true);
+
+    // The handshake still completes at the network level, so the QuicChannel is established and
+    // tracked. A leaked channel stays in activeConnections until the 30s idle timeout; a properly
+    // handled cancellation closes it, dropping activeConnections back to zero well inside this
+    // window.
+    long deadline = System.currentTimeMillis() + 15_000;
+    while (clientTransport.getActiveConnections() > 0 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(50);
+    }
+    Assertions.assertEquals(
+        0,
+        clientTransport.getActiveConnections(),
+        "a cancelled dial must close (not leak) the established QUIC connection");
+
+    clientTransport.close().get(5, TimeUnit.SECONDS);
+    serverTransport.close().get(5, TimeUnit.SECONDS);
+  }
 }

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -21,7 +21,9 @@ import io.libp2p.protocol.Ping;
 import io.libp2p.protocol.PingController;
 import io.libp2p.security.noise.NoiseXXSecureChannel;
 import io.libp2p.security.tls.TlsSecureChannel;
+import io.libp2p.transport.implementation.ConnectionOverNetty;
 import io.libp2p.transport.tcp.TcpTransport;
+import io.netty.channel.Channel;
 import io.netty.handler.logging.LogLevel;
 import java.util.ArrayList;
 import java.util.List;
@@ -689,5 +691,102 @@ public class QuicServerTestJava {
     }
 
     transport.close().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Each outbound {@code dial()} binds its own ephemeral {@code NioDatagramChannel} to carry the
+   * QUIC connection. When the QUIC connection closes, that underlying datagram channel must be
+   * closed too — closing a {@code QuicChannel} does not close its parent datagram channel in Netty.
+   * If it is left open, every dial leaks a datagram channel (plus its codec, native quiche config
+   * and queued direct buffers) for the lifetime of the transport.
+   */
+  @Test
+  void dialClosesUnderlyingDatagramChannelWhenConnectionCloses() throws Exception {
+    String serverListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Pair<PrivKey, PubKey> serverKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    Pair<PrivKey, PubKey> clientKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    List<io.libp2p.core.multistream.ProtocolBinding<?>> emptyProtocols = new ArrayList<>();
+
+    QuicTransport serverTransport = QuicTransport.ECDSA(serverKeyPair.component1(), emptyProtocols);
+    QuicTransport clientTransport = QuicTransport.ECDSA(clientKeyPair.component1(), emptyProtocols);
+    serverTransport.initialize();
+    clientTransport.initialize();
+
+    serverTransport
+        .listen(new Multiaddr(serverListenAddress), conn -> {}, null)
+        .get(5, TimeUnit.SECONDS);
+
+    Connection connection =
+        clientTransport
+            .dial(new Multiaddr(serverListenAddress), conn -> {}, null)
+            .get(10, TimeUnit.SECONDS);
+
+    Channel quicChannel = ((ConnectionOverNetty) connection).getNettyChannel();
+    Channel datagramChannel = quicChannel.parent();
+    Assertions.assertNotNull(
+        datagramChannel, "QUIC connection should ride on an underlying datagram channel");
+    Assertions.assertTrue(
+        datagramChannel.isOpen(), "datagram channel should be open while the connection is live");
+
+    // Closing the QUIC connection must cascade to the ephemeral dial datagram channel.
+    connection.close().get(5, TimeUnit.SECONDS);
+
+    datagramChannel.closeFuture().get(5, TimeUnit.SECONDS);
+    Assertions.assertFalse(
+        datagramChannel.isOpen(),
+        "underlying datagram channel must be closed after the QUIC connection closes");
+
+    clientTransport.close().get(5, TimeUnit.SECONDS);
+    serverTransport.close().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * A dial that fails AFTER the QUIC handshake completes (e.g. the connection handler throws during
+   * setup) must close the already-established QuicChannel rather than leave it registered and open.
+   * Otherwise the failed dial leaks the QUIC connection and its underlying datagram channel for the
+   * lifetime of the transport.
+   */
+  @Test
+  void dialThatFailsAfterHandshakeDoesNotLeakConnection() throws Exception {
+    String serverListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Pair<PrivKey, PubKey> serverKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    Pair<PrivKey, PubKey> clientKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    List<io.libp2p.core.multistream.ProtocolBinding<?>> emptyProtocols = new ArrayList<>();
+
+    QuicTransport serverTransport = QuicTransport.ECDSA(serverKeyPair.component1(), emptyProtocols);
+    QuicTransport clientTransport = QuicTransport.ECDSA(clientKeyPair.component1(), emptyProtocols);
+    serverTransport.initialize();
+    clientTransport.initialize();
+
+    serverTransport
+        .listen(new Multiaddr(serverListenAddress), conn -> {}, null)
+        .get(5, TimeUnit.SECONDS);
+
+    // Connection handler that throws after the handshake completes, exercising the post-handshake
+    // failure path in dial().thenApply.
+    ConnectionHandler throwingHandler =
+        conn -> {
+          throw new RuntimeException("boom");
+        };
+
+    CompletableFuture<Connection> dial =
+        clientTransport.dial(new Multiaddr(serverListenAddress), throwingHandler, null);
+
+    Assertions.assertThrows(ExecutionException.class, () -> dial.get(10, TimeUnit.SECONDS));
+
+    // The failed dial must not leak the established QuicChannel.
+    long deadline = System.currentTimeMillis() + 5_000;
+    while (clientTransport.getActiveConnections() > 0 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(50);
+    }
+    Assertions.assertEquals(
+        0,
+        clientTransport.getActiveConnections(),
+        "a dial that fails after the handshake must close (not leak) the QUIC connection");
+
+    clientTransport.close().get(5, TimeUnit.SECONDS);
+    serverTransport.close().get(5, TimeUnit.SECONDS);
   }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/security/noise/NoiseXXCodecTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/noise/NoiseXXCodecTest.kt
@@ -1,0 +1,53 @@
+package io.libp2p.security.noise
+
+import com.southernstorm.noise.protocol.CipherState
+import io.mockk.mockk
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.embedded.EmbeddedChannel
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class NoiseXXCodecTest {
+
+    private fun codec() =
+        NoiseXXCodec(mockk<CipherState>(relaxed = true), mockk<CipherState>(relaxed = true))
+
+    private fun channelWith(codec: NoiseXXCodec): Pair<EmbeddedChannel, ChannelHandlerContext> {
+        val channel = EmbeddedChannel(codec)
+        val ctx = channel.pipeline().context(codec)!!
+        return channel to ctx
+    }
+
+    @Test
+    fun `fatal Error is rethrown and not swallowed`() {
+        val codec = codec()
+        val (_, ctx) = channelWith(codec)
+        val oom = OutOfMemoryError("Java heap space")
+
+        assertThatThrownBy { codec.exceptionCaught(ctx, oom) }
+            .isSameAs(oom)
+    }
+
+    @Test
+    fun `fatal Error closes the channel`() {
+        val codec = codec()
+        val (channel, ctx) = channelWith(codec)
+
+        runCatching { codec.exceptionCaught(ctx, OutOfMemoryError("Java heap space")) }
+
+        channel.runPendingTasks()
+        assertThat(channel.isOpen).isFalse()
+    }
+
+    @Test
+    fun `unexpected runtime exception closes the channel`() {
+        val codec = codec()
+        val (channel, ctx) = channelWith(codec)
+
+        codec.exceptionCaught(ctx, RuntimeException("boom"))
+
+        channel.runPendingTasks()
+        assertThat(channel.isOpen).isFalse()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/security/noise/NoiseXXCodecTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/security/noise/NoiseXXCodecTest.kt
@@ -4,6 +4,7 @@ import com.southernstorm.noise.protocol.CipherState
 import io.mockk.mockk
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.EncoderException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -38,6 +39,19 @@ class NoiseXXCodecTest {
 
         channel.runPendingTasks()
         assertThat(channel.isOpen).isFalse()
+    }
+
+    @Test
+    fun `wrapped fatal Error is unwrapped and rethrown as the Error`() {
+        val codec = codec()
+        val (_, ctx) = channelWith(codec)
+        val oom = OutOfMemoryError("Java heap space")
+        // Netty wraps throwables from encode() in an EncoderException; the fatal JVM signal
+        // must be surfaced as the Error itself, not downgraded to the runtime wrapper.
+        val wrapped = EncoderException(oom)
+
+        assertThatThrownBy { codec.exceptionCaught(ctx, wrapped) }
+            .isSameAs(oom)
     }
 
     @Test


### PR DESCRIPTION
## Overview

Two fixes that came out of investigating an `OutOfMemoryError` reported on a soak node. The investigation surfaced two distinct defects, so this PR addresses both:

1. **The actual leak was off-heap, in the QUIC transport:** every outbound QUIC dial leaked its ephemeral `NioDatagramChannel`, growing direct memory ~3 GiB/day under connection churn.
2. **`NoiseXXCodec` was masking failures:** it swallowed fatal JVM `Error`s (incl. `OutOfMemoryError`) instead of failing fast, which is how the symptom first showed up.

JVM **heap** usage was flat the whole time — the growth was in `jvm_buffer_pool_used_bytes{pool="direct"}` / process RSS. A heap-dump reverse-reference scan confirmed the cause: ~1,085 orphaned `NioDatagramChannel`s (each holding a codec, native quiche config and a `PendingWriteQueue` backlog of direct buffers) against only ~206 live QUIC connections.

---

## Fix 1 — QUIC: close the ephemeral dial datagram channel (`QuicTransport`)

Each outbound `dial()` binds its own ephemeral `NioDatagramChannel` to carry the QUIC connection. Closing a `QuicChannel` does **not** close its parent datagram channel in Netty, so when the connection ended (reset / timeout / normal close) the datagram channel — plus its codec, native quiche config, and queued direct buffers — was leaked for the lifetime of the transport. Under normal connection churn this is a linear off-heap leak.

This change:
- **Ties the datagram channel lifecycle to the `QuicChannel`:** closes it on `QuicChannel` close, and on connect failure.
- **Closes the established `QuicChannel` when post-handshake setup fails** (e.g. the connection handler throws), so a failed dial can't strand the connection and its datagram channel.

> Scope note: this is the leak fix. Sharing the client `QuicSslContext` across dials (an efficiency + PeerId-validation change) and broader error-path hardening are intentionally **deferred to follow-up PRs**, since the former touches handshake security and deserves its own review.

## Fix 2 — Noise: stop `NoiseXXCodec` swallowing fatal errors

Previously, the `else` branch in `NoiseXXCodec.exceptionCaught` logged any unexpected throwable (including `OutOfMemoryError`) at ERROR but **left the channel open and did not rethrow**, masking the failure and letting the Netty event-loop thread keep running in a degraded state.

This change:
- Closes the channel on **any** unexpected throwable (previously the connection was leaked).
- Adds a dedicated branch for fatal JVM `Error`s that closes the channel **and rethrows**, so the failure is surfaced rather than downgraded to a single log line.

> Note: this is defensive hardening — it stops the failure being masked and the connection leaking; it does not by itself prevent heap exhaustion. The OOM that triggered the investigation was off-heap (Fix 1), not heap.

## Tests

**QUIC (`QuicServerTestJava`, TDD — watched to fail first):**
- the underlying datagram channel is closed when the dial's connection closes
- a dial that fails after the handshake does not leak a connection

**Noise (`NoiseXXCodecTest`, TDD — watched to fail first):**
- fatal `Error` is rethrown and not swallowed
- fatal `Error` closes the channel
- unexpected `RuntimeException` closes the channel

`./gradlew :libp2p:test` (QUIC + Noise suites), `:libp2p:spotlessCheck`, and `:libp2p:detekt` all pass.
