### PR TITLE
fix(tls,quic): expose libp2p host pubkey as remotePubKey, not the ephemeral cert subject key 2/2

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/implementation/ConnectionOverNetty.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/implementation/ConnectionOverNetty.kt
@@ -50,4 +50,15 @@ open class ConnectionOverNetty(
 
     override fun remoteAddress(): Multiaddr =
         cachedRemoteAddress ?: nettyTransport.remoteAddress(nettyChannel).also { cachedRemoteAddress = it }
+
+    /**
+     * Eagerly resolves and caches the local and remote addresses while the underlying channel is
+     * still live. Transports whose channels free their native state on close (e.g. QUIC) must call
+     * this before exposing the connection, so a teardown-time caller that is the first to read an
+     * address gets the cached value instead of dereferencing the freed channel.
+     */
+    fun cacheAddresses() {
+        localAddress()
+        remoteAddress()
+    }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/implementation/ConnectionOverNetty.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/implementation/ConnectionOverNetty.kt
@@ -20,6 +20,16 @@ open class ConnectionOverNetty(
     private lateinit var muxerSession: StreamMuxer.Session
     private lateinit var secureSession: SecureChannel.Session
 
+    // Addresses are resolved from the underlying Netty channel, but some transports (e.g. QUIC)
+    // free the native channel state on close, after which the socket addresses are no longer
+    // available. We cache the addresses on first successful read while the channel is still live
+    // so that teardown-time callers (e.g. disconnect handlers) get a stable value instead of an NPE.
+    @Volatile
+    private var cachedLocalAddress: Multiaddr? = null
+
+    @Volatile
+    private var cachedRemoteAddress: Multiaddr? = null
+
     init {
         ch.attr(CONNECTION).set(this)
     }
@@ -35,6 +45,9 @@ open class ConnectionOverNetty(
     override fun secureSession() = secureSession
     override fun transport() = nettyTransport
 
-    override fun localAddress(): Multiaddr = nettyTransport.localAddress(nettyChannel)
-    override fun remoteAddress(): Multiaddr = nettyTransport.remoteAddress(nettyChannel)
+    override fun localAddress(): Multiaddr =
+        cachedLocalAddress ?: nettyTransport.localAddress(nettyChannel).also { cachedLocalAddress = it }
+
+    override fun remoteAddress(): Multiaddr =
+        cachedRemoteAddress ?: nettyTransport.remoteAddress(nettyChannel).also { cachedRemoteAddress = it }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -530,19 +530,23 @@ class QuicTransport(
                 val peerCerts = quicChannel.sslEngine()?.session?.peerCertificates
                     ?: throw Libp2pException("No peer certificates in hole-punched connection from $addr")
 
-                // remotePubKey must be the libp2p host key from the cert extension, not the
-                // ephemeral cert subject key (verifyAndExtractIdentity), so that the invariant
-                // PeerId.fromPubKey(remotePubKey) == remoteId holds on the hole-punch path too.
+                // remoteId and remotePubKey must both come from the libp2p host key in the cert
+                // extension (verifyAndExtractIdentity), never the ephemeral cert subject key, so
+                // that the invariant PeerId.fromPubKey(remotePubKey) == remoteId holds on the
+                // hole-punch path too.
                 val remoteIdentity = verifyAndExtractIdentity(peerCerts)
                 val expectedPeerId = addr.getPeerId()
-                val remotePeerId = expectedPeerId ?: remoteIdentity.peerId
-                val remotePubKey = remoteIdentity.pubKey
+                if (expectedPeerId != null && remoteIdentity.peerId != expectedPeerId) {
+                    throw Libp2pException(
+                        "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} but dial target was $expectedPeerId"
+                    )
+                }
 
                 connection.setSecureSession(
                     SecureChannel.Session(
                         PeerId.fromPubKey(localKey.publicKey()),
-                        remotePeerId,
-                        remotePubKey,
+                        remoteIdentity.peerId,
+                        remoteIdentity.pubKey,
                         null
                     )
                 )

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -293,6 +293,10 @@ class QuicTransport(
                         )
                     )
 
+                    // Warm the address cache while the QuicChannel is still live; once closed it
+                    // frees native state and remoteSocketAddress() returns null.
+                    connection.cacheAddresses()
+
                     preHandler?.also { visitor -> visitor.visit(connection) }
                     connHandler.handleConnection(connection)
 
@@ -429,6 +433,11 @@ class QuicTransport(
                                     // Remove this handler as it's no longer needed
                                     ctx.pipeline().remove(this)
 
+                                    // Warm the address cache while the QuicChannel is still live;
+                                    // once closed it frees native state and remoteSocketAddress()
+                                    // returns null.
+                                    connection.cacheAddresses()
+
                                     // Check if this connection is completing a pending hole punch
                                     val remoteAddr = ctx.channel().remoteAddress() as? InetSocketAddress
                                     val holePunchFuture = if (remoteAddr != null) {
@@ -524,37 +533,48 @@ class QuicTransport(
             }
             .thenApply { quicChannel ->
                 registerChannel(quicChannel)
-                val connection = ConnectionOverNetty(quicChannel, this@QuicTransport, false)
-                connection.setMuxerSession(QuicMuxerSession(quicChannel, connection))
+                try {
+                    val connection = ConnectionOverNetty(quicChannel, this@QuicTransport, false)
+                    connection.setMuxerSession(QuicMuxerSession(quicChannel, connection))
 
-                val peerCerts = quicChannel.sslEngine()?.session?.peerCertificates
-                    ?: throw Libp2pException("No peer certificates in hole-punched connection from $addr")
+                    val peerCerts = quicChannel.sslEngine()?.session?.peerCertificates
+                        ?: throw Libp2pException("No peer certificates in hole-punched connection from $addr")
 
-                // remoteId and remotePubKey must both come from the libp2p host key in the cert
-                // extension (verifyAndExtractIdentity), never the ephemeral cert subject key, so
-                // that the invariant PeerId.fromPubKey(remotePubKey) == remoteId holds on the
-                // hole-punch path too.
-                val remoteIdentity = verifyAndExtractIdentity(peerCerts)
-                val expectedPeerId = addr.getPeerId()
-                if (expectedPeerId != null && remoteIdentity.peerId != expectedPeerId) {
-                    throw Libp2pException(
-                        "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} but dial target was $expectedPeerId"
+                    // remoteId and remotePubKey must both come from the libp2p host key in the cert
+                    // extension (verifyAndExtractIdentity), never the ephemeral cert subject key, so
+                    // that the invariant PeerId.fromPubKey(remotePubKey) == remoteId holds on the
+                    // hole-punch path too.
+                    val remoteIdentity = verifyAndExtractIdentity(peerCerts)
+                    val expectedPeerId = addr.getPeerId()
+                    if (expectedPeerId != null && remoteIdentity.peerId != expectedPeerId) {
+                        throw Libp2pException(
+                            "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} but dial target was $expectedPeerId"
+                        )
+                    }
+
+                    connection.setSecureSession(
+                        SecureChannel.Session(
+                            PeerId.fromPubKey(localKey.publicKey()),
+                            remoteIdentity.peerId,
+                            remoteIdentity.pubKey,
+                            null
+                        )
                     )
+
+                    // Warm the address cache while the QuicChannel is still live; once closed it
+                    // frees native state and remoteSocketAddress() returns null.
+                    connection.cacheAddresses()
+
+                    preHandler?.also { visitor -> visitor.visit(connection) }
+                    connHandler.handleConnection(connection)
+                    quicChannel.attr(CONNECTION).set(connection)
+                    connection
+                } catch (e: Throwable) {
+                    // Post-handshake setup failed — close the registered QuicChannel so neither it
+                    // nor its underlying datagram channel is leaked (mirrors the normal dial path).
+                    quicChannel.close()
+                    throw e
                 }
-
-                connection.setSecureSession(
-                    SecureChannel.Session(
-                        PeerId.fromPubKey(localKey.publicKey()),
-                        remoteIdentity.peerId,
-                        remoteIdentity.pubKey,
-                        null
-                    )
-                )
-
-                preHandler?.also { visitor -> visitor.visit(connection) }
-                connHandler.handleConnection(connection)
-                quicChannel.attr(CONNECTION).set(connection)
-                connection
             }
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/transport/implementation/ConnectionOverNettyTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/implementation/ConnectionOverNettyTest.kt
@@ -1,0 +1,52 @@
+package io.libp2p.transport.implementation
+
+import io.libp2p.core.multiformats.Multiaddr
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.netty.channel.embedded.EmbeddedChannel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ConnectionOverNettyTest {
+
+    private val localMultiaddr = Multiaddr("/ip4/127.0.0.1/udp/1234/quic-v1")
+    private val remoteMultiaddr = Multiaddr("/ip4/127.0.0.1/udp/5678/quic-v1")
+
+    private fun newConnection(transport: NettyTransport): ConnectionOverNetty =
+        ConnectionOverNetty(EmbeddedChannel(), transport, true)
+
+    @Test
+    fun `remoteAddress is cached after first read so it survives a freed channel`() {
+        val transport = mockk<NettyTransport>()
+        // First read resolves from the live channel; a second resolution would NPE because the
+        // underlying (QUIC) native channel has been freed and remoteSocketAddress() returns null.
+        every { transport.remoteAddress(any()) } returns remoteMultiaddr andThenThrows
+            NullPointerException("channel freed")
+
+        val connection = newConnection(transport)
+
+        // Read once while the channel is "live"
+        assertThat(connection.remoteAddress()).isEqualTo(remoteMultiaddr)
+
+        // A teardown-time read (e.g. a disconnect handler) must return the cached value rather
+        // than hitting the freed channel again.
+        assertThat(connection.remoteAddress()).isEqualTo(remoteMultiaddr)
+
+        verify(exactly = 1) { transport.remoteAddress(any()) }
+    }
+
+    @Test
+    fun `localAddress is cached after first read so it survives a freed channel`() {
+        val transport = mockk<NettyTransport>()
+        every { transport.localAddress(any()) } returns localMultiaddr andThenThrows
+            NullPointerException("channel freed")
+
+        val connection = newConnection(transport)
+
+        assertThat(connection.localAddress()).isEqualTo(localMultiaddr)
+        assertThat(connection.localAddress()).isEqualTo(localMultiaddr)
+
+        verify(exactly = 1) { transport.localAddress(any()) }
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/transport/implementation/ConnectionOverNettyTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/implementation/ConnectionOverNettyTest.kt
@@ -49,4 +49,28 @@ class ConnectionOverNettyTest {
 
         verify(exactly = 1) { transport.localAddress(any()) }
     }
+
+    @Test
+    fun `cacheAddresses warms the cache so a teardown-time read is the first to hit the live channel`() {
+        val transport = mockk<NettyTransport>()
+        // The transport may only be queried once per address while the channel is live; any later
+        // resolution would NPE because the underlying (QUIC) native channel has been freed.
+        every { transport.localAddress(any()) } returns localMultiaddr andThenThrows
+            NullPointerException("channel freed")
+        every { transport.remoteAddress(any()) } returns remoteMultiaddr andThenThrows
+            NullPointerException("channel freed")
+
+        val connection = newConnection(transport)
+
+        // Warm the cache while the channel is live (as the QUIC transport does before exposing it).
+        connection.cacheAddresses()
+
+        // A teardown handler being the very first caller of the public getters must still succeed,
+        // served entirely from the warmed cache without re-hitting the freed channel.
+        assertThat(connection.localAddress()).isEqualTo(localMultiaddr)
+        assertThat(connection.remoteAddress()).isEqualTo(remoteMultiaddr)
+
+        verify(exactly = 1) { transport.localAddress(any()) }
+        verify(exactly = 1) { transport.remoteAddress(any()) }
+    }
 }


### PR DESCRIPTION
## Summary

This PR contains two related fixes to the QUIC transport.

### 1. Expose the libp2p host pubkey as `remotePubKey` (hole-punch path)

Part 2/2 of exposing the libp2p host public key (not the ephemeral X.509 cert
subject key) as `SecureChannel.Session.remotePubKey`. Part 1/2 (the TLS channel
and the QUIC server-inbound / client-dial paths) is already merged into
`develop`; this completes the QUIC transport by bringing the **hole-punch /
direct connection path** in line with the rest.

This upholds the invariant `PeerId.fromPubKey(remotePubKey) == remoteId` that
SecIO, Noise, and Plaintext already guarantee and that downstream consumers
rely on (e.g. signed-record verification).

### 2. Cache connection addresses to avoid NPE on a freed QUIC channel

`ConnectionOverNetty` resolved local/remote addresses from the underlying Netty
channel on every call. For QUIC the native channel state is freed on close,
after which `remoteSocketAddress()` returns `null` and the `!!` in
`QuicTransport.remoteAddress()` throws a `NullPointerException`. This surfaced
when a disconnect handler read the remote address during idle-timeout teardown
(observed downstream in Teku's `LibP2PPeer.internalDisconnectImmediately`).

## Changes

`QuicTransport.kt` (hole-punch path):

- Both `remoteId` and `remotePubKey` for the `SecureChannel.Session` now come
  from the single libp2p host key extracted from the cert extension
  (`verifyAndExtractIdentity`), never the ephemeral cert subject key.
- Add a defence-in-depth check: if a dial-target peer id is known, assert the
  libp2p key extracted from the cert hashes to it, throwing `Libp2pException`
  otherwise. This mirrors the guard already on the client-dial path and means a
  misconfigured trust manager cannot silently leak the wrong identity into the
  connection.
- Remove the now-unused `remotePeerId` / `remotePubKey` locals.

`ConnectionOverNetty.kt`:

- Cache the local and remote `Multiaddr` on first successful read while the
  channel is still live, so teardown-time callers get a stable value instead of
  dereferencing the freed native channel.

## Testing

- `QuicRemotePubKeyIdentityTest` (added with part 1/2, already on `develop`)
  exercises a real QUIC handshake between two hosts and asserts
  `PeerId.fromPubKey(secureSession.remotePubKey) == secureSession.remoteId` on
  both the client and server connections.
- `ConnectionOverNettyTest` (new) verifies that both `localAddress()` and
  `remoteAddress()` return the cached value and do not re-hit the transport
  after the underlying channel has been freed.
