### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,61 @@
+name: "Create Release PR"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The release version (e.g., 1.3.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Checkout develop branch
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0 # Fetch all history so we can merge master later
+
+      # 2. Configure Git Identity
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # 3. Create the release branch from develop
+      - name: Create Release Branch
+        run: |
+          git checkout -b ${{ github.event.inputs.version }}
+
+      # 4. Merge master into the fork branch
+      - name: Merge Master into Release Branch
+        run: |
+          git fetch origin master:master
+          git merge master --no-edit || (echo "Merge conflict detected!" && exit 1)
+
+      # 5. Update the version in build.gradle.kts
+      - name: Update Version in build.gradle.kts
+        run: |
+          sed -i 's/version = ".*"/version = "${{ github.event.inputs.version }}-RELEASE"/g' build.gradle.kts
+          
+          git add build.gradle.kts
+          git commit -m "chore: bump version to ${{ github.event.inputs.version }}-RELEASE"
+          git push origin ${{ github.event.inputs.version }}
+
+      # 6. Make a PR from the release branch to master
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --head ${{ github.event.inputs.version }} \
+            --base master \
+            --title "Release ${{ github.event.inputs.version }}" \
+            --body "Please review, approve, and **Regular Merge** (do not squash) this PR to trigger the Cloudsmith deployment."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,44 @@
+name: "Publish Release"
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  publish-release:
+    # Only run when the PR was actually merged (not just closed/discarded).
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Ensure the source branch name is strictly SemVer (e.g., 1.3.3 or 0.14.2).
+      - name: Check release branch name
+        id: check
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if [[ "$HEAD_REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "Branch '$HEAD_REF' is not a SemVer release; skipping publish."
+          fi
+
+      # 2. Publish artifact to Cloudsmith from a clean docker instance
+      - name: Publish Artifact to Cloudsmith (Docker)
+        if: steps.check.outputs.is_release == 'true'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: gradle:jdk11
+          options: -v ${{ github.workspace }}:/workspace
+          run: |
+            set -e
+            # Clean clone directly from master branch inside the docker environment
+            git clone -b master https://github.com/libp2p/jvm-libp2p.git /tmp/jvm-libp2p
+            cd /tmp/jvm-libp2p
+            
+            set +o history
+            ./gradlew publish \
+              -PcloudsmithUser="${{ secrets.CLOUDSMITH_USER }}" \
+              -PcloudsmithApiKey="${{ secrets.CLOUDSMITH_API_KEY }}"


### PR DESCRIPTION
This is an attempt to automate release process. It is broken down in two steps:

1. Manually kick off the release (by inputting version number) and a PR will be created, which needs to be approved. 
2. Once that is done, the release process will kick off automatically and the artifact will be deployed on Cloudsmith.