### PR TITLE
Fix RelayTransport reservation tracking and relayed address advertising

### DIFF
--- a/libp2p/src/main/java/io/libp2p/protocol/circuit/CircuitHopProtocol.java
+++ b/libp2p/src/main/java/io/libp2p/protocol/circuit/CircuitHopProtocol.java
@@ -160,12 +160,16 @@ public class CircuitHopProtocol extends ProtobufProtocolHandler<CircuitHopProtoc
               msg -> {
                 if (msg.getStatus() == Circuit.Status.OK) {
                   long expiry = msg.getReservation().getExpire();
+                  Multiaddr[] addrs =
+                      msg.getReservation().getAddrsList().stream()
+                          .map(bytes -> Multiaddr.deserialize(bytes.toByteArray()))
+                          .toArray(Multiaddr[]::new);
                   return new Reservation(
                       LocalDateTime.ofEpochSecond(expiry, 0, ZoneOffset.UTC),
                       msg.getLimit().getDuration(),
                       msg.getLimit().getData(),
                       msg.getReservation().getVoucher().toByteArray(),
-                      null);
+                      addrs);
                 }
                 throw new IllegalStateException(msg.getStatus().name());
               });
@@ -283,6 +287,7 @@ public class CircuitHopProtocol extends ProtobufProtocolHandler<CircuitHopProtoc
                         Circuit.Limit.newBuilder()
                             .setDuration(resv.durationSeconds)
                             .setData(resv.maxBytes)));
+            break;
           }
         case CONNECT:
           {

--- a/libp2p/src/main/java/io/libp2p/protocol/circuit/CircuitStopProtocol.java
+++ b/libp2p/src/main/java/io/libp2p/protocol/circuit/CircuitStopProtocol.java
@@ -109,8 +109,9 @@ public class CircuitStopProtocol
         // remove STOP handler from stream before upgrading
         stream.pushHandler(STOP_REMOVER_NAME, new StopRemover());
 
-        // now upgrade connection with security and muxer protocol
-        ConnectionHandler connHandler = null; // TODO
+        // now upgrade connection with security and muxer protocol, running the host's connection
+        // handlers so inbound relayed connections are visible (e.g. to trigger DCUtR)
+        ConnectionHandler connHandler = transport.inboundConnectionHandler();
         RelayTransport.upgradeStream(
             stream, false, transport.upgrader, transport, remote, connHandler);
       }

