### PR TITLE
fix(quic): validate hole-punch peer identity early and handle STOP_SENDING

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverter.kt
@@ -12,6 +12,13 @@ import io.netty.handler.codec.quic.QuicStreamResetException
  */
 class QuicStreamReadCloseEventConverter : ChannelInboundHandlerAdapter() {
 
+    companion object {
+        // Netty's quiche codec (QuicheQuicStreamChannel) raises ChannelOutputShutdownException with
+        // exactly this message when the remote sent STOP_SENDING. The only other message it uses is
+        // "Fin was sent already" for a local write-after-FIN, which must NOT be swallowed.
+        private const val STOP_SENDING_MESSAGE = "STOP_SENDING frame received"
+    }
+
     override fun userEventTriggered(ctx: ChannelHandlerContext, evt: Any) {
         if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
             ctx.fireUserEventTriggered(RemoteWriteClosed)
@@ -21,21 +28,24 @@ class QuicStreamReadCloseEventConverter : ChannelInboundHandlerAdapter() {
     }
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        when (cause) {
-            is QuicStreamResetException -> {
+        when {
+            cause is QuicStreamResetException -> {
                 // The remote peer reset the stream. The muxer-based transports close the
                 // stream quietly in this case (see AbstractMuxHandler.onRemoteClose) — match
                 // that instead of surfacing the exception. Netty also leaves the stream
                 // channel open after a reset, so close it here to not leak it.
                 ctx.close()
             }
-            is ChannelOutputShutdownException -> {
+            cause is ChannelOutputShutdownException && cause.message == STOP_SENDING_MESSAGE -> {
                 // The remote peer sent STOP_SENDING: it no longer wants to read from this stream,
                 // so Netty fails our queued writes with this exception. This is a benign half-close
                 // — only our write side is affected; the read side may still deliver data — so we
                 // swallow it rather than surfacing a spurious error to application handlers, and we
                 // do NOT close the channel (matching Netty's own "should not close the channel"
-                // handling of STOP_SENDING).
+                // handling of STOP_SENDING). Other ChannelOutputShutdownException causes (e.g. a
+                // local write after the FIN was sent) fall through to be propagated below: for
+                // writeAndFlush with a void promise this pipeline exception is the only signal that
+                // bytes were not accepted, so swallowing it would silently drop data.
             }
             else -> ctx.fireExceptionCaught(cause)
         }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverter.kt
@@ -4,6 +4,7 @@ import io.libp2p.etc.util.netty.mux.RemoteWriteClosed
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.socket.ChannelInputShutdownReadComplete
+import io.netty.channel.socket.ChannelOutputShutdownException
 import io.netty.handler.codec.quic.QuicStreamResetException
 
 /**
@@ -20,14 +21,23 @@ class QuicStreamReadCloseEventConverter : ChannelInboundHandlerAdapter() {
     }
 
     override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-        if (cause is QuicStreamResetException) {
-            // The remote peer reset the stream. The muxer-based transports close the
-            // stream quietly in this case (see AbstractMuxHandler.onRemoteClose) — match
-            // that instead of surfacing the exception. Netty also leaves the stream
-            // channel open after a reset, so close it here to not leak it.
-            ctx.close()
-        } else {
-            ctx.fireExceptionCaught(cause)
+        when (cause) {
+            is QuicStreamResetException -> {
+                // The remote peer reset the stream. The muxer-based transports close the
+                // stream quietly in this case (see AbstractMuxHandler.onRemoteClose) — match
+                // that instead of surfacing the exception. Netty also leaves the stream
+                // channel open after a reset, so close it here to not leak it.
+                ctx.close()
+            }
+            is ChannelOutputShutdownException -> {
+                // The remote peer sent STOP_SENDING: it no longer wants to read from this stream,
+                // so Netty fails our queued writes with this exception. This is a benign half-close
+                // — only our write side is affected; the read side may still deliver data — so we
+                // swallow it rather than surfacing a spurious error to application handlers, and we
+                // do NOT close the channel (matching Netty's own "should not close the channel"
+                // handling of STOP_SENDING).
+            }
+            else -> ctx.fireExceptionCaught(cause)
         }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -84,10 +84,57 @@ class QuicTransport(
      * peer id we expect that connection to present. A hole punch always targets a known peer, so this
      * is never null (see [dialAsListener]).
      */
-    private data class PendingHolePunch(
+    internal data class PendingHolePunch(
         val expectedPeerId: PeerId,
         val future: CompletableFuture<QuicChannel>
     )
+
+    /**
+     * Routes a completed inbound (server-side) handshake, applying the hole-punch identity guard
+     * before the connection is exposed to application handlers. Extracted from the channelActive
+     * handler in [serverTransportBuilder] so the reject-before-exposure guarantee is testable without
+     * a live QUIC channel.
+     *
+     * If [pending] is a hole punch whose identity does not match the dial target, [closeChannel] is
+     * invoked and the pending future is completed exceptionally — neither [prepareConnection] nor
+     * [exposeConnection] runs, so a wrong-identity peer never reaches inbound protocol handlers.
+     * Otherwise the connection is prepared and then either handed to the waiting hole-punch caller
+     * ([holePunchChannel]) or exposed via [exposeConnection].
+     */
+    internal fun routeInboundHandshake(
+        remoteIdentity: io.libp2p.security.tls.TlsPeerIdentity,
+        pending: PendingHolePunch?,
+        prepareConnection: () -> Unit,
+        closeChannel: () -> Unit,
+        holePunchChannel: () -> QuicChannel,
+        exposeConnection: () -> Unit
+    ) {
+        if (pending != null && !holePunchIdentityMatches(pending.expectedPeerId, remoteIdentity.peerId)) {
+            logger.warn(
+                "Hole-punched peer presented libp2p id {} but dial target was {}; closing",
+                remoteIdentity.peerId,
+                pending.expectedPeerId
+            )
+            closeChannel()
+            pending.future.completeExceptionally(
+                Libp2pException(
+                    "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} " +
+                        "but dial target was ${pending.expectedPeerId}"
+                )
+            )
+            return
+        }
+
+        prepareConnection()
+
+        if (pending != null) {
+            // Route this validated inbound connection to the waiting hole-punch caller.
+            pending.future.complete(holePunchChannel())
+        } else {
+            // Normal path: deliver to the connection handler.
+            exposeConnection()
+        }
+    }
 
     /** Pending hole punches keyed by the remote address we are trying to reach. */
     private val pendingHolePunches = ConcurrentHashMap<InetSocketAddress, PendingHolePunch>()
@@ -427,6 +474,7 @@ class QuicTransport(
                         "quic-handshake-waiter",
                         object : ChannelInboundHandlerAdapter() {
                             override fun channelActive(ctx: ChannelHandlerContext) {
+                                val self = this
                                 // Read peer certificates from this connection's own SSL session
                                 // rather than shared TrustManager state, avoiding a race between
                                 // concurrent handshakes. Both remoteId and remotePubKey come from
@@ -455,50 +503,34 @@ class QuicTransport(
                                     // check closes the channel, giving a wrong-identity peer that
                                     // reached the expected UDP tuple an unauthenticated-by-target
                                     // window into inbound protocols.
-                                    if (pending != null &&
-                                        !holePunchIdentityMatches(pending.expectedPeerId, remoteIdentity.peerId)
-                                    ) {
-                                        logger.warn(
-                                            "Hole-punched peer presented libp2p id {} but dial target was {}; closing",
-                                            remoteIdentity.peerId,
-                                            pending.expectedPeerId
-                                        )
-                                        ctx.close()
-                                        pending.future.completeExceptionally(
-                                            Libp2pException(
-                                                "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} " +
-                                                    "but dial target was ${pending.expectedPeerId}"
+                                    routeInboundHandshake(
+                                        remoteIdentity = remoteIdentity,
+                                        pending = pending,
+                                        prepareConnection = {
+                                            connection.setSecureSession(
+                                                SecureChannel.Session(
+                                                    PeerId.fromPubKey(localKey.publicKey()),
+                                                    remoteIdentity.peerId,
+                                                    remoteIdentity.pubKey,
+                                                    null
+                                                )
                                             )
-                                        )
-                                        return
-                                    }
 
-                                    connection.setSecureSession(
-                                        SecureChannel.Session(
-                                            PeerId.fromPubKey(localKey.publicKey()),
-                                            remoteIdentity.peerId,
-                                            remoteIdentity.pubKey,
-                                            null
-                                        )
+                                            // Remove this handler as it's no longer needed
+                                            ctx.pipeline().remove(self)
+
+                                            // Warm the address cache while the QuicChannel is still
+                                            // live; once closed it frees native state and
+                                            // remoteSocketAddress() returns null.
+                                            connection.cacheAddresses()
+                                        },
+                                        closeChannel = { ctx.close() },
+                                        holePunchChannel = { ctx.channel() as QuicChannel },
+                                        exposeConnection = {
+                                            preHandler?.also { visitor -> visitor.visit(connection) }
+                                            connHandler.handleConnection(connection)
+                                        }
                                     )
-
-                                    // Remove this handler as it's no longer needed
-                                    ctx.pipeline().remove(this)
-
-                                    // Warm the address cache while the QuicChannel is still live;
-                                    // once closed it frees native state and remoteSocketAddress()
-                                    // returns null.
-                                    connection.cacheAddresses()
-
-                                    if (pending != null) {
-                                        // Route this validated inbound connection to the waiting
-                                        // hole-punch caller.
-                                        pending.future.complete(ctx.channel() as QuicChannel)
-                                    } else {
-                                        // Normal path: deliver to the connection handler
-                                        preHandler?.also { visitor -> visitor.visit(connection) }
-                                        connHandler.handleConnection(connection)
-                                    }
                                 } else {
                                     // This should not happen if channelActive is called after handshake
                                     ctx.close()

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -43,6 +43,14 @@ import java.util.concurrent.TimeUnit
 enum class AddressFamily { IPV4, IPV6 }
 
 /**
+ * Whether an inbound hole-punched connection presenting libp2p identity [actual] is acceptable for
+ * a hole punch that targeted [expected]. A null [expected] (dial multiaddr carried no peer id) means
+ * any valid identity is accepted, matching the behaviour of a normal inbound server connection.
+ */
+internal fun holePunchIdentityMatches(expected: PeerId?, actual: PeerId): Boolean =
+    expected == null || expected == actual
+
+/**
  * QUIC transport for libp2p using QUIC v1 (RFC 9000) with TLS 1.3.
  *
  * Security and multiplexing are native to QUIC — no separate Noise/TLS negotiation
@@ -70,8 +78,17 @@ class QuicTransport(
     /** Tracks active listener DatagramChannels by address family. */
     internal val listenerChannelsByFamily = ConcurrentHashMap<AddressFamily, Channel>()
 
-    /** Pending hole punch futures keyed by the remote address we are trying to reach. */
-    private val pendingHolePunches = ConcurrentHashMap<InetSocketAddress, CompletableFuture<QuicChannel>>()
+    /**
+     * A pending hole punch: the future completed when the inbound QUIC connection arrives, plus the
+     * peer id we expect that connection to present (null if the dial multiaddr carried no peer id).
+     */
+    private data class PendingHolePunch(
+        val expectedPeerId: PeerId?,
+        val future: CompletableFuture<QuicChannel>
+    )
+
+    /** Pending hole punches keyed by the remote address we are trying to reach. */
+    private val pendingHolePunches = ConcurrentHashMap<InetSocketAddress, PendingHolePunch>()
 
     private var workerGroup by lazyVar {
         MultiThreadIoEventLoopGroup(NioIoHandler.newFactory())
@@ -421,6 +438,39 @@ class QuicTransport(
 
                                     logger.info("Handshake completed with remote peer id: {}", remoteIdentity.peerId)
 
+                                    // Check if this connection is completing a pending hole punch.
+                                    val remoteAddr = ctx.channel().remoteAddress() as? InetSocketAddress
+                                    val pending = if (remoteAddr != null) {
+                                        pendingHolePunches.remove(remoteAddr)
+                                    } else {
+                                        null
+                                    }
+
+                                    // For a hole punch, validate the inbound peer's identity against
+                                    // the dial target BEFORE exposing the connection. The server
+                                    // pipeline's InboundStreamHandler would otherwise dispatch streams
+                                    // to protocol handlers during the window before the dialAsListener
+                                    // check closes the channel, giving a wrong-identity peer that
+                                    // reached the expected UDP tuple an unauthenticated-by-target
+                                    // window into inbound protocols.
+                                    if (pending != null &&
+                                        !holePunchIdentityMatches(pending.expectedPeerId, remoteIdentity.peerId)
+                                    ) {
+                                        logger.warn(
+                                            "Hole-punched peer presented libp2p id {} but dial target was {}; closing",
+                                            remoteIdentity.peerId,
+                                            pending.expectedPeerId
+                                        )
+                                        ctx.close()
+                                        pending.future.completeExceptionally(
+                                            Libp2pException(
+                                                "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} " +
+                                                    "but dial target was ${pending.expectedPeerId}"
+                                            )
+                                        )
+                                        return
+                                    }
+
                                     connection.setSecureSession(
                                         SecureChannel.Session(
                                             PeerId.fromPubKey(localKey.publicKey()),
@@ -438,17 +488,10 @@ class QuicTransport(
                                     // returns null.
                                     connection.cacheAddresses()
 
-                                    // Check if this connection is completing a pending hole punch
-                                    val remoteAddr = ctx.channel().remoteAddress() as? InetSocketAddress
-                                    val holePunchFuture = if (remoteAddr != null) {
-                                        pendingHolePunches.remove(remoteAddr)
-                                    } else {
-                                        null
-                                    }
-
-                                    if (holePunchFuture != null) {
-                                        // Route this inbound connection to the waiting hole-punch caller
-                                        holePunchFuture.complete(ctx.channel() as QuicChannel)
+                                    if (pending != null) {
+                                        // Route this validated inbound connection to the waiting
+                                        // hole-punch caller.
+                                        pending.future.complete(ctx.channel() as QuicChannel)
                                     } else {
                                         // Normal path: deliver to the connection handler
                                         preHandler?.also { visitor -> visitor.visit(connection) }
@@ -508,7 +551,9 @@ class QuicTransport(
             )
 
         val inboundFuture = CompletableFuture<QuicChannel>()
-        pendingHolePunches[targetAddr] = inboundFuture
+        // Record the expected peer id so the inbound handshake can be validated against the dial
+        // target before the connection is exposed (see channelActive in serverTransportBuilder).
+        pendingHolePunches[targetAddr] = PendingHolePunch(addr.getPeerId(), inboundFuture)
 
         // Send UDP probe packets to open NAT mappings on both sides.
         // Probes are raw UDP datagrams — not QUIC frames.

--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -44,11 +44,12 @@ enum class AddressFamily { IPV4, IPV6 }
 
 /**
  * Whether an inbound hole-punched connection presenting libp2p identity [actual] is acceptable for
- * a hole punch that targeted [expected]. A null [expected] (dial multiaddr carried no peer id) means
- * any valid identity is accepted, matching the behaviour of a normal inbound server connection.
+ * a hole punch that targeted [expected]. A hole punch always targets a known peer, so the inbound
+ * identity must match exactly — unlike a normal inbound server connection, reaching the expected UDP
+ * tuple is not sufficient to be handed back to the caller as the dialed peer.
  */
-internal fun holePunchIdentityMatches(expected: PeerId?, actual: PeerId): Boolean =
-    expected == null || expected == actual
+internal fun holePunchIdentityMatches(expected: PeerId, actual: PeerId): Boolean =
+    expected == actual
 
 /**
  * QUIC transport for libp2p using QUIC v1 (RFC 9000) with TLS 1.3.
@@ -80,10 +81,11 @@ class QuicTransport(
 
     /**
      * A pending hole punch: the future completed when the inbound QUIC connection arrives, plus the
-     * peer id we expect that connection to present (null if the dial multiaddr carried no peer id).
+     * peer id we expect that connection to present. A hole punch always targets a known peer, so this
+     * is never null (see [dialAsListener]).
      */
     private data class PendingHolePunch(
-        val expectedPeerId: PeerId?,
+        val expectedPeerId: PeerId,
         val future: CompletableFuture<QuicChannel>
     )
 
@@ -544,6 +546,11 @@ class QuicTransport(
     ): CompletableFuture<Connection> {
         if (closed) throw Libp2pException("Transport is closed")
         val targetAddr = fromMultiaddr(addr) as InetSocketAddress
+        // A hole punch always targets a known peer. Without a target peer id the inbound connection
+        // could not be validated before exposure, so any peer reaching the expected UDP tuple would
+        // be handed back as the dialed peer — defeating the identity check. Fail fast instead.
+        val expectedPeerId = addr.getPeerId()
+            ?: throw Libp2pException("Hole punch requires a target peer id (/p2p) in $addr")
         val family = if (targetAddr.address is Inet6Address) AddressFamily.IPV6 else AddressFamily.IPV4
         val listenerChannel = listenerChannelsByFamily[family]
             ?: throw Libp2pException(
@@ -553,7 +560,7 @@ class QuicTransport(
         val inboundFuture = CompletableFuture<QuicChannel>()
         // Record the expected peer id so the inbound handshake can be validated against the dial
         // target before the connection is exposed (see channelActive in serverTransportBuilder).
-        pendingHolePunches[targetAddr] = PendingHolePunch(addr.getPeerId(), inboundFuture)
+        pendingHolePunches[targetAddr] = PendingHolePunch(expectedPeerId, inboundFuture)
 
         // Send UDP probe packets to open NAT mappings on both sides.
         // Probes are raw UDP datagrams — not QUIC frames.
@@ -590,8 +597,7 @@ class QuicTransport(
                     // that the invariant PeerId.fromPubKey(remotePubKey) == remoteId holds on the
                     // hole-punch path too.
                     val remoteIdentity = verifyAndExtractIdentity(peerCerts)
-                    val expectedPeerId = addr.getPeerId()
-                    if (expectedPeerId != null && remoteIdentity.peerId != expectedPeerId) {
+                    if (remoteIdentity.peerId != expectedPeerId) {
                         throw Libp2pException(
                             "Remote peer presented libp2p pubkey for ${remoteIdentity.peerId} but dial target was $expectedPeerId"
                         )

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -25,9 +25,12 @@ import io.libp2p.security.noise.NoiseXXSecureChannel;
 import io.libp2p.security.tls.TlsSecureChannel;
 import io.libp2p.transport.implementation.ConnectionOverNetty;
 import io.libp2p.transport.tcp.TcpTransport;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.ChannelOutputShutdownException;
+import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.handler.codec.quic.QuicStreamResetException;
 import io.netty.handler.logging.LogLevel;
 import java.util.ArrayList;
@@ -770,6 +773,105 @@ public class QuicServerTestJava {
         "Remote stream reset must not surface QuicStreamResetException to application handlers,"
             + " got: "
             + serverStreamExceptions);
+
+    clientHost.stop().get(5, TimeUnit.SECONDS);
+    serverHost.stop().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * A remote STOP_SENDING frame (the peer no longer wants to read from the stream) must not surface
+   * to application handlers. Netty fails our queued/in-flight writes with a
+   * ChannelOutputShutdownException("STOP_SENDING frame received"); without special handling that
+   * exception travels the stream pipeline's exceptionCaught path and reaches the application's
+   * ProtocolMessageHandler.onException (Teku logs "Unhandled error while processing req/response").
+   * QuicStreamReadCloseEventConverter must swallow it quietly and leave the stream open, since only
+   * the write side is affected.
+   */
+  @Test
+  void remoteStopSendingDoesNotSurfaceToApplicationHandlers() throws Exception {
+    String localListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    CompletableFuture<Stream> serverStreamFuture = new CompletableFuture<>();
+    PingProtocol capturingPing =
+        new PingProtocol(32) {
+          @Override
+          protected CompletableFuture<PingController> onStartResponder(@NotNull Stream stream) {
+            serverStreamFuture.complete(stream);
+            return super.onStartResponder(stream);
+          }
+        };
+
+    Host clientHost =
+        new HostBuilder().keyType(KeyType.ED25519).secureTransport(QuicTransport::ECDSA).build();
+    Host serverHost =
+        new HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::ECDSA)
+            .protocol(new PingBinding(capturingPing))
+            .listen(localListenAddress)
+            .build();
+
+    clientHost.start().get(5, TimeUnit.SECONDS);
+    serverHost.start().get(5, TimeUnit.SECONDS);
+
+    Connection connection =
+        clientHost
+            .getNetwork()
+            .connect(serverHost.getPeerId(), new Multiaddr(localListenAddress))
+            .get(10, TimeUnit.SECONDS);
+
+    StreamPromise<PingController> ping = connection.muxerSession().createStream(new Ping());
+    Stream pingStream = ping.getStream().get(5, TimeUnit.SECONDS);
+    ping.getController().get(5, TimeUnit.SECONDS);
+
+    QuicStreamChannel clientStreamChannel = ((QuicStream) pingStream).getQuicStreamChannel();
+
+    // Capture exceptions that get past the converter towards application handlers. Insert the
+    // capturer immediately after QuicStreamReadCloseEventConverter so the converter runs first:
+    // if it swallows the exception (the fix) nothing reaches the capturer; if it forwards it (the
+    // bug) the capturer records it, exactly where the application handler would otherwise see it.
+    List<Throwable> appExceptions = new CopyOnWriteArrayList<>();
+    String converterName =
+        clientStreamChannel.pipeline().context(QuicStreamReadCloseEventConverter.class).name();
+    clientStreamChannel
+        .pipeline()
+        .addAfter(
+            converterName,
+            "test-app-exception-capture",
+            new ChannelInboundHandlerAdapter() {
+              @Override
+              public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                appExceptions.add(cause);
+                ctx.fireExceptionCaught(cause);
+              }
+            });
+
+    Stream serverStream = serverStreamFuture.get(5, TimeUnit.SECONDS);
+
+    // The server stops reading: quiche sends a STOP_SENDING frame to the client.
+    ((QuicStream) serverStream).getQuicStreamChannel().shutdownInput().sync();
+
+    // Write to the client stream after STOP_SENDING. Use a void promise so a write failure is
+    // routed through the pipeline's exceptionCaught (mirroring how the exception surfaced in the
+    // wild), rather than only failing the write future. quiche reports STREAM_STOPPED and Netty
+    // fails the write with ChannelOutputShutdownException.
+    for (int i = 0; i < 40 && clientStreamChannel.isOpen(); i++) {
+      clientStreamChannel.writeAndFlush(
+          Unpooled.wrappedBuffer(new byte[256]), clientStreamChannel.voidPromise());
+      Thread.sleep(25);
+    }
+
+    // Allow any fired exception to propagate through the pipeline before asserting.
+    Thread.sleep(500);
+
+    Assertions.assertTrue(
+        appExceptions.stream().noneMatch(t -> t instanceof ChannelOutputShutdownException),
+        "Remote STOP_SENDING must not surface ChannelOutputShutdownException to application"
+            + " handlers, got: "
+            + appExceptions);
+    Assertions.assertTrue(
+        clientStreamChannel.isOpen(),
+        "STOP_SENDING only stops the write side; the stream must stay open for reads");
 
     clientHost.stop().get(5, TimeUnit.SECONDS);
     serverHost.stop().get(5, TimeUnit.SECONDS);

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -3,6 +3,7 @@ package io.libp2p.transport.quic;
 import io.libp2p.core.Connection;
 import io.libp2p.core.ConnectionHandler;
 import io.libp2p.core.Host;
+import io.libp2p.core.Libp2pException;
 import io.libp2p.core.PeerId;
 import io.libp2p.core.Stream;
 import io.libp2p.core.StreamPromise;
@@ -930,9 +931,12 @@ public class QuicServerTestJava {
     System.out.println("Transport listening on: " + localListenAddress);
 
     // Dial a non-existent peer at an address where nobody will connect back
-    // Use a different port so nobody is listening there
+    // Use a different port so nobody is listening there. A hole punch always targets a known
+    // peer, so the address must carry a /p2p peer id (otherwise dialAsListener fails fast).
     int unreachablePort = getPort();
-    Multiaddr unreachableAddr = new Multiaddr("/ip4/127.0.0.1/udp/" + unreachablePort + "/quic-v1");
+    Multiaddr unreachableAddr =
+        new Multiaddr(
+            "/ip4/127.0.0.1/udp/" + unreachablePort + "/quic-v1/p2p/" + PeerId.random().toBase58());
 
     CompletableFuture<Connection> holePunchFuture =
         transport.dialAsListener(unreachableAddr, conn -> {}, null);
@@ -951,6 +955,32 @@ public class QuicServerTestJava {
           e.getCause(),
           "Expected TimeoutException but got: " + e.getCause());
     }
+
+    transport.close().get(5, TimeUnit.SECONDS);
+  }
+
+  /**
+   * A hole punch always targets a known peer. dialAsListener must reject an address with no {@code
+   * /p2p} peer id, because without it the inbound connection could not be validated before exposure
+   * — any peer reaching the expected UDP tuple would be handed back as the dialed peer.
+   */
+  @Test
+  void holePunchWithoutPeerIdIsRejected() throws Exception {
+    String localListenAddress = "/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1";
+
+    Pair<PrivKey, PubKey> serverKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    List<io.libp2p.core.multistream.ProtocolBinding<?>> emptyProtocols = new ArrayList<>();
+
+    QuicTransport transport = QuicTransport.ECDSA(serverKeyPair.component1(), emptyProtocols);
+    transport.initialize();
+    transport.listen(new Multiaddr(localListenAddress), conn -> {}, null).get(5, TimeUnit.SECONDS);
+
+    Multiaddr noPeerIdAddr = new Multiaddr("/ip4/127.0.0.1/udp/" + getPort() + "/quic-v1");
+
+    Assertions.assertThrows(
+        Libp2pException.class,
+        () -> transport.dialAsListener(noPeerIdAddr, conn -> {}, null),
+        "dialAsListener must reject a hole-punch target with no /p2p peer id");
 
     transport.close().get(5, TimeUnit.SECONDS);
   }

--- a/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicHolePunchIdentityTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicHolePunchIdentityTest.kt
@@ -20,9 +20,4 @@ class QuicHolePunchIdentityTest {
 
         assertThat(holePunchIdentityMatches(expected = target, actual = impostor)).isFalse()
     }
-
-    @Test
-    fun `accepts any identity when the dial target carried no peer id`() {
-        assertThat(holePunchIdentityMatches(expected = null, actual = PeerId.random())).isTrue()
-    }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicHolePunchIdentityTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicHolePunchIdentityTest.kt
@@ -1,0 +1,28 @@
+package io.libp2p.transport.quic
+
+import io.libp2p.core.PeerId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class QuicHolePunchIdentityTest {
+
+    @Test
+    fun `accepts the inbound peer when its identity matches the dial target`() {
+        val target = PeerId.random()
+
+        assertThat(holePunchIdentityMatches(expected = target, actual = target)).isTrue()
+    }
+
+    @Test
+    fun `rejects the inbound peer when its identity differs from the dial target`() {
+        val target = PeerId.random()
+        val impostor = PeerId.random()
+
+        assertThat(holePunchIdentityMatches(expected = target, actual = impostor)).isFalse()
+    }
+
+    @Test
+    fun `accepts any identity when the dial target carried no peer id`() {
+        assertThat(holePunchIdentityMatches(expected = null, actual = PeerId.random())).isTrue()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicInboundHandshakeRoutingTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicInboundHandshakeRoutingTest.kt
@@ -1,0 +1,110 @@
+package io.libp2p.transport.quic
+
+import io.libp2p.core.PeerId
+import io.libp2p.crypto.keys.generateEd25519KeyPair
+import io.libp2p.security.tls.TlsPeerIdentity
+import io.mockk.mockk
+import io.netty.handler.codec.quic.QuicChannel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Drives [QuicTransport.routeInboundHandshake] — the inbound (server-side) handshake routing
+ * extracted from the channelActive handler — to verify the hole-punch identity guard rejects a
+ * wrong-identity peer BEFORE the connection is exposed to application handlers. A full network
+ * hole-punch e2e is impractical because the transport's dial binds an ephemeral source port and
+ * dialAsListener only waits, so a mismatched peer cannot be made to connect from the registered
+ * target tuple. Testing the seam directly proves the security-critical reject-before-exposure path.
+ */
+class QuicInboundHandshakeRoutingTest {
+
+    private fun transport(): QuicTransport =
+        QuicTransport.Ed25519(generateEd25519KeyPair().first, emptyList())
+
+    private fun identity(): TlsPeerIdentity {
+        val pubKey = generateEd25519KeyPair().second
+        return TlsPeerIdentity(PeerId.fromPubKey(pubKey), pubKey)
+    }
+
+    @Test
+    fun `rejects a wrong-identity hole punch before exposing the connection`() {
+        val transport = transport()
+        val inbound = identity()
+        val future = CompletableFuture<QuicChannel>()
+        // Pending hole punch targeting a DIFFERENT peer than the one that connected back.
+        val pending = QuicTransport.PendingHolePunch(PeerId.random(), future)
+
+        var prepared = false
+        var closed = false
+        var exposed = false
+
+        transport.routeInboundHandshake(
+            remoteIdentity = inbound,
+            pending = pending,
+            prepareConnection = { prepared = true },
+            closeChannel = { closed = true },
+            holePunchChannel = { error("must not hand a wrong-identity channel to the caller") },
+            exposeConnection = { exposed = true }
+        )
+
+        // Channel closed, caller future failed, and crucially the connection was never prepared
+        // nor exposed to application handlers.
+        assertThat(closed).isTrue()
+        assertThat(future).isCompletedExceptionally()
+        assertThat(prepared).isFalse()
+        assertThat(exposed).isFalse()
+    }
+
+    @Test
+    fun `hands a matching-identity hole punch to the waiting caller`() {
+        val transport = transport()
+        val inbound = identity()
+        val future = CompletableFuture<QuicChannel>()
+        // Pending hole punch whose target matches the peer that connected back.
+        val pending = QuicTransport.PendingHolePunch(inbound.peerId, future)
+        val channel = mockk<QuicChannel>()
+
+        var prepared = false
+        var closed = false
+        var exposed = false
+
+        transport.routeInboundHandshake(
+            remoteIdentity = inbound,
+            pending = pending,
+            prepareConnection = { prepared = true },
+            closeChannel = { closed = true },
+            holePunchChannel = { channel },
+            exposeConnection = { exposed = true }
+        )
+
+        assertThat(prepared).isTrue()
+        assertThat(future.getNow(null)).isSameAs(channel)
+        assertThat(closed).isFalse()
+        // Hole-punch caller is handed the channel directly; it is not exposed via connHandler.
+        assertThat(exposed).isFalse()
+    }
+
+    @Test
+    fun `exposes a normal inbound connection when no hole punch is pending`() {
+        val transport = transport()
+        val inbound = identity()
+
+        var prepared = false
+        var closed = false
+        var exposed = false
+
+        transport.routeInboundHandshake(
+            remoteIdentity = inbound,
+            pending = null,
+            prepareConnection = { prepared = true },
+            closeChannel = { closed = true },
+            holePunchChannel = { error("no hole punch is pending") },
+            exposeConnection = { exposed = true }
+        )
+
+        assertThat(prepared).isTrue()
+        assertThat(exposed).isTrue()
+        assertThat(closed).isFalse()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverterTest.kt
@@ -1,0 +1,59 @@
+package io.libp2p.transport.quic
+
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.channel.socket.ChannelOutputShutdownException
+import io.netty.handler.codec.quic.QuicStreamResetException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class QuicStreamReadCloseEventConverterTest {
+
+    /** Records exceptions that reach application handlers (i.e. were not swallowed by the converter). */
+    private class CapturingHandler : ChannelInboundHandlerAdapter() {
+        val caught = mutableListOf<Throwable>()
+        override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+            caught.add(cause)
+        }
+    }
+
+    private fun channelWithConverter(): Pair<EmbeddedChannel, CapturingHandler> {
+        val capturing = CapturingHandler()
+        // Converter first (as QuicStream installs it), application handler after it.
+        val channel = EmbeddedChannel(QuicStreamReadCloseEventConverter(), capturing)
+        return channel to capturing
+    }
+
+    @Test
+    fun `swallows STOP_SENDING ChannelOutputShutdownException without surfacing it or closing the stream`() {
+        val (channel, capturing) = channelWithConverter()
+
+        channel.pipeline().fireExceptionCaught(ChannelOutputShutdownException("STOP_SENDING frame received"))
+
+        // STOP_SENDING only stops our writes; the read side may still be live, so the stream must
+        // stay open and the exception must not reach application handlers.
+        assertThat(capturing.caught).isEmpty()
+        assertThat(channel.isOpen).isTrue()
+    }
+
+    @Test
+    fun `closes the stream quietly on a remote QuicStreamResetException`() {
+        val (channel, capturing) = channelWithConverter()
+
+        channel.pipeline().fireExceptionCaught(QuicStreamResetException("reset", 0))
+
+        assertThat(capturing.caught).isEmpty()
+        assertThat(channel.isOpen).isFalse()
+    }
+
+    @Test
+    fun `propagates unrelated exceptions to application handlers`() {
+        val (channel, capturing) = channelWithConverter()
+        val unrelated = RuntimeException("boom")
+
+        channel.pipeline().fireExceptionCaught(unrelated)
+
+        assertThat(capturing.caught).containsExactly(unrelated)
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicStreamReadCloseEventConverterTest.kt
@@ -38,6 +38,19 @@ class QuicStreamReadCloseEventConverterTest {
     }
 
     @Test
+    fun `propagates a non-STOP_SENDING ChannelOutputShutdownException without swallowing it`() {
+        val (channel, capturing) = channelWithConverter()
+        // Netty raises this for a local write after the FIN was sent. Unlike STOP_SENDING it means
+        // bytes were not accepted, so it must reach application handlers rather than be dropped.
+        val finAlreadySent = ChannelOutputShutdownException("Fin was sent already")
+
+        channel.pipeline().fireExceptionCaught(finAlreadySent)
+
+        assertThat(capturing.caught).containsExactly(finAlreadySent)
+        assertThat(channel.isOpen).isTrue()
+    }
+
+    @Test
     fun `closes the stream quietly on a remote QuicStreamResetException`() {
         val (channel, capturing) = channelWithConverter()
 


### PR DESCRIPTION
## Summary

Two follow-up QUIC transport fixes on top of #492 (which is merged into `develop`).

### 1. Validate hole-punch peer identity before exposing the connection

On the hole-punch inbound path, `channelActive` set the secure/muxer sessions and
completed the pending future with the raw `QuicChannel` **before** the dial-target peer
id was checked — that check only ran later in `dialAsListener`'s `thenApply`. Because the
server codec installs an `InboundStreamHandler`, a peer that reached the expected UDP
tuple but presented a valid certificate for the **wrong** libp2p identity could have
inbound streams dispatched to protocol handlers during the window before the later check
closed the channel (an unauthenticated-by-target window into inbound protocols).

The dial-target validation now happens in `channelActive`, before the connection is
exposed:

- Each pending hole punch carries its expected peer id (`PendingHolePunch`).
- `holePunchIdentityMatches(expected, actual)` is extracted and unit-tested (null expected
  ⇒ accept any, matching a normal inbound server connection).
- On mismatch, the channel is closed and the future failed **before** the secure session is
  set or the future completed. `channelActive` and stream-activation events run serially on
  the channel event loop, so closing synchronously here closes the window.
- The existing `dialAsListener` check is retained as defence-in-depth.

### 2. Swallow STOP_SENDING `ChannelOutputShutdownException` on streams

When a remote peer sends a STOP_SENDING frame (it no longer wants to read from a stream)
while the local side has queued writes, Netty fails those writes with
`ChannelOutputShutdownException("STOP_SENDING frame received")` and surfaces it into the
stream channel's pipeline. `QuicStreamReadCloseEventConverter` only special-cased
`QuicStreamResetException`, so this exception was forwarded to application handlers and
logged as an unhandled error (e.g. Teku "Unhandled error while processing req/response").

STOP_SENDING is a benign half-close: only our write side is affected, the read side may
still deliver data. The converter's `exceptionCaught` now swallows
`ChannelOutputShutdownException` quietly **without** closing the stream (matching Netty's
own "should not close the channel" handling of STOP_SENDING), mirroring the existing
remote-reset handling.

## Testing

- `QuicHolePunchIdentityTest` — unit tests for the `holePunchIdentityMatches` gate
  (match / mismatch / null-expected).
- `QuicStreamReadCloseEventConverterTest` — deterministic `EmbeddedChannel` unit tests:
  STOP_SENDING swallowed without surfacing or closing, remote-reset closes quietly, and
  unrelated exceptions still propagate.
- Existing `QuicServerTestJava` integration suite (including the remote-reset and
  closeWrite tests) still passes; `spotlessCheck` clean.
