### PR TITLE
Gossip heartbeat allocations reduction

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -668,6 +668,8 @@ open class GossipRouter(
         }
 
         try {
+            val gossipMessageIdsByTopic = mCache.getGossipMessageIdsByTopic()
+
             mesh.entries.forEach { (topic, peers) ->
 
                 // drop underscored peers from mesh
@@ -718,7 +720,7 @@ open class GossipRouter(
                     }
                 }
 
-                emitGossip(topic, peers)
+                emitGossip(topic, peers, gossipMessageIdsByTopic)
             }
             fanout.entries.forEach { (topic, peers) ->
                 peers.removeIf {
@@ -731,7 +733,7 @@ open class GossipRouter(
                         .shuffled(random)
                         .take(needMore)
                 }
-                emitGossip(topic, peers)
+                emitGossip(topic, peers, gossipMessageIdsByTopic)
             }
             lastPublished.entries.removeIf { (topic, lastPub) ->
                 (currentTimeSupplier() - lastPub > params.fanoutTTL.toMillis())
@@ -746,9 +748,12 @@ open class GossipRouter(
         }
     }
 
-    private fun emitGossip(topic: Topic, excludePeers: Collection<PeerHandler>) {
-        val ids = mCache.getMessageIds(topic)
-        if (ids.isEmpty()) return
+    private fun emitGossip(
+        topic: Topic,
+        excludePeers: Collection<PeerHandler>,
+        gossipMessageIdsByTopic: Map<Topic, Set<MessageId>>
+    ) {
+        val ids = gossipMessageIdsByTopic[topic] ?: return
 
         val shuffledMessageIds = ids.shuffled(random).take(params.maxIHaveLength)
         val peers = (getTopicPeers(topic) - excludePeers)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -668,6 +668,8 @@ open class GossipRouter(
         }
 
         try {
+            // Heartbeat runs on the router event executor. With the supported single-thread executor,
+            // publish/inbound validation tasks cannot mutate mCache while emitGossip consumes this snapshot.
             val gossipMessageIdsByTopic = mCache.getGossipMessageIdsByTopic()
 
             mesh.entries.forEach { (topic, peers) ->

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -190,7 +190,7 @@ class DefaultGossipScore(
         val peerScore = getPeerScores(peerId)
         val topicsScore = min(
             if (peerParams.topicScoreCap > 0) peerParams.topicScoreCap else Double.MAX_VALUE,
-            peerScore.topicScores.values.map { it.calcTopicScore() }.sum()
+            peerScore.topicScores.values.sumOf { it.calcTopicScore() }
         )
         val appScore = peerParams.appSpecificScore(peerId) * peerParams.appSpecificWeight
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/MCache.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/MCache.kt
@@ -26,23 +26,9 @@ class MCache(val gossipSize: Int, historyLength: Int) {
             }
         }
 
-    // Within-heartbeat memo: the last [gossipSize] history windows flattened into one list.
-    // getMessageIds() is called once per topic, only from emitGossip(), which runs only inside
-    // heartbeat(). heartbeat() runs as a single task on the gossip event thread, so no add()/
-    // shift() can interleave between its per-topic queries — the first topic builds the snapshot
-    // and the rest reuse it, turning ~(topic count) flattens per heartbeat into one. add()/shift()
-    // invalidate it, but only between heartbeats (and at heartbeat end via shift()), when it is
-    // not being read. Single-threaded access also makes this plain field safe, like the maps above.
-    private var gossipHistorySnapshot: List<CacheEntry>? = null
-
-    private fun gossipHistory(): List<CacheEntry> =
-        gossipHistorySnapshot ?: history.takeLast(gossipSize).flatten()
-            .also { gossipHistorySnapshot = it }
-
     fun add(msg: PubsubMessage) {
         messages[msg.messageId] = msg
         history.last().add(CacheEntry(msg.messageId, msg.topics.toSet()))
-        gossipHistorySnapshot = null
     }
 
     operator fun get(msgId: MessageId) = messages[msgId]
@@ -54,17 +40,23 @@ class MCache(val gossipSize: Int, historyLength: Int) {
         MessageForPeer(it, sentCount)
     }
 
-    fun getMessageIds(topic: Topic): List<MessageId> =
-        gossipHistory().asSequence()
-            .filter { topic in it.topics }
-            .map { it.msgId }
-            .distinct()
-            .toList()
+    fun getGossipMessageIdsByTopic(): Map<Topic, Set<MessageId>> {
+        val messageIdsByTopic = mutableMapOf<Topic, MutableSet<MessageId>>()
+        val startIndex = (history.size - gossipSize).coerceAtLeast(0)
+        val gossipWindows = history.listIterator(startIndex)
 
-    fun shift() {
-        history.add(mutableListOf())
-        gossipHistorySnapshot = null
+        while (gossipWindows.hasNext()) {
+            gossipWindows.next().forEach { entry ->
+                entry.topics.forEach { topic ->
+                    messageIdsByTopic.getOrPut(topic) { linkedSetOf() }.add(entry.msgId)
+                }
+            }
+        }
+
+        return messageIdsByTopic
     }
+
+    fun shift() = history.add(mutableListOf())
 
     operator fun plusAssign(msg: PubsubMessage) = add(msg)
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/MCache.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/MCache.kt
@@ -26,9 +26,23 @@ class MCache(val gossipSize: Int, historyLength: Int) {
             }
         }
 
+    // Within-heartbeat memo: the last [gossipSize] history windows flattened into one list.
+    // getMessageIds() is called once per topic, only from emitGossip(), which runs only inside
+    // heartbeat(). heartbeat() runs as a single task on the gossip event thread, so no add()/
+    // shift() can interleave between its per-topic queries — the first topic builds the snapshot
+    // and the rest reuse it, turning ~(topic count) flattens per heartbeat into one. add()/shift()
+    // invalidate it, but only between heartbeats (and at heartbeat end via shift()), when it is
+    // not being read. Single-threaded access also makes this plain field safe, like the maps above.
+    private var gossipHistorySnapshot: List<CacheEntry>? = null
+
+    private fun gossipHistory(): List<CacheEntry> =
+        gossipHistorySnapshot ?: history.takeLast(gossipSize).flatten()
+            .also { gossipHistorySnapshot = it }
+
     fun add(msg: PubsubMessage) {
         messages[msg.messageId] = msg
-        history.last.add(CacheEntry(msg.messageId, msg.topics.toSet()))
+        history.last().add(CacheEntry(msg.messageId, msg.topics.toSet()))
+        gossipHistorySnapshot = null
     }
 
     operator fun get(msgId: MessageId) = messages[msgId]
@@ -40,10 +54,17 @@ class MCache(val gossipSize: Int, historyLength: Int) {
         MessageForPeer(it, sentCount)
     }
 
-    fun getMessageIds(topic: Topic) =
-        history.takeLast(gossipSize).flatten().filter { topic in it.topics }.map { it.msgId }.distinct()
+    fun getMessageIds(topic: Topic): List<MessageId> =
+        gossipHistory().asSequence()
+            .filter { topic in it.topics }
+            .map { it.msgId }
+            .distinct()
+            .toList()
 
-    fun shift() = history.add(mutableListOf())
+    fun shift() {
+        history.add(mutableListOf())
+        gossipHistorySnapshot = null
+    }
 
     operator fun plusAssign(msg: PubsubMessage) = add(msg)
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/MCache.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/MCache.kt
@@ -11,6 +11,9 @@ private data class CacheEntry(val msgId: MessageId, val topics: Set<Topic>)
 
 data class MessageForPeer(val msg: PubsubMessage, val sentCount: Int)
 
+/**
+ * Message cache owned by [GossipRouter]'s event executor. It is not thread-safe.
+ */
 class MCache(val gossipSize: Int, historyLength: Int) {
 
     private val messages = mutableMapOf<MessageId, PubsubMessage>()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/MCacheTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/MCacheTest.kt
@@ -1,0 +1,78 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.etc.types.toBytesBigEndian
+import io.libp2p.etc.types.toProtobuf
+import io.libp2p.pubsub.DefaultPubsubMessage
+import io.libp2p.pubsub.PubsubMessage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+
+class MCacheTest {
+
+    private var seqNo = 0L
+
+    private fun msg(vararg topics: String): PubsubMessage =
+        DefaultPubsubMessage(
+            Rpc.Message.newBuilder()
+                .also { b -> topics.forEach { b.addTopicIDs(it) } }
+                .setSeqno((++seqNo).toBytesBigEndian().toProtobuf())
+                .build()
+        )
+
+    @Test
+    fun `getMessageIds returns ids only for the requested topic`() {
+        val mCache = MCache(3, 5)
+        val a = msg("topicA")
+        val b = msg("topicB")
+        val ab = msg("topicA", "topicB")
+        mCache.add(a)
+        mCache.add(b)
+        mCache.add(ab)
+
+        assertThat(mCache.getMessageIds("topicA")).containsExactlyInAnyOrder(a.messageId, ab.messageId)
+        assertThat(mCache.getMessageIds("topicB")).containsExactlyInAnyOrder(b.messageId, ab.messageId)
+        assertThat(mCache.getMessageIds("topicC")).isEmpty()
+    }
+
+    @Test
+    fun `getMessageIds reflects messages added after an earlier query (snapshot invalidation on add)`() {
+        val mCache = MCache(3, 5)
+        val a = msg("t")
+        mCache.add(a)
+        // populate the internal snapshot
+        assertThat(mCache.getMessageIds("t")).containsExactly(a.messageId)
+
+        val b = msg("t")
+        mCache.add(b)
+        // a stale snapshot would miss 'b'
+        assertThat(mCache.getMessageIds("t")).containsExactlyInAnyOrder(a.messageId, b.messageId)
+    }
+
+    @Test
+    fun `getMessageIds dedups a message id present in multiple windows`() {
+        val mCache = MCache(3, 5)
+        val a = msg("t")
+        mCache.add(a)
+        mCache.shift()
+        mCache.add(a) // same message id appears in a second window
+
+        assertThat(mCache.getMessageIds("t")).containsExactly(a.messageId)
+    }
+
+    @Test
+    fun `getMessageIds only considers the last gossipSize windows (snapshot invalidation on shift)`() {
+        val mCache = MCache(gossipSize = 2, historyLength = 5)
+        val old = msg("t")
+        mCache.add(old)
+        mCache.shift()
+        val mid = msg("t")
+        mCache.add(mid)
+        mCache.shift()
+        // 'old' is now outside the gossipSize=2 window
+        val recent = msg("t")
+        mCache.add(recent)
+
+        assertThat(mCache.getMessageIds("t")).containsExactlyInAnyOrder(mid.messageId, recent.messageId)
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/MCacheTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/MCacheTest.kt
@@ -3,6 +3,7 @@ package io.libp2p.pubsub.gossip
 import io.libp2p.etc.types.toBytesBigEndian
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.pubsub.DefaultPubsubMessage
+import io.libp2p.pubsub.MessageId
 import io.libp2p.pubsub.PubsubMessage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -11,6 +12,9 @@ import pubsub.pb.Rpc
 class MCacheTest {
 
     private var seqNo = 0L
+
+    private fun MCache.getMessageIds(topic: String): Set<MessageId> =
+        getGossipMessageIdsByTopic()[topic].orEmpty()
 
     private fun msg(vararg topics: String): PubsubMessage =
         DefaultPubsubMessage(
@@ -36,20 +40,6 @@ class MCacheTest {
     }
 
     @Test
-    fun `getMessageIds reflects messages added after an earlier query (snapshot invalidation on add)`() {
-        val mCache = MCache(3, 5)
-        val a = msg("t")
-        mCache.add(a)
-        // populate the internal snapshot
-        assertThat(mCache.getMessageIds("t")).containsExactly(a.messageId)
-
-        val b = msg("t")
-        mCache.add(b)
-        // a stale snapshot would miss 'b'
-        assertThat(mCache.getMessageIds("t")).containsExactlyInAnyOrder(a.messageId, b.messageId)
-    }
-
-    @Test
     fun `getMessageIds dedups a message id present in multiple windows`() {
         val mCache = MCache(3, 5)
         val a = msg("t")
@@ -61,7 +51,7 @@ class MCacheTest {
     }
 
     @Test
-    fun `getMessageIds only considers the last gossipSize windows (snapshot invalidation on shift)`() {
+    fun `getMessageIds only considers the last gossipSize windows`() {
         val mCache = MCache(gossipSize = 2, historyLength = 5)
         val old = msg("t")
         mCache.add(old)
@@ -74,5 +64,26 @@ class MCacheTest {
         mCache.add(recent)
 
         assertThat(mCache.getMessageIds("t")).containsExactlyInAnyOrder(mid.messageId, recent.messageId)
+    }
+
+    @Test
+    fun `getGossipMessageIdsByTopic groups ids for the current gossip window`() {
+        val mCache = MCache(gossipSize = 2, historyLength = 5)
+        val old = msg("topicA")
+        mCache.add(old)
+        mCache.shift()
+
+        val mid = msg("topicA", "topicB")
+        mCache.add(mid)
+        mCache.shift()
+        mCache.add(mid)
+        val recent = msg("topicB")
+        mCache.add(recent)
+
+        val idsByTopic = mCache.getGossipMessageIdsByTopic()
+
+        assertThat(idsByTopic["topicA"]).containsExactly(mid.messageId)
+        assertThat(idsByTopic["topicB"]).containsExactlyInAnyOrder(mid.messageId, recent.messageId)
+        assertThat(idsByTopic).doesNotContainKey("topicC")
     }
 }


### PR DESCRIPTION
# Gossipsub Allocation Optimizations

Two allocation hotspots in the gossip heartbeat, found by profiling Teku (mainnet head,
all-subnets, `async-profiler -e alloc`) and fixed in this repo.

## The two fixes

### 1. Gossip message-ids — build them once per heartbeat instead of per topic
`MCache.getMessageIds(topic)` was called once per topic from `emitGossip()`, which runs only
inside `heartbeat()`. Its `history.takeLast(gossipSize).flatten()` is **topic-independent**, yet
it was rebuilt for every topic — ~64+ times per heartbeat under all-subnets — each time growing
a default-capacity `ArrayList` (`grow → Arrays.copyOf`) and then re-filtering/dedup per topic.

Fix: replace it with `MCache.getGossipMessageIdsByTopic(): Map<Topic, Set<MessageId>>` that makes
**one pass** over the last `gossipSize` history windows (via `listIterator(size - gossipSize)`,
no intermediate `takeLast`/`flatten` lists) and buckets ids into per-topic `LinkedHashSet`s
(dedup + insertion order preserved). `heartbeat()` calls it **once** and passes the map to each
`emitGossip(topic, peers, map)`, which just does `map[topic] ?: return`.

This is stateless — a pure function of `history`, no cache and no invalidation contract — and
removes both the per-topic re-flatten **and** the per-topic dedup rescan.

### 2. `DefaultGossipScore.score` — drop the boxing in the topic-score sum
`peerScore.topicScores.values.map { it.calcTopicScore() }.sum()` allocates an intermediate
`List<Double>` and **boxes one `Double` per (peer, topic)** on every `score()` call (called
O(peers × topics) times per heartbeat).

Fix: `…values.sumOf { it.calcTopicScore() }` — folds with a primitive `double` accumulator;
no list, no boxing. (The remaining `CappedValueDelegate` boxing is structural to the generic
delegate and left untouched.)

## Impact (Teku, mainnet head, `--p2p-subscribe-all-subnets-enabled`)

Measured in **bytes** with `async-profiler -e alloc --total`, two 300s steady-state windows,
baseline `1.3.2-RELEASE` vs the patched build:

| Path | Baseline 1.3.2 | Patched | Saved / epoch |
|---|---|---|---|
| msg-id build (`getMessageIds` → `getGossipMessageIdsByTopic`) | 16.6 MB/s · 6.2 GB/epoch · 3.19% | 0.35 MB/s · 132 MB/epoch · 0.08% | −6.1 GB |
| `DefaultGossipScore.score` | 13.5 MB/s · 5.1 GB/epoch · 2.60% | 0.56 MB/s · 211 MB/epoch · 0.13% | −4.9 GB |
| **Combined** | **30.1 MB/s · 11.3 GB/epoch · 5.79%** | **0.92 MB/s · 344 MB/epoch · 0.22%** | **−10.9 GB** |

**Combined saving ≈ 29 MB/s ≈ 10.9 GB/epoch ≈ ~2.4 TB/day — a 97% reduction** of these two
paths' allocation. (`%` = share of all allocation in each run.)

> ⚠️ These figures are for a **super-node meshed on ~64+ topics** (all attestation + custody
> subnets). The savings scale with topic × peer count; a default-subscription node (\~2 subnets)
> would see a small fraction of the absolute numbers. `--total` is sampled (±\~10%), and the two
> windows are different mainnet traffic, so only the per-path delta is attributable to the fix.