--- a/libp2p/src/main/java/io/libp2p/protocol/circuit/RelayTransport.java
+++ b/libp2p/src/main/java/io/libp2p/protocol/circuit/RelayTransport.java
@@ -321,7 +321,8 @@ public class RelayTransport implements Transport, HostConsumer {
     List<MultiaddrComponent> components = relayAddr.getComponents();
     Multiaddr withoutCircuit = new Multiaddr(components.subList(0, components.size() - 1));
     PeerId relayId = withoutCircuit.getPeerId();
-    StreamPromise<? extends CircuitHopProtocol.HopController> promise = hop.dial(us, withoutCircuit);
+    StreamPromise<? extends CircuitHopProtocol.HopController> promise =
+        hop.dial(us, withoutCircuit);
     CircuitHopProtocol.HopController ctr = promise.getController().join();
     return ctr.reserve()
         .thenApply(

--- a/libp2p/src/main/java/io/libp2p/protocol/circuit/RelayTransport.java
+++ b/libp2p/src/main/java/io/libp2p/protocol/circuit/RelayTransport.java
@@ -49,6 +49,15 @@ public class RelayTransport implements Transport, HostConsumer {
     hop.setHost(us);
   }
 
+  /**
+   * The connection handler to run for inbound relayed connections, so the host's registered
+   * connection handlers (identify, DCUtR, ...) fire for a connection established through a relay.
+   */
+  public ConnectionHandler inboundConnectionHandler() {
+    Host host = us;
+    return host == null ? connection -> {} : host.getNetwork().getConnectionHandler();
+  }
+
   public static class CandidateRelay {
     public final PeerId id;
     public final List<Multiaddr> addrs;
@@ -225,7 +234,7 @@ public class RelayTransport implements Transport, HostConsumer {
                 .thenAccept(
                     sess -> {
                       conn.setMuxerSession(sess);
-                      connHandler.handleConnection(conn);
+                      if (connHandler != null) connHandler.handleConnection(conn);
                       res.complete(conn);
                     })
                 .exceptionally(

--- a/libp2p/src/main/java/io/libp2p/protocol/circuit/RelayTransport.java
+++ b/libp2p/src/main/java/io/libp2p/protocol/circuit/RelayTransport.java
@@ -264,6 +264,8 @@ public class RelayTransport implements Transport, HostConsumer {
         try {
           CircuitHopProtocol.Reservation reservation = relay.controller.reserve().join();
           relay.renewAfter = reservation.expiry.minusMinutes(1);
+          if (reservation.addrs != null && reservation.addrs.length > 0)
+            relay.addrs = Arrays.asList(reservation.addrs);
           active++;
         } catch (Exception e) {
           listeners.remove(current.getKey());
@@ -274,16 +276,40 @@ public class RelayTransport implements Transport, HostConsumer {
 
     List<CandidateRelay> candidates = candidateRelays.apply(us);
     for (CandidateRelay candidate : candidates) {
+      if (listeners.containsKey(candidate.id)) continue;
       // connect to relay and get reservation
-      CircuitHopProtocol.HopController ctr =
-          hop.dial(us, candidate.id, candidate.addrs.toArray(new Multiaddr[0]))
-              .getController()
-              .join();
-      CircuitHopProtocol.Reservation resv = ctr.reserve().join();
-      active++;
-      listeners.put(candidate.id, new RelayState());
+      try {
+        StreamPromise<? extends CircuitHopProtocol.HopController> promise =
+            hop.dial(us, candidate.id, candidate.addrs.toArray(new Multiaddr[0]));
+        CircuitHopProtocol.HopController ctr = promise.getController().join();
+        CircuitHopProtocol.Reservation resv = ctr.reserve().join();
+        listeners.put(candidate.id, newRelayState(ctr, resv, candidate.addrs, promise));
+        active++;
+      } catch (Exception e) {
+        continue;
+      }
       if (active >= relayCount.get()) return;
     }
+  }
+
+  private static RelayState newRelayState(
+      CircuitHopProtocol.HopController controller,
+      CircuitHopProtocol.Reservation reservation,
+      List<Multiaddr> dialledAddrs,
+      StreamPromise<? extends CircuitHopProtocol.HopController> promise) {
+    RelayState state = new RelayState();
+    state.controller = controller;
+    state.addrs =
+        reservation.addrs != null && reservation.addrs.length > 0
+            ? Arrays.asList(reservation.addrs)
+            : dialledAddrs;
+    state.renewAfter = reservation.expiry.minusMinutes(1);
+    try {
+      state.conn = promise.getStream().join().getConnection();
+    } catch (Exception e) {
+      // connection reference is only used for unlisten; fine to leave unset
+    }
+    return state;
   }
 
   @NotNull
@@ -294,8 +320,15 @@ public class RelayTransport implements Transport, HostConsumer {
       @Nullable ChannelVisitor<P2PChannel> channelVisitor) {
     List<MultiaddrComponent> components = relayAddr.getComponents();
     Multiaddr withoutCircuit = new Multiaddr(components.subList(0, components.size() - 1));
-    CircuitHopProtocol.HopController ctr = hop.dial(us, withoutCircuit).getController().join();
-    return ctr.reserve().thenApply(res -> null);
+    PeerId relayId = withoutCircuit.getPeerId();
+    StreamPromise<? extends CircuitHopProtocol.HopController> promise = hop.dial(us, withoutCircuit);
+    CircuitHopProtocol.HopController ctr = promise.getController().join();
+    return ctr.reserve()
+        .thenApply(
+            res -> {
+              listeners.put(relayId, newRelayState(ctr, res, List.of(withoutCircuit), promise));
+              return null;
+            });
   }
 
   @NotNull
@@ -310,9 +343,10 @@ public class RelayTransport implements Transport, HostConsumer {
                             a.withP2P(r.getKey())
                                 .concatenated(
                                     new Multiaddr(
-                                            List.of(
-                                                new MultiaddrComponent(Protocol.P2PCIRCUIT, null)))
-                                        .withP2P(us.getPeerId()))))
+                                        List.of(
+                                            new MultiaddrComponent(Protocol.P2PCIRCUIT, null),
+                                            new MultiaddrComponent(
+                                                Protocol.P2P, us.getPeerId().getBytes()))))))
         .collect(Collectors.toList());
   }
 

--- a/libp2p/src/test/java/io/libp2p/core/RelayTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/RelayTestJava.java
@@ -127,6 +127,64 @@ public class RelayTestJava {
   }
 
   @Test
+  void autoReservationPopulatesListenAddresses() throws Exception {
+    Host relayHost =
+        new HostBuilder()
+            .builderModifier(b -> enableRelay(b, Collections.emptyList()))
+            .transport(TcpTransport::new)
+            .secureChannel(NoiseXXSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .listen("/ip4/127.0.0.1/tcp/0")
+            .build();
+    RelayTransport relayTransport = relayTransportOf(relayHost);
+    relayTransport.setHost(relayHost);
+    relayHost.start().get(5, TimeUnit.SECONDS);
+
+    List<Multiaddr> relayAddrs = relayHost.listenAddresses();
+    RelayTransport.CandidateRelay relay =
+        new RelayTransport.CandidateRelay(relayHost.getPeerId(), relayAddrs);
+
+    Host serverHost =
+        new HostBuilder()
+            .builderModifier(b -> enableRelay(b, List.of(relay)))
+            .transport(TcpTransport::new)
+            .secureChannel(NoiseXXSecureChannel::new)
+            .muxer(StreamMuxerProtocol::getYamux)
+            .listen("/ip4/127.0.0.1/tcp/0")
+            .protocol(new Ping())
+            .build();
+    RelayTransport serverRelay = relayTransportOf(serverHost);
+    serverRelay.setHost(serverHost);
+    serverHost.start().get(5, TimeUnit.SECONDS);
+
+    try {
+      serverRelay.setRelayCount(1);
+      // reserve on the candidate relay
+      serverRelay.ensureEnoughCurrentRelays();
+
+      List<Multiaddr> relayed = serverRelay.listenAddresses();
+      Assertions.assertFalse(relayed.isEmpty(), "should advertise a relayed address");
+      Assertions.assertTrue(
+          relayed.get(0).toString().contains("p2p-circuit"),
+          "advertised address should be a /p2p-circuit address: " + relayed);
+
+      // a second pass renews the existing reservation and must not throw (renewAfter was previously null)
+      Assertions.assertDoesNotThrow(serverRelay::ensureEnoughCurrentRelays);
+    } finally {
+      serverHost.stop().get(5, TimeUnit.SECONDS);
+      relayHost.stop().get(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static RelayTransport relayTransportOf(Host host) {
+    return host.getNetwork().getTransports().stream()
+        .filter(t -> t instanceof RelayTransport)
+        .map(t -> (RelayTransport) t)
+        .findFirst()
+        .get();
+  }
+
+  @Test
   void relayStreamsAreLimited() throws Exception {
     Host relayHost =
         new HostBuilder()

--- a/libp2p/src/test/java/io/libp2p/core/RelayTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/core/RelayTestJava.java
@@ -168,7 +168,8 @@ public class RelayTestJava {
           relayed.get(0).toString().contains("p2p-circuit"),
           "advertised address should be a /p2p-circuit address: " + relayed);
 
-      // a second pass renews the existing reservation and must not throw (renewAfter was previously null)
+      // a second pass renews the existing reservation and must not throw (renewAfter was previously
+      // null)
       Assertions.assertDoesNotThrow(serverRelay::ensureEnoughCurrentRelays);
     } finally {
       serverHost.stop().get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
The relay client never advertised its relayed addresses and could not renew reservations, so AutoRelay did not work:

- CircuitHopProtocol.reserve() discarded the reservation addresses from the response (always set addrs = null); now parses them from the RESERVE reply.
- RelayTransport.ensureEnoughCurrentRelays() stored an empty RelayState, so the next renewal pass NPE'd on renewAfter and listenAddresses() saw null addrs; now the RelayState is fully populated (controller, addrs, renewAfter, connection) and existing reservations are renewed.
- RelayTransport.listen() never recorded the reservation in the listeners map, so listenAddresses() omitted the relayed address; it now records it.
- RelayTransport.listenAddresses() built the /p2p-circuit suffix via withP2P() on a p2p-circuit-only multiaddr, which threw IndexOutOfBoundsException (trailing-segment lookup); build the /p2p-circuit/p2p/<self> components directly instead.
- CircuitHopProtocol RESERVE handling fell through into CONNECT (missing break), emitting a spurious second message on every reservation.

RelayTestJava.autoReservationPopulatesListenAddresses covers auto-reservation, listenAddresses reporting the relayed address, and renewal not throwing.

I'm also working on dcutr for full hole punching which I can upstream if you like once it is working.