### PR TITLE
QUIC memory leak fix

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -90,6 +90,17 @@ abstract class P2PService(
                 streamActive(this)
             }
         }
+
+        override fun channelWritabilityChanged(ctx: ChannelHandlerContext) {
+            ctx.fireChannelWritabilityChanged()
+            val peer = peerHandler ?: return
+            runOnEventThread(peer) {
+                if (!aborted && !closed) {
+                    streamWritabilityChanged(this)
+                }
+            }
+        }
+
         override fun channelUnregistered(ctx: ChannelHandlerContext?) {
             closed = true
             runOnEventThread(peerHandler) {
@@ -128,6 +139,7 @@ abstract class P2PService(
         open val peerId = streamHandler.stream.remotePeerId()
         open fun writeAndFlush(msg: Any): CompletableFuture<Unit> = streamHandler.ctx!!.writeAndFlush(msg).toVoidCompletableFuture()
         open fun isActive() = streamHandler.ctx != null
+        open fun isWritable(): Boolean = getOutboundHandler()?.ctx?.channel()?.isWritable == true
         open fun getInboundHandler(): StreamHandler? = streamHandler
         open fun getOutboundHandler(): StreamHandler? = streamHandler
         override fun toString(): String {
@@ -163,6 +175,8 @@ abstract class P2PService(
     }
 
     protected open fun createPeerHandler(streamHandler: StreamHandler) = PeerHandler(streamHandler)
+
+    protected open fun streamWritabilityChanged(stream: StreamHandler) {}
 
     protected open fun streamActive(stream: StreamHandler) {
         if (stream.aborted) return

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -9,8 +9,11 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.util.ReferenceCountUtil
 import org.slf4j.LoggerFactory
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 
 private val logger = LoggerFactory.getLogger(P2PService::class.java)
 
@@ -231,7 +234,40 @@ abstract class P2PService(
      * Executes the code on the service event thread
      * Supply additional info which is reported to [onServiceException]
      */
-    fun runOnEventThread(peer: PeerHandler? = null, msg: Any? = null, run: () -> Unit) = executor.execute {
+    fun runOnEventThread(peer: PeerHandler? = null, msg: Any? = null, run: () -> Unit) =
+        executor.execute(guarded(peer, msg, run))
+
+    /**
+     * Schedules code on the service event thread.
+     * Supply additional info which is reported to [onServiceException].
+     */
+    fun scheduleOnEventThread(
+        delay: Duration,
+        peer: PeerHandler? = null,
+        msg: Any? = null,
+        run: () -> Unit
+    ): ScheduledFuture<*> =
+        executor.schedule(guarded(peer, msg, run), delay.toMillis(), TimeUnit.MILLISECONDS)
+
+    /**
+     * Schedules recurring code on the service event thread with a fixed delay between runs.
+     * Supply additional info which is reported to [onServiceException].
+     */
+    fun scheduleWithFixedDelayOnEventThread(
+        initialDelay: Duration,
+        delay: Duration,
+        peer: PeerHandler? = null,
+        msg: Any? = null,
+        run: () -> Unit
+    ): ScheduledFuture<*> =
+        executor.scheduleWithFixedDelay(
+            guarded(peer, msg, run),
+            initialDelay.toMillis(),
+            delay.toMillis(),
+            TimeUnit.MILLISECONDS
+        )
+
+    private fun guarded(peer: PeerHandler?, msg: Any?, run: () -> Unit) = Runnable {
         try {
             run()
         } catch (e: Exception) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -54,7 +54,6 @@ abstract class AbstractRouter(
     protected open val peersTopics = mutableMultiBiMap<PeerHandler, Topic>()
     protected open val subscribedTopics = linkedSetOf<Topic>()
     protected open val pendingRpcParts = PendingRpcPartsMap<RpcPartsQueue> { DefaultRpcPartsQueue() }
-    protected open val pendingMessagePromises = MultiSet<PeerHandler, CompletableFuture<Unit>>()
     private val outboundSendStates = mutableMapOf<PeerHandler, OutboundSendState>()
     private val stalledOutboundPeers = mutableMapOf<PeerHandler, Throwable>()
 
@@ -65,25 +64,35 @@ abstract class AbstractRouter(
     private class OutboundSendState {
         var activeWrite: CompletableFuture<Unit>? = null
         var progressDeadline: ScheduledFuture<*>? = null
-        var batchPromises: List<CompletableFuture<Unit>> = emptyList()
+        var activeMessages: List<Rpc.RPC> = emptyList()
+        var activeMessageIndex: Int = 0
+        var activePromises: List<CompletableFuture<Unit>> = emptyList()
+        var activeUsage: OutboundResourceUsage = OutboundResourceUsage.ZERO
     }
 
     protected fun hasOutboundState(): Boolean =
         outboundSendStates.isNotEmpty() ||
             stalledOutboundPeers.isNotEmpty() ||
-            pendingRpcParts.pendingPeers.isNotEmpty() ||
-            pendingMessagePromises.any()
+            pendingRpcParts.pendingPeers.isNotEmpty()
 
     protected class PendingRpcPartsMap<out TPartsQueue : RpcPartsQueue>(
         private val queueFactory: () -> TPartsQueue
     ) {
-        private val map = linkedMapOf<PeerHandler, TPartsQueue>()
+        data class PendingGeneration<out TPartsQueue : RpcPartsQueue>(
+            val queue: TPartsQueue,
+            val promises: MutableList<CompletableFuture<Unit>> = mutableListOf(),
+            var usage: OutboundResourceUsage = OutboundResourceUsage.ZERO
+        )
+
+        private val map = linkedMapOf<PeerHandler, PendingGeneration<TPartsQueue>>()
 
         val pendingPeers: Collection<PeerHandler> get() = map.keys.copy()
 
-        fun getQueue(peer: PeerHandler) = map.computeIfAbsent(peer) { queueFactory() }
-        fun popQueue(peer: PeerHandler) = map.remove(peer) ?: queueFactory()
-        fun popQueueOrNull(peer: PeerHandler) = map.remove(peer)
+        fun get(peer: PeerHandler): PendingGeneration<TPartsQueue> =
+            map.computeIfAbsent(peer) { PendingGeneration(queueFactory()) }
+
+        fun getOrNull(peer: PeerHandler) = map[peer]
+        fun pop(peer: PeerHandler) = map.remove(peer)
     }
 
     override fun publish(msg: PubsubMessage): CompletableFuture<Unit> {
@@ -99,11 +108,61 @@ abstract class AbstractRouter(
     }
 
     protected open fun submitPublishMessage(toPeer: PeerHandler, msg: PubsubMessage): CompletableFuture<Unit> {
-        stalledOutboundPeers[toPeer]?.let { return completedExceptionally(it) }
-        pendingRpcParts.getQueue(toPeer).addPublish(msg.protobufMessage)
+        val rpc = Rpc.RPC.newBuilder().addPublish(msg.protobufMessage).build()
+        if (rpc.serializedSize > maxMsgSize) {
+            return completedExceptionally(
+                InvalidMessageException(
+                    "Outbound pubsub message size ${rpc.serializedSize} exceeds maxGossipMessageSize $maxMsgSize"
+                )
+            )
+        }
         val sendPromise = CompletableFuture<Unit>()
-        pendingMessagePromises[toPeer] += sendPromise
+        val cause = enqueueOutbound(
+            toPeer,
+            pendingRpcParts,
+            OutboundResourceUsage.fromRpc(rpc, promiseEntries = 1),
+            sendPromise
+        ) { it.addPublish(msg.protobufMessage) }
+        cause?.let(sendPromise::completeExceptionally)
         return sendPromise
+    }
+
+    protected fun <TPartsQueue : RpcPartsQueue> enqueueOutbound(
+        peer: PeerHandler,
+        pendingMap: PendingRpcPartsMap<TPartsQueue>,
+        usage: OutboundResourceUsage,
+        promise: CompletableFuture<Unit>? = null,
+        addPart: (TPartsQueue) -> Unit
+    ): Throwable? {
+        stalledOutboundPeers[peer]?.let { return it }
+        val state = outboundSendStates.getOrPut(peer) { OutboundSendState() }
+        val pending = pendingMap.get(peer)
+        val retained = state.activeUsage.plusOrNull(pending.usage)
+        val projected = retained?.plusOrNull(usage)
+
+        if (projected == null || !projected.fits(outboundLimits)) {
+            val cause = OutboundQueueOverflowException(
+                "Outbound pubsub queue for ${peer.peerId} exceeds " +
+                    "${outboundLimits.maxRetainedBytesPerPeer} bytes or " +
+                    "${outboundLimits.maxRetainedEntriesPerPeer} entries"
+            )
+            cleanupOutbound(peer, cause, resetStream = true)
+            return cause
+        }
+
+        try {
+            addPart(pending.queue)
+        } catch (error: Throwable) {
+            if (pending.usage == OutboundResourceUsage.ZERO &&
+                pending.promises.isEmpty()
+            ) {
+                pendingMap.pop(peer)
+            }
+            throw error
+        }
+        pending.usage = pending.usage.plusOrNull(usage)!!
+        promise?.let(pending.promises::add)
+        return null
     }
 
     internal open fun validateMessageListLimits(msg: Rpc.RPCOrBuilder): Boolean {
@@ -134,11 +193,22 @@ abstract class AbstractRouter(
         val state = outboundSendStates.getOrPut(peer) { OutboundSendState() }
         if (state.activeWrite != null) return
 
-        val peerMessages = pendingRpcParts.popQueueOrNull(peer)?.takeMerged() ?: return
-        if (peerMessages.isEmpty()) return
+        val pending = pendingRpcParts.pop(peer)
+        if (pending == null) {
+            outboundSendStates.remove(peer)
+            return
+        }
 
-        state.batchPromises = pendingMessagePromises.removeAll(peer) ?: emptyList()
-        sendNext(peer, state, peerMessages, 0)
+        state.activeMessages = pending.queue.takeMerged()
+        state.activeMessageIndex = 0
+        state.activePromises = pending.promises.toList()
+        state.activeUsage = pending.usage
+        if (state.activeMessages.isEmpty()) {
+            completeActiveGeneration(state)
+            outboundSendStates.remove(peer)
+            return
+        }
+        sendNext(peer, state)
     }
 
     override fun addPeer(peer: Stream) = addPeerWithDebugHandler(peer, null)
@@ -189,9 +259,8 @@ abstract class AbstractRouter(
     protected abstract fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler)
 
     override fun onPeerActive(peer: PeerHandler) {
-        val partsQueue = pendingRpcParts.getQueue(peer)
         subscribedTopics.forEach {
-            partsQueue.addSubscribe(it)
+            enqueueSubscription(peer, it, RpcPartsQueue.SubscriptionStatus.Subscribed)
         }
         flushPending(peer)
     }
@@ -373,7 +442,9 @@ abstract class AbstractRouter(
     }
 
     protected open fun subscribe(topic: Topic) {
-        activePeers.forEach { pendingRpcParts.getQueue(it).addSubscribe(topic) }
+        activePeers.forEach {
+            enqueueSubscription(it, topic, RpcPartsQueue.SubscriptionStatus.Subscribed)
+        }
         subscribedTopics += topic
     }
 
@@ -385,8 +456,27 @@ abstract class AbstractRouter(
     }
 
     protected open fun unsubscribe(topic: Topic) {
-        activePeers.forEach { pendingRpcParts.getQueue(it).addUnsubscribe(topic) }
+        activePeers.forEach {
+            enqueueSubscription(it, topic, RpcPartsQueue.SubscriptionStatus.Unsubscribed)
+        }
         subscribedTopics -= topic
+    }
+
+    private fun enqueueSubscription(
+        peer: PeerHandler,
+        topic: Topic,
+        status: RpcPartsQueue.SubscriptionStatus
+    ) {
+        val subscription = Rpc.RPC.SubOpts.newBuilder()
+            .setTopicid(topic)
+            .setSubscribe(status == RpcPartsQueue.SubscriptionStatus.Subscribed)
+            .build()
+        val rpc = Rpc.RPC.newBuilder().addSubscriptions(subscription).build()
+        enqueueOutbound(
+            peer,
+            pendingRpcParts,
+            OutboundResourceUsage.fromRpc(rpc)
+        ) { it.addSubscription(topic, status) }
     }
 
     override fun getPeerTopics(): CompletableFuture<Map<PeerId, Set<Topic>>> {
@@ -404,18 +494,25 @@ abstract class AbstractRouter(
     }
 
     protected fun enqueueRpc(peer: PeerHandler, msg: Rpc.RPC) {
-        pendingRpcParts.getQueue(peer).addRpc(msg)
-        flushPending(peer)
+        if (msg.serializedSize > maxMsgSize) {
+            throw InvalidMessageException(
+                "Outbound RPC size ${msg.serializedSize} exceeds maxGossipMessageSize $maxMsgSize"
+            )
+        }
+        val cause = enqueueOutbound(
+            peer,
+            pendingRpcParts,
+            OutboundResourceUsage.fromRpc(msg)
+        ) { it.addRpc(msg) }
+        if (cause == null) flushPending(peer)
     }
 
     private fun sendNext(
         peer: PeerHandler,
-        state: OutboundSendState,
-        messages: List<Rpc.RPC>,
-        messageIndex: Int
+        state: OutboundSendState
     ) {
         val write = try {
-            send(peer, messages[messageIndex])
+            send(peer, state.activeMessages[state.activeMessageIndex])
         } catch (cause: Throwable) {
             completedExceptionally(cause)
         }
@@ -442,15 +539,24 @@ abstract class AbstractRouter(
 
                 if (error != null) {
                     cleanupOutbound(peer, error, resetStream = true)
-                } else if (messageIndex + 1 < messages.size) {
-                    sendNext(peer, state, messages, messageIndex + 1)
+                } else if (state.activeMessageIndex + 1 < state.activeMessages.size) {
+                    state.activeMessageIndex++
+                    sendNext(peer, state)
                 } else {
-                    state.batchPromises.forEach { it.complete(Unit) }
-                    state.batchPromises = emptyList()
+                    completeActiveGeneration(state)
                     flushPending(peer)
                 }
             }
         }
+    }
+
+    private fun completeActiveGeneration(state: OutboundSendState) {
+        if (state.activeMessages.isEmpty()) return
+        state.activePromises.forEach { it.complete(Unit) }
+        state.activePromises = emptyList()
+        state.activeMessages = emptyList()
+        state.activeMessageIndex = 0
+        state.activeUsage = OutboundResourceUsage.ZERO
     }
 
     private fun cleanupOutbound(peer: PeerHandler, cause: Throwable, resetStream: Boolean) {
@@ -459,8 +565,11 @@ abstract class AbstractRouter(
             state.progressDeadline = null
             state.activeWrite?.completeExceptionally(cause)
             state.activeWrite = null
-            state.batchPromises.forEach { it.completeExceptionally(cause) }
-            state.batchPromises = emptyList()
+            state.activePromises.forEach { it.completeExceptionally(cause) }
+            state.activePromises = emptyList()
+            state.activeMessages = emptyList()
+            state.activeMessageIndex = 0
+            state.activeUsage = OutboundResourceUsage.ZERO
         }
         failQueuedOutbound(peer, cause)
 
@@ -475,8 +584,11 @@ abstract class AbstractRouter(
     }
 
     private fun failQueuedOutbound(peer: PeerHandler, cause: Throwable) {
-        pendingRpcParts.popQueue(peer)
-        pendingMessagePromises.removeAll(peer)?.forEach { it.completeExceptionally(cause) }
+        pendingRpcParts.pop(peer)?.let { pending ->
+            pending.promises.forEach { it.completeExceptionally(cause) }
+            pending.promises.clear()
+            pending.usage = OutboundResourceUsage.ZERO
+        }
     }
 
     override fun initHandler(handler: (PubsubMessage) -> CompletableFuture<ValidationResult>) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -48,6 +48,8 @@ abstract class AbstractRouter(
 
     protected var msgHandler: PubsubMessageHandler = { throw IllegalStateException("Message handler is not initialized for PubsubRouter") }
     protected var outboundWriteProgressTimeout: Duration = DEFAULT_OUTBOUND_WRITE_PROGRESS_TIMEOUT
+    internal var outboundLimits: PubsubOutboundLimits = PubsubOutboundLimits.UNBOUNDED
+        private set
 
     protected open val peersTopics = mutableMultiBiMap<PeerHandler, Topic>()
     protected open val subscribedTopics = linkedSetOf<Topic>()
@@ -55,6 +57,10 @@ abstract class AbstractRouter(
     protected open val pendingMessagePromises = MultiSet<PeerHandler, CompletableFuture<Unit>>()
     private val outboundSendStates = mutableMapOf<PeerHandler, OutboundSendState>()
     private val stalledOutboundPeers = mutableMapOf<PeerHandler, Throwable>()
+
+    internal fun configureOutboundLimits(limits: PubsubOutboundLimits) {
+        outboundLimits = limits
+    }
 
     private class OutboundSendState {
         var activeWrite: CompletableFuture<Unit>? = null

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -162,6 +162,7 @@ abstract class AbstractRouter(
         }
         pending.usage = pending.usage.plusOrNull(usage)!!
         promise?.let(pending.promises::add)
+        ensureProgressDeadline(peer, state)
         return null
     }
 
@@ -191,29 +192,18 @@ abstract class AbstractRouter(
             return
         }
         val state = outboundSendStates.getOrPut(peer) { OutboundSendState() }
-        if (state.activeWrite != null) return
+        pumpOutbound(peer, state)
+    }
 
-        val pending = pendingRpcParts.pop(peer)
-        if (pending == null) {
-            outboundSendStates.remove(peer)
-            return
-        }
+    protected open fun isOutboundWritable(peer: PeerHandler): Boolean =
+        peer.isWritable()
 
-        state.activeMessageIndex = 0
-        state.activePromises = pending.promises.toList()
-        state.activeUsage = pending.usage
-        try {
-            state.activeMessages = pending.queue.takeMerged()
-        } catch (cause: Throwable) {
-            cleanupOutbound(peer, cause, resetStream = true)
-            return
+    override fun streamWritabilityChanged(stream: StreamHandler) {
+        if (stream.aborted || stream.closed) return
+        val peer = stream.getPeerHandler()
+        if (peer.getOutboundHandler() === stream) {
+            outboundSendStates[peer]?.let { pumpOutbound(peer, it) }
         }
-        if (state.activeMessages.isEmpty()) {
-            completeActiveGeneration(state)
-            outboundSendStates.remove(peer)
-            return
-        }
-        sendNext(peer, state)
     }
 
     override fun addPeer(peer: Stream) = addPeerWithDebugHandler(peer, null)
@@ -512,28 +502,95 @@ abstract class AbstractRouter(
         if (cause == null) flushPending(peer)
     }
 
-    private fun sendNext(
+    private fun pumpOutbound(
         peer: PeerHandler,
         state: OutboundSendState
     ) {
+        if (outboundSendStates[peer] !== state || state.activeWrite != null) return
+
+        if (state.activeMessageIndex >= state.activeMessages.size) {
+            completeActiveGeneration(state)
+            if (pendingRpcParts.getOrNull(peer) == null) {
+                removeIdleState(peer, state)
+                return
+            }
+            if (!isOutboundWritable(peer)) {
+                ensureProgressDeadline(peer, state)
+                return
+            }
+            val pending = pendingRpcParts.pop(peer)!!
+            state.activePromises = pending.promises.toList()
+            state.activeUsage = pending.usage
+            state.activeMessages = try {
+                pending.queue.takeMerged()
+            } catch (cause: Throwable) {
+                cleanupOutbound(peer, cause, resetStream = true)
+                return
+            }
+            state.activeMessageIndex = 0
+            if (state.activeMessages.isEmpty()) {
+                completeActiveGeneration(state)
+                removeIdleState(peer, state)
+                return
+            }
+        }
+
+        if (!isOutboundWritable(peer)) {
+            ensureProgressDeadline(peer, state)
+            return
+        }
+
+        startWrite(peer, state, state.activeMessages[state.activeMessageIndex])
+    }
+
+    private fun removeIdleState(peer: PeerHandler, state: OutboundSendState) {
+        if (state.activeWrite == null &&
+            state.activeMessages.isEmpty() &&
+            pendingRpcParts.getOrNull(peer) == null &&
+            outboundSendStates.remove(peer, state)
+        ) {
+            state.progressDeadline?.cancel(false)
+            state.progressDeadline = null
+        }
+    }
+
+    private fun hasRetainedWork(
+        peer: PeerHandler,
+        state: OutboundSendState
+    ): Boolean =
+        state.activeWrite != null ||
+            state.activeMessages.isNotEmpty() ||
+            pendingRpcParts.getOrNull(peer) != null
+
+    private fun ensureProgressDeadline(peer: PeerHandler, state: OutboundSendState) {
+        if (state.progressDeadline != null) return
+        state.progressDeadline =
+            scheduleOnEventThread(outboundWriteProgressTimeout, peer) {
+                if (outboundSendStates[peer] === state && hasRetainedWork(peer, state)) {
+                    state.progressDeadline = null
+                    cleanupOutbound(
+                        peer,
+                        TimeoutException(
+                            "Outbound pubsub write to ${peer.peerId} made no progress within $outboundWriteProgressTimeout"
+                        ),
+                        resetStream = true
+                    )
+                }
+            }
+    }
+
+    private fun startWrite(
+        peer: PeerHandler,
+        state: OutboundSendState,
+        msg: Rpc.RPC
+    ) {
         val write = try {
-            send(peer, state.activeMessages[state.activeMessageIndex])
+            send(peer, msg)
         } catch (cause: Throwable) {
             completedExceptionally(cause)
         }
         state.activeWrite = write
-        state.progressDeadline = scheduleOnEventThread(outboundWriteProgressTimeout, peer) {
-            if (outboundSendStates[peer] === state && state.activeWrite === write) {
-                state.progressDeadline = null
-                cleanupOutbound(
-                    peer,
-                    TimeoutException(
-                        "Outbound pubsub write to ${peer.peerId} made no progress within $outboundWriteProgressTimeout"
-                    ),
-                    resetStream = true
-                )
-            }
-        }
+        ensureProgressDeadline(peer, state)
         write.whenComplete { _, error ->
             runOnEventThread(peer) {
                 if (outboundSendStates[peer] !== state || state.activeWrite !== write) return@runOnEventThread
@@ -544,19 +601,24 @@ abstract class AbstractRouter(
 
                 if (error != null) {
                     cleanupOutbound(peer, error, resetStream = true)
-                } else if (state.activeMessageIndex + 1 < state.activeMessages.size) {
-                    state.activeMessageIndex++
-                    sendNext(peer, state)
                 } else {
-                    completeActiveGeneration(state)
-                    flushPending(peer)
+                    state.activeMessageIndex++
+                    if (hasRetainedWork(peer, state)) {
+                        ensureProgressDeadline(peer, state)
+                    }
+                    pumpOutbound(peer, state)
                 }
             }
         }
     }
 
     private fun completeActiveGeneration(state: OutboundSendState) {
-        if (state.activeMessages.isEmpty()) return
+        if (state.activeMessages.isEmpty() &&
+            state.activePromises.isEmpty() &&
+            state.activeUsage == OutboundResourceUsage.ZERO
+        ) {
+            return
+        }
         state.activePromises.forEach { it.complete(Unit) }
         state.activePromises = emptyList()
         state.activeMessages = emptyList()

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -62,6 +62,12 @@ abstract class AbstractRouter(
         var batchPromises: List<CompletableFuture<Unit>> = emptyList()
     }
 
+    protected fun hasOutboundState(): Boolean =
+        outboundSendStates.isNotEmpty() ||
+            stalledOutboundPeers.isNotEmpty() ||
+            pendingRpcParts.pendingPeers.isNotEmpty() ||
+            pendingMessagePromises.any()
+
     protected class PendingRpcPartsMap<out TPartsQueue : RpcPartsQueue>(
         private val queueFactory: () -> TPartsQueue
     ) {
@@ -454,8 +460,12 @@ abstract class AbstractRouter(
 
         if (resetStream) {
             stalledOutboundPeers[peer] = cause
-            peer.getOutboundHandler()?.stream?.reset()
+            resetOutboundStream(peer)
         }
+    }
+
+    protected open fun resetOutboundStream(peer: PeerHandler) {
+        peer.getOutboundHandler()?.stream?.reset()
     }
 
     private fun failQueuedOutbound(peer: PeerHandler, cause: Throwable) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -199,10 +199,15 @@ abstract class AbstractRouter(
             return
         }
 
-        state.activeMessages = pending.queue.takeMerged()
         state.activeMessageIndex = 0
         state.activePromises = pending.promises.toList()
         state.activeUsage = pending.usage
+        try {
+            state.activeMessages = pending.queue.takeMerged()
+        } catch (cause: Throwable) {
+            cleanupOutbound(peer, cause, resetStream = true)
+            return
+        }
         if (state.activeMessages.isEmpty()) {
             completeActiveGeneration(state)
             outboundSendStates.remove(peer)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -61,13 +61,18 @@ abstract class AbstractRouter(
         outboundLimits = limits
     }
 
+    private class ActiveGeneration(
+        val promises: List<CompletableFuture<Unit>>,
+        val usage: OutboundResourceUsage
+    ) {
+        var messages: List<Rpc.RPC> = emptyList()
+        var messageIndex: Int = 0
+    }
+
     private class OutboundSendState {
+        var activeGeneration: ActiveGeneration? = null
         var activeWrite: CompletableFuture<Unit>? = null
         var progressDeadline: ScheduledFuture<*>? = null
-        var activeMessages: List<Rpc.RPC> = emptyList()
-        var activeMessageIndex: Int = 0
-        var activePromises: List<CompletableFuture<Unit>> = emptyList()
-        var activeUsage: OutboundResourceUsage = OutboundResourceUsage.ZERO
     }
 
     protected fun hasOutboundState(): Boolean =
@@ -135,9 +140,10 @@ abstract class AbstractRouter(
         addPart: (TPartsQueue) -> Unit
     ): Throwable? {
         stalledOutboundPeers[peer]?.let { return it }
-        val state = outboundSendStates.getOrPut(peer) { OutboundSendState() }
+        val existingState = outboundSendStates[peer]
         val pending = pendingMap.get(peer)
-        val retained = state.activeUsage.plusOrNull(pending.usage)
+        val activeUsage = existingState?.activeGeneration?.usage ?: OutboundResourceUsage.ZERO
+        val retained = activeUsage.plusOrNull(pending.usage)
         val projected = retained?.plusOrNull(usage)
 
         if (projected == null || !projected.fits(outboundLimits)) {
@@ -162,6 +168,7 @@ abstract class AbstractRouter(
         }
         pending.usage = pending.usage.plusOrNull(usage)!!
         promise?.let(pending.promises::add)
+        val state = existingState ?: OutboundSendState().also { outboundSendStates[peer] = it }
         ensureProgressDeadline(peer, state)
         return null
     }
@@ -508,8 +515,11 @@ abstract class AbstractRouter(
     ) {
         if (outboundSendStates[peer] !== state || state.activeWrite != null) return
 
-        if (state.activeMessageIndex >= state.activeMessages.size) {
-            completeActiveGeneration(state)
+        var generation = state.activeGeneration
+        if (generation == null || generation.messageIndex >= generation.messages.size) {
+            if (generation != null) {
+                completeActiveGeneration(state)
+            }
             if (pendingRpcParts.getOrNull(peer) == null) {
                 removeIdleState(peer, state)
                 return
@@ -519,16 +529,15 @@ abstract class AbstractRouter(
                 return
             }
             val pending = pendingRpcParts.pop(peer)!!
-            state.activePromises = pending.promises.toList()
-            state.activeUsage = pending.usage
-            state.activeMessages = try {
+            generation = ActiveGeneration(pending.promises.toList(), pending.usage)
+            state.activeGeneration = generation
+            generation.messages = try {
                 pending.queue.takeMerged()
             } catch (cause: Throwable) {
                 cleanupOutbound(peer, cause, resetStream = true)
                 return
             }
-            state.activeMessageIndex = 0
-            if (state.activeMessages.isEmpty()) {
+            if (generation.messages.isEmpty()) {
                 completeActiveGeneration(state)
                 removeIdleState(peer, state)
                 return
@@ -540,12 +549,12 @@ abstract class AbstractRouter(
             return
         }
 
-        startWrite(peer, state, state.activeMessages[state.activeMessageIndex])
+        startWrite(peer, state, generation.messages[generation.messageIndex])
     }
 
     private fun removeIdleState(peer: PeerHandler, state: OutboundSendState) {
         if (state.activeWrite == null &&
-            state.activeMessages.isEmpty() &&
+            state.activeGeneration == null &&
             pendingRpcParts.getOrNull(peer) == null &&
             outboundSendStates.remove(peer, state)
         ) {
@@ -559,7 +568,7 @@ abstract class AbstractRouter(
         state: OutboundSendState
     ): Boolean =
         state.activeWrite != null ||
-            state.activeMessages.isNotEmpty() ||
+            state.activeGeneration?.let { it.messageIndex < it.messages.size } == true ||
             pendingRpcParts.getOrNull(peer) != null
 
     private fun ensureProgressDeadline(peer: PeerHandler, state: OutboundSendState) {
@@ -602,7 +611,7 @@ abstract class AbstractRouter(
                 if (error != null) {
                     cleanupOutbound(peer, error, resetStream = true)
                 } else {
-                    state.activeMessageIndex++
+                    state.activeGeneration!!.messageIndex++
                     if (hasRetainedWork(peer, state)) {
                         ensureProgressDeadline(peer, state)
                     }
@@ -613,17 +622,9 @@ abstract class AbstractRouter(
     }
 
     private fun completeActiveGeneration(state: OutboundSendState) {
-        if (state.activeMessages.isEmpty() &&
-            state.activePromises.isEmpty() &&
-            state.activeUsage == OutboundResourceUsage.ZERO
-        ) {
-            return
-        }
-        state.activePromises.forEach { it.complete(Unit) }
-        state.activePromises = emptyList()
-        state.activeMessages = emptyList()
-        state.activeMessageIndex = 0
-        state.activeUsage = OutboundResourceUsage.ZERO
+        val generation = state.activeGeneration ?: return
+        generation.promises.forEach { it.complete(Unit) }
+        state.activeGeneration = null
     }
 
     private fun cleanupOutbound(peer: PeerHandler, cause: Throwable, resetStream: Boolean) {
@@ -632,11 +633,8 @@ abstract class AbstractRouter(
             state.progressDeadline = null
             state.activeWrite?.completeExceptionally(cause)
             state.activeWrite = null
-            state.activePromises.forEach { it.completeExceptionally(cause) }
-            state.activePromises = emptyList()
-            state.activeMessages = emptyList()
-            state.activeMessageIndex = 0
-            state.activeUsage = OutboundResourceUsage.ZERO
+            state.activeGeneration?.promises?.forEach { it.completeExceptionally(cause) }
+            state.activeGeneration = null
         }
         failQueuedOutbound(peer, cause)
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -13,13 +13,17 @@ import io.netty.handler.codec.protobuf.ProtobufEncoder
 import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender
 import org.slf4j.LoggerFactory
 import pubsub.pb.Rpc
+import java.time.Duration
 import java.util.Collections.singletonList
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeoutException
 
 // 1 MB default max message size
 const val DEFAULT_MAX_PUBSUB_MESSAGE_SIZE = 1 shl 20
+val DEFAULT_OUTBOUND_WRITE_PROGRESS_TIMEOUT: Duration = Duration.ofSeconds(30)
 
 typealias PubsubMessageHandler = (PubsubMessage) -> CompletableFuture<ValidationResult>
 
@@ -43,11 +47,20 @@ abstract class AbstractRouter(
 ) : P2PServiceSemiDuplex(executor), PubsubRouter, PubsubRouterDebug {
 
     protected var msgHandler: PubsubMessageHandler = { throw IllegalStateException("Message handler is not initialized for PubsubRouter") }
+    protected var outboundWriteProgressTimeout: Duration = DEFAULT_OUTBOUND_WRITE_PROGRESS_TIMEOUT
 
     protected open val peersTopics = mutableMultiBiMap<PeerHandler, Topic>()
     protected open val subscribedTopics = linkedSetOf<Topic>()
     protected open val pendingRpcParts = PendingRpcPartsMap<RpcPartsQueue> { DefaultRpcPartsQueue() }
     protected open val pendingMessagePromises = MultiSet<PeerHandler, CompletableFuture<Unit>>()
+    private val outboundSendStates = mutableMapOf<PeerHandler, OutboundSendState>()
+    private val stalledOutboundPeers = mutableMapOf<PeerHandler, Throwable>()
+
+    private class OutboundSendState {
+        var activeWrite: CompletableFuture<Unit>? = null
+        var progressDeadline: ScheduledFuture<*>? = null
+        var batchPromises: List<CompletableFuture<Unit>> = emptyList()
+    }
 
     protected class PendingRpcPartsMap<out TPartsQueue : RpcPartsQueue>(
         private val queueFactory: () -> TPartsQueue
@@ -58,6 +71,7 @@ abstract class AbstractRouter(
 
         fun getQueue(peer: PeerHandler) = map.computeIfAbsent(peer) { queueFactory() }
         fun popQueue(peer: PeerHandler) = map.remove(peer) ?: queueFactory()
+        fun popQueueOrNull(peer: PeerHandler) = map.remove(peer)
     }
 
     override fun publish(msg: PubsubMessage): CompletableFuture<Unit> {
@@ -73,6 +87,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun submitPublishMessage(toPeer: PeerHandler, msg: PubsubMessage): CompletableFuture<Unit> {
+        stalledOutboundPeers[toPeer]?.let { return completedExceptionally(it) }
         pendingRpcParts.getQueue(toPeer).addPublish(msg.protobufMessage)
         val sendPromise = CompletableFuture<Unit>()
         pendingMessagePromises[toPeer] += sendPromise
@@ -100,11 +115,18 @@ abstract class AbstractRouter(
     }
 
     protected fun flushPending(peer: PeerHandler) {
-        val peerMessages = pendingRpcParts.popQueue(peer).takeMerged()
-        val allSendPromise = peerMessages.map { send(peer, it) }.thenApplyAll { }
-        pendingMessagePromises.removeAll(peer)?.forEach {
-            allSendPromise.forward(it)
+        if (stalledOutboundPeers.containsKey(peer)) {
+            failQueuedOutbound(peer, stalledOutboundPeers.getValue(peer))
+            return
         }
+        val state = outboundSendStates.getOrPut(peer) { OutboundSendState() }
+        if (state.activeWrite != null) return
+
+        val peerMessages = pendingRpcParts.popQueueOrNull(peer)?.takeMerged() ?: return
+        if (peerMessages.isEmpty()) return
+
+        state.batchPromises = pendingMessagePromises.removeAll(peer) ?: emptyList()
+        sendNext(peer, state, peerMessages, 0)
     }
 
     override fun addPeer(peer: Stream) = addPeerWithDebugHandler(peer, null)
@@ -301,6 +323,8 @@ abstract class AbstractRouter(
     }
 
     override fun onPeerDisconnected(peer: PeerHandler) {
+        cleanupOutbound(peer, io.libp2p.core.ConnectionClosedException(), resetStream = false)
+        stalledOutboundPeers -= peer
         super.onPeerDisconnected(peer)
         peersTopics.removeAllByFirst(peer)
     }
@@ -365,6 +389,78 @@ abstract class AbstractRouter(
 
     protected open fun send(peer: PeerHandler, msg: Rpc.RPC): CompletableFuture<Unit> {
         return peer.writeAndFlush(msg)
+    }
+
+    protected fun enqueueRpc(peer: PeerHandler, msg: Rpc.RPC) {
+        pendingRpcParts.getQueue(peer).addRpc(msg)
+        flushPending(peer)
+    }
+
+    private fun sendNext(
+        peer: PeerHandler,
+        state: OutboundSendState,
+        messages: List<Rpc.RPC>,
+        messageIndex: Int
+    ) {
+        val write = try {
+            send(peer, messages[messageIndex])
+        } catch (cause: Throwable) {
+            completedExceptionally(cause)
+        }
+        state.activeWrite = write
+        state.progressDeadline = scheduleOnEventThread(outboundWriteProgressTimeout, peer) {
+            if (outboundSendStates[peer] === state && state.activeWrite === write) {
+                state.progressDeadline = null
+                cleanupOutbound(
+                    peer,
+                    TimeoutException(
+                        "Outbound pubsub write to ${peer.peerId} made no progress within $outboundWriteProgressTimeout"
+                    ),
+                    resetStream = true
+                )
+            }
+        }
+        write.whenComplete { _, error ->
+            runOnEventThread(peer) {
+                if (outboundSendStates[peer] !== state || state.activeWrite !== write) return@runOnEventThread
+
+                state.progressDeadline?.cancel(false)
+                state.progressDeadline = null
+                state.activeWrite = null
+
+                if (error != null) {
+                    cleanupOutbound(peer, error, resetStream = true)
+                } else if (messageIndex + 1 < messages.size) {
+                    sendNext(peer, state, messages, messageIndex + 1)
+                } else {
+                    state.batchPromises.forEach { it.complete(Unit) }
+                    state.batchPromises = emptyList()
+                    flushPending(peer)
+                }
+            }
+        }
+    }
+
+    private fun cleanupOutbound(peer: PeerHandler, cause: Throwable, resetStream: Boolean) {
+        outboundSendStates.remove(peer)?.let { state ->
+            state.progressDeadline?.cancel(false)
+            state.progressDeadline = null
+            state.activeWrite?.completeExceptionally(cause)
+            state.activeWrite = null
+            state.batchPromises.forEach { it.completeExceptionally(cause) }
+            state.batchPromises = emptyList()
+        }
+        failQueuedOutbound(peer, cause)
+
+        if (resetStream) {
+            stalledOutboundPeers[peer] = cause
+            peer.getOutboundHandler()?.stream?.reset()
+        }
+    }
+
+    private fun failQueuedOutbound(peer: PeerHandler, cause: Throwable) {
+        pendingRpcParts.popQueue(peer)
+        pendingMessagePromises.removeAll(peer)?.forEach { it.completeExceptionally(cause) }
     }
 
     override fun initHandler(handler: (PubsubMessage) -> CompletableFuture<ValidationResult>) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/Errors.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/Errors.kt
@@ -21,3 +21,8 @@ class InvalidMessageException(message: String) : PubsubException(message)
  * Thrown when no suitable peers found to broadcast outbound exception
  */
 class NoPeersForOutboundMessageException(message: String) : PubsubException(message)
+
+/**
+ * Thrown when a peer's retained outbound pubsub work exceeds its configured limits.
+ */
+class OutboundQueueOverflowException(message: String) : PubsubException(message)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
@@ -3,7 +3,7 @@ package io.libp2p.pubsub
 import pubsub.pb.Rpc
 
 private const val MIB = 1024L * 1024L
-const val DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER = 1024
+const val DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER = 10_000
 
 data class PubsubOutboundLimits(
     val maxRetainedBytesPerPeer: Long,

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
@@ -46,35 +46,35 @@ data class OutboundResourceUsage internal constructor(
 
     companion object {
         val ZERO = OutboundResourceUsage()
-    }
-}
 
-internal fun OutboundResourceUsage.Companion.fromRpc(
-    rpc: Rpc.RPC,
-    promiseEntries: Long = 0
-): OutboundResourceUsage {
-    val controlEntries = if (rpc.hasControl()) {
-        val control = rpc.control
-        control.ihaveCount.toLong() +
-            control.ihaveList.sumOf { it.messageIDsCount.toLong() } +
-            control.iwantCount.toLong() +
-            control.iwantList.sumOf { it.messageIDsCount.toLong() } +
-            control.graftCount.toLong() +
-            control.pruneCount.toLong() +
-            control.pruneList.sumOf { it.peersCount.toLong() } +
-            control.idontwantCount.toLong() +
-            control.idontwantList.sumOf { it.messageIDsCount.toLong() } +
-            (if (control.hasExtensions()) 1L else 0L)
-    } else {
-        0L
+        internal fun fromRpc(
+            rpc: Rpc.RPC,
+            promiseEntries: Long = 0
+        ): OutboundResourceUsage {
+            val controlEntries = if (rpc.hasControl()) {
+                val control = rpc.control
+                control.ihaveCount.toLong() +
+                    control.ihaveList.sumOf { it.messageIDsCount.toLong() } +
+                    control.iwantCount.toLong() +
+                    control.iwantList.sumOf { it.messageIDsCount.toLong() } +
+                    control.graftCount.toLong() +
+                    control.pruneCount.toLong() +
+                    control.pruneList.sumOf { it.peersCount.toLong() } +
+                    control.idontwantCount.toLong() +
+                    control.idontwantList.sumOf { it.messageIDsCount.toLong() } +
+                    (if (control.hasExtensions()) 1L else 0L)
+            } else {
+                0L
+            }
+            val logicalEntries =
+                1L +
+                    rpc.subscriptionsCount.toLong() +
+                    rpc.publishList.sumOf { 1L + it.topicIDsCount.toLong() } +
+                    controlEntries +
+                    promiseEntries +
+                    (if (rpc.hasPartial()) 1L else 0L) +
+                    (if (rpc.hasTestExtension()) 1L else 0L)
+            return OutboundResourceUsage(rpc.serializedSize.toLong(), logicalEntries)
+        }
     }
-    val logicalEntries =
-        1L +
-            rpc.subscriptionsCount.toLong() +
-            rpc.publishList.sumOf { 1L + it.topicIDsCount.toLong() } +
-            controlEntries +
-            promiseEntries +
-            (if (rpc.hasPartial()) 1L else 0L) +
-            (if (rpc.hasTestExtension()) 1L else 0L)
-    return OutboundResourceUsage(rpc.serializedSize.toLong(), logicalEntries)
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
@@ -1,5 +1,7 @@
 package io.libp2p.pubsub
 
+import pubsub.pb.Rpc
+
 private const val MIB = 1024L * 1024L
 const val DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER = 1024
 
@@ -45,4 +47,34 @@ data class OutboundResourceUsage internal constructor(
     companion object {
         val ZERO = OutboundResourceUsage()
     }
+}
+
+internal fun OutboundResourceUsage.Companion.fromRpc(
+    rpc: Rpc.RPC,
+    promiseEntries: Long = 0
+): OutboundResourceUsage {
+    val controlEntries = if (rpc.hasControl()) {
+        val control = rpc.control
+        control.ihaveCount.toLong() +
+            control.ihaveList.sumOf { it.messageIDsCount.toLong() } +
+            control.iwantCount.toLong() +
+            control.iwantList.sumOf { it.messageIDsCount.toLong() } +
+            control.graftCount.toLong() +
+            control.pruneCount.toLong() +
+            control.pruneList.sumOf { it.peersCount.toLong() } +
+            control.idontwantCount.toLong() +
+            control.idontwantList.sumOf { it.messageIDsCount.toLong() } +
+            (if (control.hasExtensions()) 1L else 0L)
+    } else {
+        0L
+    }
+    val logicalEntries =
+        1L +
+            rpc.subscriptionsCount.toLong() +
+            rpc.publishList.sumOf { 1L + it.topicIDsCount.toLong() } +
+            controlEntries +
+            promiseEntries +
+            (if (rpc.hasPartial()) 1L else 0L) +
+            (if (rpc.hasTestExtension()) 1L else 0L)
+    return OutboundResourceUsage(rpc.serializedSize.toLong(), logicalEntries)
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubOutboundLimits.kt
@@ -1,0 +1,48 @@
+package io.libp2p.pubsub
+
+private const val MIB = 1024L * 1024L
+const val DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER = 1024
+
+data class PubsubOutboundLimits(
+    val maxRetainedBytesPerPeer: Long,
+    val maxRetainedEntriesPerPeer: Int
+) {
+    fun validate(maxMessageSize: Int): PubsubOutboundLimits = apply {
+        require(maxRetainedBytesPerPeer >= maxMessageSize.toLong()) {
+            "maxOutboundRetainedBytesPerPeer ($maxRetainedBytesPerPeer) must be >= maxGossipMessageSize ($maxMessageSize)"
+        }
+        require(maxRetainedEntriesPerPeer >= 1) {
+            "maxOutboundRetainedEntriesPerPeer must be >= 1: $maxRetainedEntriesPerPeer"
+        }
+    }
+
+    companion object {
+        fun defaults(maxMessageSize: Int): PubsubOutboundLimits =
+            PubsubOutboundLimits(
+                maxOf(8L * MIB, maxMessageSize.toLong() + 4L * MIB),
+                DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER
+            )
+
+        val UNBOUNDED = PubsubOutboundLimits(Long.MAX_VALUE, Int.MAX_VALUE)
+    }
+}
+
+data class OutboundResourceUsage internal constructor(
+    val bytes: Long = 0,
+    val entries: Long = 0
+) {
+    fun plusOrNull(other: OutboundResourceUsage): OutboundResourceUsage? {
+        if (other.bytes < 0 || other.entries < 0) return null
+        if (Long.MAX_VALUE - bytes < other.bytes) return null
+        if (Long.MAX_VALUE - entries < other.entries) return null
+        return OutboundResourceUsage(bytes + other.bytes, entries + other.entries)
+    }
+
+    fun fits(limits: PubsubOutboundLimits): Boolean =
+        bytes <= limits.maxRetainedBytesPerPeer &&
+            entries <= limits.maxRetainedEntriesPerPeer.toLong()
+
+    companion object {
+        val ZERO = OutboundResourceUsage()
+    }
+}

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -27,10 +27,18 @@ interface RpcPartsQueue {
  *
  * NOT thread safe
  */
-open class DefaultRpcPartsQueue : RpcPartsQueue {
+open class DefaultRpcPartsQueue(
+    private val maxMessageSize: Int = Int.MAX_VALUE
+) : RpcPartsQueue {
 
     protected interface AbstractPart {
         fun appendToBuilder(builder: Rpc.RPC.Builder)
+
+        fun standaloneRpcSize(): Int =
+            Rpc.RPC.newBuilder()
+                .also(::appendToBuilder)
+                .build()
+                .serializedSize
     }
 
     protected data class PublishPart(val message: Rpc.Message) : AbstractPart {
@@ -43,6 +51,8 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
             builder.mergeFrom(rpc)
         }
+
+        override fun standaloneRpcSize(): Int = rpc.serializedSize
     }
 
     protected data class SubscriptionPart(val topic: Topic, val status: RpcPartsQueue.SubscriptionStatus) : AbstractPart {
@@ -60,6 +70,13 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         parts += part
     }
 
+    protected fun requirePartFits(part: AbstractPart): Int =
+        part.standaloneRpcSize().also { size ->
+            require(size <= maxMessageSize) {
+                "Outbound RPC part size $size exceeds maxGossipMessageSize $maxMessageSize"
+            }
+        }
+
     override fun addPublish(message: Rpc.Message) {
         addPart(PublishPart(message))
     }
@@ -75,22 +92,34 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
     override fun takeMerged(): List<Rpc.RPC> {
         val messages = mutableListOf<Rpc.RPC>()
         var builder = Rpc.RPC.newBuilder()
+        var estimatedSize = 0
         var hasMergedParts = false
+
+        fun flushBuilder() {
+            messages += builder.build()
+            builder = Rpc.RPC.newBuilder()
+            estimatedSize = 0
+            hasMergedParts = false
+        }
+
         parts.forEach { part ->
+            val partSize = requirePartFits(part)
             if (part is RpcPart) {
-                if (hasMergedParts) {
-                    messages += builder.build()
-                    builder = Rpc.RPC.newBuilder()
-                    hasMergedParts = false
-                }
+                if (hasMergedParts) flushBuilder()
                 messages += part.rpc
             } else {
+                if (hasMergedParts && estimatedSize > maxMessageSize - partSize) {
+                    flushBuilder()
+                }
                 part.appendToBuilder(builder)
+                estimatedSize += partSize
                 hasMergedParts = true
             }
         }
         parts.clear()
-        if (hasMergedParts || messages.isEmpty()) {
+        if (hasMergedParts) {
+            flushBuilder()
+        } else if (messages.isEmpty()) {
             messages += builder.build()
         }
         return messages

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -7,6 +7,7 @@ interface RpcPartsQueue {
     enum class SubscriptionStatus { Subscribed, Unsubscribed }
 
     fun addPublish(message: Rpc.Message)
+    fun addRpc(rpc: Rpc.RPC)
 
     fun addSubscribe(topic: Topic) {
         addSubscription(topic, SubscriptionStatus.Subscribed)
@@ -38,6 +39,12 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         }
     }
 
+    protected data class RpcPart(val rpc: Rpc.RPC) : AbstractPart {
+        override fun appendToBuilder(builder: Rpc.RPC.Builder) {
+            builder.mergeFrom(rpc)
+        }
+    }
+
     protected data class SubscriptionPart(val topic: Topic, val status: RpcPartsQueue.SubscriptionStatus) : AbstractPart {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
             builder.addSubscriptionsBuilder().apply {
@@ -57,16 +64,35 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         addPart(PublishPart(message))
     }
 
+    override fun addRpc(rpc: Rpc.RPC) {
+        addPart(RpcPart(rpc))
+    }
+
     override fun addSubscription(topic: Topic, status: RpcPartsQueue.SubscriptionStatus) {
         addPart(SubscriptionPart(topic, status))
     }
 
     override fun takeMerged(): List<Rpc.RPC> {
-        val builder = Rpc.RPC.newBuilder()
-        parts.forEach {
-            it.appendToBuilder(builder)
+        val messages = mutableListOf<Rpc.RPC>()
+        var builder = Rpc.RPC.newBuilder()
+        var hasMergedParts = false
+        parts.forEach { part ->
+            if (part is RpcPart) {
+                if (hasMergedParts) {
+                    messages += builder.build()
+                    builder = Rpc.RPC.newBuilder()
+                    hasMergedParts = false
+                }
+                messages += part.rpc
+            } else {
+                part.appendToBuilder(builder)
+                hasMergedParts = true
+            }
         }
         parts.clear()
-        return listOf(builder.build())
+        if (hasMergedParts || messages.isEmpty()) {
+            messages += builder.build()
+        }
+        return messages
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -175,6 +175,7 @@ open class GossipRouter(
         eventBroadcaster.notifyConnected(peer.peerId, peer.getRemoteAddress())
         heartbeatTask.hashCode() // force lazy initialization
         sendControlExtensions(peer)
+        flushPending(peer)
     }
 
     override fun notifyUnseenMessage(peer: PeerHandler, msg: PubsubMessage) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -162,7 +162,6 @@ open class GossipRouter(
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
-        pendingRpcParts.popQueue(peer) // discard them
         gossipExtensionsState.onPeerDisconnected(peer.peerId)
         super.onPeerDisconnected(peer)
     }
@@ -797,27 +796,82 @@ open class GossipRouter(
             .forEach { sendIdontwant(it, msg.messageId) }
     }
 
+    private fun enqueueGossipPart(
+        peer: PeerHandler,
+        standaloneRpc: Rpc.RPC,
+        addPart: (GossipRpcPartsQueue) -> Unit
+    ) {
+        enqueueOutbound(
+            peer,
+            pendingRpcParts,
+            OutboundResourceUsage.fromRpc(standaloneRpc),
+            addPart = addPart
+        )
+    }
+
     private fun enqueuePrune(peer: PeerHandler, topic: Topic) {
-        val peerQueue = pendingRpcParts.getQueue(peer)
-        if (peer.getPeerProtocol().supportsBackoffAndPX() && this.protocol.supportsBackoffAndPX()) {
-            val backoffPeers = (getTopicPeers(topic) - peer)
+        val supportsBackoff =
+            peer.getPeerProtocol().supportsBackoffAndPX() &&
+                protocol.supportsBackoffAndPX()
+        val backoffPeers = if (supportsBackoff) {
+            (getTopicPeers(topic) - peer)
                 .take(params.maxPeersSentInPruneMsg)
                 .filter { score.score(it.peerId) >= 0 }
                 .map { it.peerId }
-            peerQueue.addPrune(topic, params.pruneBackoff.seconds, backoffPeers)
         } else {
-            peerQueue.addPrune(topic)
+            emptyList()
+        }
+        val prune = Rpc.ControlPrune.newBuilder().setTopicID(topic).apply {
+            if (supportsBackoff) {
+                setBackoff(params.pruneBackoff.seconds)
+                addAllPeers(
+                    backoffPeers.map {
+                        Rpc.PeerInfo.newBuilder()
+                            .setPeerID(it.bytes.toProtobuf())
+                            .build()
+                    }
+                )
+            }
+        }.build()
+        val rpc = Rpc.RPC.newBuilder()
+            .setControl(Rpc.ControlMessage.newBuilder().addPrune(prune))
+            .build()
+        enqueueGossipPart(peer, rpc) { queue ->
+            if (supportsBackoff) {
+                queue.addPrune(topic, params.pruneBackoff.seconds, backoffPeers)
+            } else {
+                queue.addPrune(topic)
+            }
         }
     }
 
-    private fun enqueueGraft(peer: PeerHandler, topic: Topic) =
-        pendingRpcParts.getQueue(peer).addGraft(topic)
+    private fun enqueueGraft(peer: PeerHandler, topic: Topic) {
+        val rpc = Rpc.RPC.newBuilder().apply {
+            controlBuilder.addGraftBuilder().setTopicID(topic)
+        }.build()
+        enqueueGossipPart(peer, rpc) { it.addGraft(topic) }
+    }
 
-    private fun enqueueIwant(peer: PeerHandler, messageIds: List<MessageId>) =
-        pendingRpcParts.getQueue(peer).addIWants(messageIds)
+    private fun enqueueIwant(peer: PeerHandler, messageIds: List<MessageId>) {
+        val rpc = Rpc.RPC.newBuilder().apply {
+            controlBuilder.addIwantBuilder()
+                .addAllMessageIDs(messageIds.map { it.toProtobuf() })
+        }.build()
+        enqueueGossipPart(peer, rpc) { it.addIWants(messageIds) }
+    }
 
-    private fun enqueueIhave(peer: PeerHandler, messageIds: List<MessageId>, topic: Topic) =
-        pendingRpcParts.getQueue(peer).addIHaves(messageIds, topic)
+    private fun enqueueIhave(
+        peer: PeerHandler,
+        messageIds: List<MessageId>,
+        topic: Topic
+    ) {
+        val rpc = Rpc.RPC.newBuilder().apply {
+            controlBuilder.addIhaveBuilder()
+                .setTopicID(topic)
+                .addAllMessageIDs(messageIds.map { it.toProtobuf() })
+        }.build()
+        enqueueGossipPart(peer, rpc) { it.addIHaves(messageIds, topic) }
+    }
 
     private fun sendIdontwant(peer: PeerHandler, messageId: MessageId) {
         if (!peer.getPeerProtocol().supportsIDontWant()) {
@@ -850,9 +904,18 @@ open class GossipRouter(
 
         logger.trace("Sending control extensions message to peer {}", peer.peerId)
 
-        pendingRpcParts.getQueue(peer)
-            .addControlExtensions(gossipExtensionsState.localExtensionSupport)
-        gossipExtensionsState.registerControlExtensionMessageSentToPeers(peer.peerId)
+        val extensions = gossipExtensionsState.localExtensionSupport
+        val rpc = Rpc.RPC.newBuilder().apply {
+            controlBuilder.setExtensions(extensions)
+        }.build()
+        val cause = enqueueOutbound(
+            peer,
+            pendingRpcParts,
+            OutboundResourceUsage.fromRpc(rpc)
+        ) { it.addControlExtensions(extensions) }
+        if (cause == null) {
+            gossipExtensionsState.registerControlExtensionMessageSentToPeers(peer.peerId)
+        }
     }
 
     data class AcceptRequestsWhitelistEntry(val whitelistedTill: Long, val messagesAccepted: Int = 0) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -14,7 +14,6 @@ import java.time.Duration
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.collections.Collection
 import kotlin.collections.List
@@ -101,6 +100,10 @@ open class GossipRouter(
     messageValidator
 ) {
 
+    internal fun configureOutboundWriteProgressTimeout(timeout: Duration) {
+        outboundWriteProgressTimeout = timeout
+    }
+
     // The idea behind choosing these specific default values for acceptRequestsWhitelist was
     // - from one side are pretty small and safe: peer unlikely be able to drop its score to `graylist`
     //   with 128 messages. But even if so then it's not critical to accept some extra messages before
@@ -124,11 +127,10 @@ open class GossipRouter(
     private val iWantRequests = createLRUMap<Pair<PeerHandler, MessageId>, Long>(MaxIWantRequestsEntries)
     private val peerIDontWant = createLRUMap<PeerHandler, IDontWantCacheEntry>(MaxPeerIDontWantEntries)
     private val heartbeatTask by lazy {
-        executor.scheduleWithFixedDelay(
-            ::catchingHeartbeat,
-            heartbeatInitialDelay.toMillis(),
-            params.heartbeatInterval.toMillis(),
-            TimeUnit.MILLISECONDS
+        scheduleWithFixedDelayOnEventThread(
+            heartbeatInitialDelay,
+            params.heartbeatInterval,
+            run = ::heartbeat
         )
     }
     private val acceptRequestsWhitelist = mutableMapOf<PeerHandler, AcceptRequestsWhitelistEntry>()
@@ -487,7 +489,7 @@ open class GossipRouter(
         val response =
             Rpc.RPC.newBuilder().setTestExtension(Rpc.TestExtension.newBuilder().build()).build()
 
-        send(receivedFrom, response)
+        enqueueRpc(receivedFrom, response)
     }
 
     private fun processPartialMessageExtension(
@@ -637,14 +639,6 @@ open class GossipRouter(
         super.unsubscribe(topic)
         mesh[topic]?.copy()?.forEach { prune(it, topic) }
         mesh -= topic
-    }
-
-    private fun catchingHeartbeat() {
-        try {
-            heartbeat()
-        } catch (e: Exception) {
-            onServiceException(null, null, e)
-        }
     }
 
     private fun heartbeat() {
@@ -828,7 +822,7 @@ open class GossipRouter(
                     .addMessageIDs(messageId.toProtobuf())
             )
         ).build()
-        send(peer, iDontWant)
+        enqueueRpc(peer, iDontWant)
     }
 
     private fun sendControlExtensions(peer: PeerHandler) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -100,6 +100,10 @@ open class GossipRouter(
     messageValidator
 ) {
 
+    init {
+        configureOutboundLimits(PubsubOutboundLimits.defaults(params.maxGossipMessageSize))
+    }
+
     internal fun configureOutboundWriteProgressTimeout(timeout: Duration) {
         outboundWriteProgressTimeout = timeout
     }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -38,7 +38,7 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
  */
 open class DefaultGossipRpcPartsQueue(
     private val params: GossipParams
-) : DefaultRpcPartsQueue(), GossipRpcPartsQueue {
+) : DefaultRpcPartsQueue(params.maxGossipMessageSize), GossipRpcPartsQueue {
 
     protected data class IHavePart(val messageId: MessageId, val topic: Topic) : AbstractPart {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
@@ -120,6 +120,7 @@ open class DefaultGossipRpcPartsQueue(
         while (partIdx < parts.size) {
             val firstPart = parts[partIdx]
             if (firstPart is RpcPart) {
+                requirePartFits(firstPart)
                 ret += firstPart.rpc
                 partIdx++
                 continue
@@ -133,12 +134,20 @@ open class DefaultGossipRpcPartsQueue(
             var iWantCount = params.maxIWantMessageIds ?: Int.MAX_VALUE
             var graftCount = params.maxGraftMessages ?: Int.MAX_VALUE
             var pruneCount = params.maxPruneMessages ?: Int.MAX_VALUE
+            var estimatedSize = 0
+            var appendedParts = 0
 
             while (partIdx < parts.size && parts[partIdx] !is RpcPart &&
                 publishCount > 0 && subscriptionCount > 0 && iHaveCount > 0 &&
                 iWantCount > 0 && graftCount > 0 && pruneCount > 0
             ) {
+                val partSize = requirePartFits(parts[partIdx])
+                val fitsBytes = estimatedSize <= params.maxGossipMessageSize - partSize
+                if (!fitsBytes && appendedParts > 0) break
+
                 val part = parts[partIdx++]
+                estimatedSize += partSize
+                appendedParts++
                 when (part) {
                     is PublishPart -> publishCount--
                     is SubscriptionPart -> subscriptionCount--

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -118,6 +118,13 @@ open class DefaultGossipRpcPartsQueue(
         val ret = mutableListOf<Rpc.RPC>()
         var partIdx = 0
         while (partIdx < parts.size) {
+            val firstPart = parts[partIdx]
+            if (firstPart is RpcPart) {
+                ret += firstPart.rpc
+                partIdx++
+                continue
+            }
+
             val builder = Rpc.RPC.newBuilder()
 
             var publishCount = params.maxPublishedMessages ?: Int.MAX_VALUE
@@ -127,7 +134,7 @@ open class DefaultGossipRpcPartsQueue(
             var graftCount = params.maxGraftMessages ?: Int.MAX_VALUE
             var pruneCount = params.maxPruneMessages ?: Int.MAX_VALUE
 
-            while (partIdx < parts.size &&
+            while (partIdx < parts.size && parts[partIdx] !is RpcPart &&
                 publishCount > 0 && subscriptionCount > 0 && iHaveCount > 0 &&
                 iWantCount > 0 && graftCount > 0 && pruneCount > 0
             ) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -44,6 +44,9 @@ open class GossipRouterBuilder(
 ) {
 
     var outboundWriteProgressTimeout: Duration = DEFAULT_OUTBOUND_WRITE_PROGRESS_TIMEOUT
+    var maxOutboundRetainedBytesPerPeer: Long? = null
+    var maxOutboundRetainedEntriesPerPeer: Int =
+        DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER
     var seenCache: SeenCache<Optional<ValidationResult>> by lazyVar { TTLSeenCache(SimpleSeenCache(), params.seenTTL, currentTimeSupplier) }
     var mCache: MCache by lazyVar { MCache(params.gossipSize, params.gossipHistoryLength) }
 
@@ -73,16 +76,25 @@ open class GossipRouterBuilder(
             messageValidator = messageValidator,
             gossipExtensionsConfig = buildGossipExtensionsConfig(),
         )
-        router.configureOutboundWriteProgressTimeout(outboundWriteProgressTimeout)
-
-        router.eventBroadcaster.listeners += gossipRouterEventListeners
         return router
     }
 
     open fun build(): GossipRouter {
         if (disposed) throw RuntimeException("The builder was already used")
         disposed = true
-        return createGossipRouter()
+        return createGossipRouter().also { router ->
+            router.configureOutboundWriteProgressTimeout(outboundWriteProgressTimeout)
+            router.configureOutboundLimits(resolveOutboundLimits())
+            router.eventBroadcaster.listeners += gossipRouterEventListeners
+        }
+    }
+
+    private fun resolveOutboundLimits(): PubsubOutboundLimits {
+        val defaults = PubsubOutboundLimits.defaults(params.maxGossipMessageSize)
+        return PubsubOutboundLimits(
+            maxOutboundRetainedBytesPerPeer ?: defaults.maxRetainedBytesPerPeer,
+            maxOutboundRetainedEntriesPerPeer
+        ).validate(params.maxGossipMessageSize)
     }
 
     private fun buildGossipExtensionsConfig(): GossipExtensionsConfig {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -5,6 +5,7 @@ import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.lazyVar
 import io.libp2p.pubsub.*
 import io.libp2p.pubsub.gossip.*
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -42,6 +43,7 @@ open class GossipRouterBuilder(
     val enabledGossipExtensions: List<GossipExtension> = mutableListOf(),
 ) {
 
+    var outboundWriteProgressTimeout: Duration = DEFAULT_OUTBOUND_WRITE_PROGRESS_TIMEOUT
     var seenCache: SeenCache<Optional<ValidationResult>> by lazyVar { TTLSeenCache(SimpleSeenCache(), params.seenTTL, currentTimeSupplier) }
     var mCache: MCache by lazyVar { MCache(params.gossipSize, params.gossipHistoryLength) }
 
@@ -71,6 +73,7 @@ open class GossipRouterBuilder(
             messageValidator = messageValidator,
             gossipExtensionsConfig = buildGossipExtensionsConfig(),
         )
+        router.configureOutboundWriteProgressTimeout(outboundWriteProgressTimeout)
 
         router.eventBroadcaster.listeners += gossipRouterEventListeners
         return router

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipRouterBuilder.kt
@@ -82,9 +82,10 @@ open class GossipRouterBuilder(
     open fun build(): GossipRouter {
         if (disposed) throw RuntimeException("The builder was already used")
         disposed = true
+        val outboundLimits = resolveOutboundLimits()
         return createGossipRouter().also { router ->
             router.configureOutboundWriteProgressTimeout(outboundWriteProgressTimeout)
-            router.configureOutboundLimits(resolveOutboundLimits())
+            router.configureOutboundLimits(outboundLimits)
             router.eventBroadcaster.listeners += gossipRouterEventListeners
         }
     }

--- a/libp2p/src/test/kotlin/io/libp2p/etc/util/P2PServiceWritabilityTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/etc/util/P2PServiceWritabilityTest.kt
@@ -1,0 +1,90 @@
+package io.libp2p.etc.util
+
+import io.libp2p.core.PeerId
+import io.libp2p.core.Stream
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.netty.channel.Channel
+import io.netty.channel.ChannelHandlerContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class P2PServiceWritabilityTest {
+    private val executor = Executors.newSingleThreadScheduledExecutor()
+
+    @AfterEach
+    fun tearDown() {
+        executor.shutdownNow()
+    }
+
+    @Test
+    fun `peer writability follows outbound channel`() {
+        val service = TestService()
+        val channel = mockk<Channel>()
+        val ctx = mockk<ChannelHandlerContext>()
+        val handler = service.newHandler(ctx)
+        val peer = service.newPeer(handler)
+
+        every { ctx.channel() } returns channel
+        every { channel.isWritable } returnsMany listOf(false, true)
+
+        assertThat(peer.isWritable()).isFalse()
+        assertThat(peer.isWritable()).isTrue()
+    }
+
+    @Test
+    fun `writability event is forwarded and scheduled on service thread`() {
+        val service = TestService()
+        val ctx = mockk<ChannelHandlerContext>(relaxed = true)
+        val handler = service.newHandler(ctx)
+        service.newPeer(handler)
+
+        handler.channelWritabilityChanged(ctx)
+
+        assertThat(service.writabilityCallback.await(1, TimeUnit.SECONDS)).isTrue()
+        verify(exactly = 1) { ctx.fireChannelWritabilityChanged() }
+        assertThat(service.callbackThread).startsWith("pool-")
+    }
+
+    @Test
+    fun `writability before peer association is only forwarded`() {
+        val service = TestService()
+        val ctx = mockk<ChannelHandlerContext>(relaxed = true)
+        val handler = service.newHandler(ctx)
+
+        handler.channelWritabilityChanged(ctx)
+
+        verify(exactly = 1) { ctx.fireChannelWritabilityChanged() }
+        assertThat(service.writabilityCallback.count).isEqualTo(1)
+    }
+
+    private inner class TestService : P2PService(executor) {
+        val writabilityCallback = CountDownLatch(1)
+        var callbackThread = ""
+
+        fun newHandler(ctx: ChannelHandlerContext): StreamHandler =
+            StreamHandler(
+                mockk<Stream> {
+                    every { remotePeerId() } returns PeerId(ByteArray(32))
+                }
+            ).also { it.ctx = ctx }
+
+        fun newPeer(handler: StreamHandler): PeerHandler =
+            PeerHandler(handler).also(handler::initPeerHandler)
+
+        override fun streamWritabilityChanged(stream: StreamHandler) {
+            callbackThread = Thread.currentThread().name
+            writabilityCallback.countDown()
+        }
+
+        override fun initChannel(streamHandler: StreamHandler) {}
+        override fun onPeerActive(peer: PeerHandler) {}
+        override fun onPeerDisconnected(peer: PeerHandler) {}
+        override fun onInbound(peer: PeerHandler, msg: Any) {}
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubOutboundLimitsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubOutboundLimitsTest.kt
@@ -1,0 +1,39 @@
+package io.libp2p.pubsub
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PubsubOutboundLimitsTest {
+    @Test
+    fun `usage adds nonnegative resources`() {
+        assertThat(OutboundResourceUsage.ZERO.plusOrNull(OutboundResourceUsage(7, 3)))
+            .isEqualTo(OutboundResourceUsage(7, 3))
+    }
+
+    @Test
+    fun `usage rejects negative additions`() {
+        assertThat(OutboundResourceUsage.ZERO.plusOrNull(OutboundResourceUsage(-1, 0))).isNull()
+        assertThat(OutboundResourceUsage.ZERO.plusOrNull(OutboundResourceUsage(0, -1))).isNull()
+    }
+
+    @Test
+    fun `usage rejects arithmetic overflow`() {
+        assertThat(
+            OutboundResourceUsage(Long.MAX_VALUE, 0)
+                .plusOrNull(OutboundResourceUsage(1, 0))
+        ).isNull()
+        assertThat(
+            OutboundResourceUsage(0, Long.MAX_VALUE)
+                .plusOrNull(OutboundResourceUsage(0, 1))
+        ).isNull()
+    }
+
+    @Test
+    fun `usage fits inclusive limits`() {
+        val limits = PubsubOutboundLimits(10, 2)
+
+        assertThat(OutboundResourceUsage(10, 2).fits(limits)).isTrue()
+        assertThat(OutboundResourceUsage(11, 2).fits(limits)).isFalse()
+        assertThat(OutboundResourceUsage(10, 3).fits(limits)).isFalse()
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -1,0 +1,256 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.PeerId
+import io.libp2p.pubsub.*
+import io.libp2p.pubsub.DeterministicFuzz.Companion.createGossipFuzzRouterFactory
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+import java.time.Duration
+import java.util.Optional
+import java.util.Random
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Deterministic proof of the per-peer write accumulation described in
+ * JVM_LIBP2P_QUIC_GOSSIPSUB_LEAK_FIX_PLAN.md.
+ *
+ * The stalled transport future is intentionally never completed. This test is expected to fail
+ * against the current implementation because every publish starts another write for that peer.
+ */
+class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
+
+    @Test
+    fun `one stalled peer write must not be superseded by another write`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = GossipParams(
+            D = 2,
+            DLow = 2,
+            DHigh = 2,
+            floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH,
+            iDontWantMinMessageSizeThreshold = 0
+        )
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = GossipPeerScoreParams(isDirect = { true })
+        )
+
+        val sender = fuzz.createTestRouter(
+            createGossipFuzzRouterFactory {
+                RecordingGossipRouterBuilder(writePolicy).apply {
+                    this.params = params
+                    this.scoreParams = scoreParams
+                    protocol = PubsubProtocol.Gossip_V_1_2
+                }
+            }
+        )
+        val healthyPeer = createPeer(fuzz, params, scoreParams)
+        val stalledPeer = createPeer(fuzz, params, scoreParams)
+
+        sender.router.subscribe(TOPIC)
+        healthyPeer.router.subscribe(TOPIC)
+        stalledPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(healthyPeer)
+        sender.connectSemiDuplex(stalledPeer)
+
+        // Drain connection setup and subscription exchange before making one peer stall.
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        val peerTopics = senderRouter.getPeerTopics().get(1, TimeUnit.SECONDS)
+        assertThat(peerTopics).hasSize(2)
+        peerTopics.values.forEach { topics -> assertThat(topics).containsExactly(TOPIC) }
+
+        writePolicy.stalledPeerId = stalledPeer.peerId
+        senderRouter.enqueueRpcForTest(
+            stalledPeer.peerId,
+            Rpc.RPC.newBuilder()
+                .setControl(
+                    Rpc.ControlMessage.newBuilder()
+                        .addIdontwant(Rpc.ControlIDontWant.getDefaultInstance())
+                )
+                .build()
+        )
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        val publishFutures = (0 until MESSAGE_COUNT).map { sequence ->
+            val future = sender.router.publish(
+                newMessage(TOPIC, sequence.toLong(), "message-$sequence".toByteArray())
+            )
+            fuzz.timeController.addTime(Duration.ofMillis(1))
+            future
+        }
+
+        // anyComplete() currently lets every public publish future complete through the healthy peer.
+        publishFutures.forEach { it.get(1, TimeUnit.SECONDS) }
+
+        assertThat(writePolicy.unresolvedWriteCount(healthyPeer.peerId)).isZero()
+        val stalledWriteCount = writePolicy.unresolvedWriteCount(stalledPeer.peerId)
+        assertThat(stalledWriteCount)
+            .withFailMessage(
+                "unresolved writes reaching the permanently stalled peer: expected 1, observed $stalledWriteCount"
+            )
+            .isEqualTo(1)
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId).single().control.idontwantCount)
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `stalled peer is reset when its outbound write misses the progress deadline`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = GossipParams(
+            D = 1,
+            DLow = 1,
+            DHigh = 1,
+            floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH
+        )
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = GossipPeerScoreParams(isDirect = { true })
+        )
+        val sender = fuzz.createTestRouter(
+            createGossipFuzzRouterFactory {
+                RecordingGossipRouterBuilder(
+                    writePolicy,
+                    progressTimeout = Duration.ofMillis(10)
+                ).apply {
+                    this.params = params
+                    this.scoreParams = scoreParams
+                    protocol = PubsubProtocol.Gossip_V_1_2
+                }
+            }
+        )
+        val stalledPeer = createPeer(fuzz, params, scoreParams)
+
+        stalledPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(stalledPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        writePolicy.stalledPeerId = stalledPeer.peerId
+        val publication = sender.router.publish(newMessage(TOPIC, 1, "stalled".toByteArray()))
+        fuzz.timeController.addTime(Duration.ofMillis(20))
+
+        assertThat(publication).isCompletedExceptionally
+        assertThat((sender.router as RecordingGossipRouter).peers).isEmpty()
+        assertThat(writePolicy.unresolvedWriteCount(stalledPeer.peerId)).isZero()
+        assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+    }
+
+    private fun createPeer(
+        fuzz: DeterministicFuzz,
+        params: GossipParams,
+        scoreParams: GossipScoreParams
+    ): TestRouter = fuzz.createTestRouter(
+        createGossipFuzzRouterFactory {
+            GossipRouterBuilder(
+                protocol = PubsubProtocol.Gossip_V_1_2,
+                params = params,
+                scoreParams = scoreParams
+            )
+        }
+    )
+
+    private class WritePolicy {
+        var stalledPeerId: PeerId? = null
+        private val unresolvedWrites = mutableMapOf<PeerId, MutableList<CompletableFuture<Unit>>>()
+        private val sentMessages = mutableMapOf<PeerId, MutableList<Rpc.RPC>>()
+
+        fun send(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> {
+            if (peerId != stalledPeerId) return CompletableFuture.completedFuture(Unit)
+
+            sentMessages.getOrPut(peerId) { mutableListOf() } += msg
+            return CompletableFuture<Unit>().also {
+                unresolvedWrites.getOrPut(peerId) { mutableListOf() } += it
+            }
+        }
+
+        fun unresolvedWriteCount(peerId: PeerId): Int = unresolvedWrites[peerId]?.count { !it.isDone } ?: 0
+        fun failedWriteCount(peerId: PeerId): Int =
+            unresolvedWrites[peerId]?.count { it.isCompletedExceptionally } ?: 0
+
+        fun messagesSentTo(peerId: PeerId): List<Rpc.RPC> = sentMessages[peerId] ?: emptyList()
+    }
+
+    private class RecordingGossipRouter(
+        params: GossipParams,
+        scoreParams: GossipScoreParams,
+        currentTimeSupplier: CurrentTimeSupplier,
+        random: Random,
+        name: String,
+        mCache: MCache,
+        score: GossipScore,
+        subscriptionTopicSubscriptionFilter: TopicSubscriptionFilter,
+        protocol: PubsubProtocol,
+        executor: ScheduledExecutorService,
+        messageFactory: PubsubMessageFactory,
+        seenMessages: SeenCache<Optional<io.libp2p.core.pubsub.ValidationResult>>,
+        messageValidator: PubsubRouterMessageValidator,
+        private val writePolicy: WritePolicy
+    ) : GossipRouter(
+        params = params,
+        scoreParams = scoreParams,
+        currentTimeSupplier = currentTimeSupplier,
+        random = random,
+        name = name,
+        mCache = mCache,
+        score = score,
+        gossipExtensionsConfig = GossipExtensionsConfig(),
+        subscriptionTopicSubscriptionFilter = subscriptionTopicSubscriptionFilter,
+        protocol = protocol,
+        executor = executor,
+        messageFactory = messageFactory,
+        seenMessages = seenMessages,
+        messageValidator = messageValidator
+    ) {
+        override fun send(peer: PeerHandler, msg: Rpc.RPC): CompletableFuture<Unit> =
+            writePolicy.send(peer.peerId, msg)
+
+        fun enqueueRpcForTest(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> =
+            submitOnEventThread { enqueueRpc(peers.single { it.peerId == peerId }, msg) }
+    }
+
+    private class RecordingGossipRouterBuilder(
+        private val writePolicy: WritePolicy,
+        progressTimeout: Duration = DEFAULT_OUTBOUND_WRITE_PROGRESS_TIMEOUT
+    ) : GossipRouterBuilder() {
+        init {
+            outboundWriteProgressTimeout = progressTimeout
+        }
+
+        override fun createGossipRouter(): GossipRouter {
+            val gossipScore = scoreFactory(
+                scoreParams,
+                scheduledAsyncExecutor,
+                currentTimeSupplier
+            ) { gossipRouterEventListeners += it }
+
+            return RecordingGossipRouter(
+                params = params,
+                scoreParams = scoreParams,
+                currentTimeSupplier = currentTimeSupplier,
+                random = random,
+                name = name,
+                mCache = mCache,
+                score = gossipScore,
+                subscriptionTopicSubscriptionFilter = subscriptionTopicSubscriptionFilter,
+                protocol = protocol,
+                executor = scheduledAsyncExecutor,
+                messageFactory = messageFactory,
+                seenMessages = seenCache,
+                messageValidator = messageValidator,
+                writePolicy = writePolicy
+            ).also {
+                it.configureOutboundWriteProgressTimeout(outboundWriteProgressTimeout)
+                it.eventBroadcaster.listeners += gossipRouterEventListeners
+            }
+        }
+    }
+
+    private companion object {
+        const val TOPIC = "backpressure-topic"
+        const val MESSAGE_COUNT = 8
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -19,11 +19,86 @@ import java.util.concurrent.TimeUnit
 /**
  * Deterministic proof of the per-peer write accumulation described in
  * JVM_LIBP2P_QUIC_GOSSIPSUB_LEAK_FIX_PLAN.md.
- *
- * The stalled transport future is intentionally never completed. This test is expected to fail
- * against the current implementation because every publish starts another write for that peer.
  */
 class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
+
+    @Test
+    fun `unwritable peer is not materialized or written until transition`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            scoreParams,
+            Duration.ofSeconds(1)
+        )
+        val peer = createPeer(fuzz, params, scoreParams)
+
+        peer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(peer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        writePolicy.setWritable(peer.peerId, false)
+        writePolicy.clearRecordedWrites(peer.peerId)
+        val publications = (1L..3L).map { sequence ->
+            sender.router.publish(
+                newMessage(TOPIC, sequence, "queued-$sequence".toByteArray())
+            )
+        }
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        assertThat(writePolicy.messagesSentTo(peer.peerId)).isEmpty()
+        assertThat(publications).allMatch { !it.isDone }
+
+        writePolicy.setWritable(peer.peerId, true)
+        senderRouter.fireWritabilityChanged(peer.peerId)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        assertThat(writePolicy.messagesSentTo(peer.peerId))
+            .singleElement()
+            .extracting { rpc -> rpc.publishList.map { it.data.toStringUtf8() } }
+            .isEqualTo(listOf("queued-1", "queued-2", "queued-3"))
+        assertThat(publications).allMatch {
+            it.isDone && !it.isCompletedExceptionally
+        }
+    }
+
+    @Test
+    fun `deadline expires while queued work waits for writability`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            scoreParams,
+            Duration.ofMillis(10)
+        )
+        val peer = createPeer(fuzz, params, scoreParams)
+
+        peer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(peer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        writePolicy.setWritable(peer.peerId, false)
+        writePolicy.clearRecordedWrites(peer.peerId)
+        val publication = sender.router.publish(
+            newMessage(TOPIC, 1, "queued".toByteArray())
+        )
+        fuzz.timeController.addTime(Duration.ofMillis(20))
+
+        assertThat(publication).isCompletedExceptionally
+        assertThat(writePolicy.messagesSentTo(peer.peerId)).isEmpty()
+        assertThat(senderRouter.resetCount(peer.peerId)).isEqualTo(1)
+        assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
+    }
 
     @Test
     fun `materialization failure settles active generation and clears state`() {
@@ -500,8 +575,19 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
 
     private class WritePolicy {
         var stalledPeerId: PeerId? = null
+        private val unwritablePeers = mutableSetOf<PeerId>()
         private val unresolvedWrites = mutableMapOf<PeerId, MutableList<CompletableFuture<Unit>>>()
         private val sentMessages = mutableMapOf<PeerId, MutableList<Rpc.RPC>>()
+
+        fun setWritable(peerId: PeerId, writable: Boolean) {
+            if (writable) {
+                unwritablePeers -= peerId
+            } else {
+                unwritablePeers += peerId
+            }
+        }
+
+        fun isWritable(peerId: PeerId): Boolean = peerId !in unwritablePeers
 
         fun record(peerId: PeerId, msg: Rpc.RPC) {
             sentMessages.getOrPut(peerId) { mutableListOf() } += msg
@@ -592,9 +678,17 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
             }
         }
 
+        override fun isOutboundWritable(peer: PeerHandler): Boolean =
+            writePolicy.isWritable(peer.peerId)
+
         override fun resetOutboundStream(peer: PeerHandler) {
             resetCounts[peer.peerId] = resetCount(peer.peerId) + 1
             super.resetOutboundStream(peer)
+        }
+
+        fun fireWritabilityChanged(peerId: PeerId) {
+            val handler = peers.single { it.peerId == peerId }.getOutboundHandler()!!
+            handler.channelWritabilityChanged(handler.ctx!!)
         }
 
         fun enqueueRpcForTest(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> =

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -493,10 +493,7 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
                 seenMessages = seenCache,
                 messageValidator = messageValidator,
                 writePolicy = writePolicy
-            ).also {
-                it.configureOutboundWriteProgressTimeout(outboundWriteProgressTimeout)
-                it.eventBroadcaster.listeners += gossipRouterEventListeners
-            }
+            )
         }
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -79,10 +79,11 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         )
         fuzz.timeController.addTime(Duration.ofMillis(1))
 
-        val publishFutures = (0 until MESSAGE_COUNT).map { sequence ->
-            val future = sender.router.publish(
-                newMessage(TOPIC, sequence.toLong(), "message-$sequence".toByteArray())
-            )
+        val publishedMessages = (0 until MESSAGE_COUNT).map { sequence ->
+            newMessage(TOPIC, sequence.toLong(), "message-$sequence".toByteArray())
+        }
+        val publishFutures = publishedMessages.map { message ->
+            val future = sender.router.publish(message)
             fuzz.timeController.addTime(Duration.ofMillis(1))
             future
         }
@@ -91,6 +92,7 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         publishFutures.forEach { it.get(1, TimeUnit.SECONDS) }
 
         assertThat(writePolicy.unresolvedWriteCount(healthyPeer.peerId)).isZero()
+        assertThat(healthyPeer.inboundMessages).containsExactlyElementsOf(publishedMessages)
         val stalledWriteCount = writePolicy.unresolvedWriteCount(stalledPeer.peerId)
         assertThat(stalledWriteCount)
             .withFailMessage(
@@ -99,6 +101,11 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
             .isEqualTo(1)
         assertThat(writePolicy.messagesSentTo(stalledPeer.peerId).single().control.idontwantCount)
             .isEqualTo(1)
+
+        val reply = newMessage(TOPIC, 100, "healthy-reply".toByteArray())
+        healthyPeer.router.publish(reply)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        assertThat(sender.inboundMessages).containsExactly(reply)
     }
 
     @Test
@@ -142,8 +149,9 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         val senderRouter = sender.router as RecordingGossipRouter
         assertThat(publications).allMatch { it.isCompletedExceptionally }
         assertThat(senderRouter.peers).isEmpty()
-        assertThat(senderRouter.pendingPeerCountForTest().join()).isZero()
+        assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
         assertThat(senderRouter.disconnectCount).isEqualTo(1)
+        assertThat(senderRouter.resetCount(stalledPeer.peerId)).isEqualTo(1)
         assertThat(writePolicy.unresolvedWriteCount(stalledPeer.peerId)).isZero()
         assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
         assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).hasSize(1)
@@ -208,7 +216,9 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         senderRouter.enqueueRpcForTest(stalledPeer.peerId, first)
         fuzz.timeController.addTime(Duration.ofMillis(1))
         senderRouter.enqueueRpcForTest(stalledPeer.peerId, second)
-        val publication = sender.router.publish(newMessage(TOPIC, 1, "queued".toByteArray()))
+        val publications = (1L..3L).map { sequence ->
+            sender.router.publish(newMessage(TOPIC, sequence, "queued-$sequence".toByteArray()))
+        }
         fuzz.timeController.addTime(Duration.ofMillis(1))
 
         assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).containsExactly(first)
@@ -221,12 +231,48 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         assertThat(writePolicy.messagesSentTo(stalledPeer.peerId))
             .hasSize(3)
             .last()
-            .extracting { it.publishList.single().data.toByteArray() }
-            .isEqualTo("queued".toByteArray())
+            .extracting { rpc -> rpc.publishList.map { it.data.toStringUtf8() } }
+            .isEqualTo(listOf("queued-1", "queued-2", "queued-3"))
 
         writePolicy.completeNext(stalledPeer.peerId)
         fuzz.timeController.addTime(Duration.ofMillis(1))
-        assertThat(publication).isCompleted
+        assertThat(publications).allMatch { it.isDone && !it.isCompletedExceptionally }
+    }
+
+    @Test
+    fun `disconnect fails queued writes and prevents any later send`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(fuzz, writePolicy, params, scoreParams, Duration.ofSeconds(1))
+        val stalledPeer = createPeer(fuzz, params, scoreParams)
+
+        stalledPeer.router.subscribe(TOPIC)
+        val connection = sender.connectSemiDuplex(stalledPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        writePolicy.stalledPeerId = stalledPeer.peerId
+        writePolicy.clearRecordedWrites(stalledPeer.peerId)
+        val publications = (0 until 3).map { sequence ->
+            sender.router.publish(newMessage(TOPIC, sequence.toLong(), "disconnect-$sequence".toByteArray()))
+        }
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).hasSize(1)
+
+        connection.disconnect()
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        assertThat(publications).allMatch { it.isCompletedExceptionally }
+        assertThat(senderRouter.peers).isEmpty()
+        assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
+        assertThat(senderRouter.resetCount(stalledPeer.peerId)).isZero()
+        assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+
+        sender.router.publish(newMessage(TOPIC, 10, "after-disconnect".toByteArray()))
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).hasSize(1)
     }
 
     @Test
@@ -237,9 +283,13 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         val scoreParams = directPeerScoreParams()
         val sender = createSender(fuzz, writePolicy, params, scoreParams, Duration.ofMillis(10))
         val senderRouter = sender.router as RecordingGossipRouter
+        val peerKeyPair = createPeer(fuzz, params, scoreParams).keyPair
+        var stalledPeerId: PeerId? = null
 
         repeat(3) { cycle ->
-            val stalledPeer = createPeer(fuzz, params, scoreParams)
+            val stalledPeer = createPeer(fuzz, params, scoreParams).also { it.keyPair = peerKeyPair }
+            stalledPeerId = stalledPeerId ?: stalledPeer.peerId
+            assertThat(stalledPeer.peerId).isEqualTo(stalledPeerId)
             stalledPeer.router.subscribe(TOPIC)
             sender.connectSemiDuplex(stalledPeer)
             fuzz.timeController.addTime(Duration.ofSeconds(2))
@@ -251,8 +301,9 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
 
             assertThat(publication).isCompletedExceptionally
             assertThat(senderRouter.peers).isEmpty()
-            assertThat(senderRouter.pendingPeerCountForTest().join()).isZero()
+            assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
             assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+            assertThat(senderRouter.resetCount(stalledPeer.peerId)).isEqualTo(cycle + 1)
         }
     }
 
@@ -309,13 +360,16 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         private val unresolvedWrites = mutableMapOf<PeerId, MutableList<CompletableFuture<Unit>>>()
         private val sentMessages = mutableMapOf<PeerId, MutableList<Rpc.RPC>>()
 
-        fun send(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> {
+        fun record(peerId: PeerId, msg: Rpc.RPC) {
             sentMessages.getOrPut(peerId) { mutableListOf() } += msg
-            if (peerId != stalledPeerId) return CompletableFuture.completedFuture(Unit)
-            return CompletableFuture<Unit>().also {
+        }
+
+        fun shouldStall(peerId: PeerId): Boolean = peerId == stalledPeerId
+
+        fun newStalledWrite(peerId: PeerId): CompletableFuture<Unit> =
+            CompletableFuture<Unit>().also {
                 unresolvedWrites.getOrPut(peerId) { mutableListOf() } += it
             }
-        }
 
         fun unresolvedWriteCount(peerId: PeerId): Int = unresolvedWrites[peerId]?.count { !it.isDone } ?: 0
         fun failedWriteCount(peerId: PeerId): Int =
@@ -367,6 +421,7 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
     ) {
         var disconnectCount = 0
             private set
+        private val resetCounts = mutableMapOf<PeerId, Int>()
 
         init {
             eventBroadcaster.listeners += object : GossipRouterEventListener {
@@ -385,14 +440,27 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
             }
         }
 
-        override fun send(peer: PeerHandler, msg: Rpc.RPC): CompletableFuture<Unit> =
-            writePolicy.send(peer.peerId, msg)
+        override fun send(peer: PeerHandler, msg: Rpc.RPC): CompletableFuture<Unit> {
+            writePolicy.record(peer.peerId, msg)
+            return if (writePolicy.shouldStall(peer.peerId)) {
+                writePolicy.newStalledWrite(peer.peerId)
+            } else {
+                super.send(peer, msg)
+            }
+        }
+
+        override fun resetOutboundStream(peer: PeerHandler) {
+            resetCounts[peer.peerId] = resetCount(peer.peerId) + 1
+            super.resetOutboundStream(peer)
+        }
 
         fun enqueueRpcForTest(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> =
             submitOnEventThread { enqueueRpc(peers.single { it.peerId == peerId }, msg) }
 
-        fun pendingPeerCountForTest(): CompletableFuture<Int> =
-            submitOnEventThread { pendingRpcParts.pendingPeers.size }
+        fun hasNoOutboundStateForTest(): CompletableFuture<Boolean> =
+            submitOnEventThread { !hasOutboundState() }
+
+        fun resetCount(peerId: PeerId): Int = resetCounts[peerId] ?: 0
     }
 
     private class RecordingGossipRouterBuilder(

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -26,6 +26,35 @@ import java.util.concurrent.TimeUnit
 class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
 
     @Test
+    fun `materialization failure settles active generation and clears state`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams().copy(maxGossipMessageSize = 1024)
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            directPeerScoreParams(),
+            Duration.ofSeconds(10)
+        )
+        val peer = createPeer(fuzz, params, directPeerScoreParams())
+
+        peer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(peer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val oversizedMessage = newProtoMessage(TOPIC, 1, ByteArray(2048))
+        val senderRouter = sender.router as RecordingGossipRouter
+        val publication = senderRouter.enqueueOversizedPublishForTest(
+            peer.peerId,
+            oversizedMessage
+        )
+
+        assertThat(publication).isCompletedExceptionally
+        assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
+    }
+
+    @Test
     fun `entry overflow resets peer and settles every promise`() {
         val fuzz = DeterministicFuzz()
         val writePolicy = WritePolicy()
@@ -570,6 +599,25 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
 
         fun enqueueRpcForTest(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> =
             submitOnEventThread { enqueueRpc(peers.single { it.peerId == peerId }, msg) }
+
+        fun enqueueOversizedPublishForTest(
+            peerId: PeerId,
+            msg: Rpc.Message
+        ): CompletableFuture<Unit> {
+            val promise = CompletableFuture<Unit>()
+            submitOnEventThread {
+                val pending = pendingRpcParts.get(peers.single { it.peerId == peerId })
+                pending.queue.addPublish(msg)
+                pending.promises += promise
+                pending.usage = OutboundResourceUsage(1, 1)
+                try {
+                    flushPending(peers.single { it.peerId == peerId })
+                } catch (_: Throwable) {
+                    // Let the test inspect the promise and router state after the service-boundary failure.
+                }
+            }.join()
+            return promise
+        }
 
         fun hasNoOutboundStateForTest(): CompletableFuture<Boolean> =
             submitOnEventThread { !hasOutboundState() }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -23,6 +23,36 @@ import java.util.concurrent.TimeUnit
 class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
 
     @Test
+    fun `v1_3 initial control extensions are flushed before progress deadline`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            scoreParams,
+            Duration.ofMillis(10),
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+        val peer = createPeer(
+            fuzz,
+            params,
+            scoreParams,
+            protocol = PubsubProtocol.Gossip_V_1_3
+        )
+
+        sender.connectSemiDuplex(peer)
+        fuzz.timeController.addTime(Duration.ofMillis(20))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        assertThat(senderRouter.resetCount(peer.peerId)).isZero()
+        assertThat(writePolicy.messagesSentTo(peer.peerId))
+            .anyMatch { it.hasControl() && it.control.hasExtensions() }
+    }
+
+    @Test
     fun `unwritable peer is not materialized or written until transition`() {
         val fuzz = DeterministicFuzz()
         val writePolicy = WritePolicy()
@@ -528,13 +558,14 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         scoreParams: GossipScoreParams,
         progressTimeout: Duration,
         maxBytes: Long? = null,
-        maxEntries: Int = DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER
+        maxEntries: Int = DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER,
+        protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_2
     ): TestRouter = fuzz.createTestRouter(
         createGossipFuzzRouterFactory {
             RecordingGossipRouterBuilder(writePolicy, progressTimeout).apply {
                 this.params = params
                 this.scoreParams = scoreParams
-                protocol = PubsubProtocol.Gossip_V_1_2
+                this.protocol = protocol
                 maxOutboundRetainedBytesPerPeer = maxBytes
                 maxOutboundRetainedEntriesPerPeer = maxEntries
             }
@@ -562,11 +593,12 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
     private fun createPeer(
         fuzz: DeterministicFuzz,
         params: GossipParams,
-        scoreParams: GossipScoreParams
+        scoreParams: GossipScoreParams,
+        protocol: PubsubProtocol = PubsubProtocol.Gossip_V_1_2
     ): TestRouter = fuzz.createTestRouter(
         createGossipFuzzRouterFactory {
             GossipRouterBuilder(
-                protocol = PubsubProtocol.Gossip_V_1_2,
+                protocol = protocol,
                 params = params,
                 scoreParams = scoreParams
             )

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -26,6 +26,116 @@ import java.util.concurrent.TimeUnit
 class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
 
     @Test
+    fun `entry overflow resets peer and settles every promise`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams().copy(maxGossipMessageSize = 1024)
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            directPeerScoreParams(),
+            Duration.ofSeconds(10),
+            maxBytes = 4096,
+            maxEntries = 8
+        )
+        val slowPeer = createPeer(fuzz, params, directPeerScoreParams())
+
+        slowPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(slowPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        writePolicy.stalledPeerId = slowPeer.peerId
+        val publications = (0 until 8).map {
+            sender.router.publish(newMessage(TOPIC, it.toLong(), byteArrayOf(it.toByte())))
+        }
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        assertThat(senderRouter.resetCount(slowPeer.peerId)).isEqualTo(1)
+        assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
+        assertThat(publications).allMatch { it.isDone }
+        assertThat(publications).anyMatch { future ->
+            future.handle { _, error ->
+                generateSequence(error) { it.cause }
+                    .any { it is OutboundQueueOverflowException }
+            }.join()
+        }
+    }
+
+    @Test
+    fun `active and pending bytes share one limit`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams().copy(maxGossipMessageSize = 256)
+        val firstMessage = newMessage(TOPIC, 1, ByteArray(16))
+        val onePublishBytes = Rpc.RPC.newBuilder()
+            .addPublish(firstMessage.protobufMessage)
+            .build()
+            .serializedSize
+        val byteLimit = params.maxGossipMessageSize.toLong()
+        val publicationCount = (byteLimit / onePublishBytes + 1).toInt()
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            directPeerScoreParams(),
+            Duration.ofSeconds(10),
+            maxBytes = byteLimit,
+            maxEntries = 100
+        )
+        val slowPeer = createPeer(fuzz, params, directPeerScoreParams())
+
+        slowPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(slowPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+        writePolicy.stalledPeerId = slowPeer.peerId
+
+        repeat(publicationCount) { sequence ->
+            sender.router.publish(
+                newMessage(TOPIC, sequence.toLong() + 1, ByteArray(16))
+            )
+            fuzz.timeController.addTime(Duration.ofMillis(1))
+        }
+
+        assertThat((sender.router as RecordingGossipRouter).resetCount(slowPeer.peerId))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `control-only backlog is bounded by entries`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams().copy(maxGossipMessageSize = 1024)
+        val sender = createSender(
+            fuzz,
+            writePolicy,
+            params,
+            directPeerScoreParams(),
+            Duration.ofSeconds(10),
+            maxBytes = 4096,
+            maxEntries = 5
+        )
+        val slowPeer = createPeer(fuzz, params, directPeerScoreParams())
+
+        slowPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(slowPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        writePolicy.stalledPeerId = slowPeer.peerId
+        writePolicy.clearRecordedWrites(slowPeer.peerId)
+        repeat(3) {
+            senderRouter.enqueueRpcForTest(slowPeer.peerId, controlRpc())
+            fuzz.timeController.addTime(Duration.ofMillis(1))
+        }
+
+        assertThat(senderRouter.resetCount(slowPeer.peerId)).isEqualTo(1)
+        assertThat(senderRouter.hasNoOutboundStateForTest().join()).isTrue()
+        assertThat(writePolicy.messagesSentTo(slowPeer.peerId)).hasSize(1)
+    }
+
+    @Test
     fun `one stalled peer write must not be superseded by another write`() {
         val fuzz = DeterministicFuzz()
         val writePolicy = WritePolicy()
@@ -312,13 +422,17 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         writePolicy: WritePolicy,
         params: GossipParams,
         scoreParams: GossipScoreParams,
-        progressTimeout: Duration
+        progressTimeout: Duration,
+        maxBytes: Long? = null,
+        maxEntries: Int = DEFAULT_MAX_OUTBOUND_RETAINED_ENTRIES_PER_PEER
     ): TestRouter = fuzz.createTestRouter(
         createGossipFuzzRouterFactory {
             RecordingGossipRouterBuilder(writePolicy, progressTimeout).apply {
                 this.params = params
                 this.scoreParams = scoreParams
                 protocol = PubsubProtocol.Gossip_V_1_2
+                maxOutboundRetainedBytesPerPeer = maxBytes
+                maxOutboundRetainedEntriesPerPeer = maxEntries
             }
         }
     )

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipOutboundWriteBackpressureTest.kt
@@ -1,6 +1,8 @@
 package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.PeerId
+import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.pubsub.*
 import io.libp2p.pubsub.DeterministicFuzz.Companion.createGossipFuzzRouterFactory
 import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
@@ -65,6 +67,7 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         peerTopics.values.forEach { topics -> assertThat(topics).containsExactly(TOPIC) }
 
         writePolicy.stalledPeerId = stalledPeer.peerId
+        writePolicy.clearRecordedWrites(stalledPeer.peerId)
         senderRouter.enqueueRpcForTest(
             stalledPeer.peerId,
             Rpc.RPC.newBuilder()
@@ -130,14 +133,162 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         fuzz.timeController.addTime(Duration.ofSeconds(2))
 
         writePolicy.stalledPeerId = stalledPeer.peerId
-        val publication = sender.router.publish(newMessage(TOPIC, 1, "stalled".toByteArray()))
+        writePolicy.clearRecordedWrites(stalledPeer.peerId)
+        val publications = (0 until 3).map { sequence ->
+            sender.router.publish(newMessage(TOPIC, sequence.toLong(), "stalled-$sequence".toByteArray()))
+        }
         fuzz.timeController.addTime(Duration.ofMillis(20))
 
-        assertThat(publication).isCompletedExceptionally
-        assertThat((sender.router as RecordingGossipRouter).peers).isEmpty()
+        val senderRouter = sender.router as RecordingGossipRouter
+        assertThat(publications).allMatch { it.isCompletedExceptionally }
+        assertThat(senderRouter.peers).isEmpty()
+        assertThat(senderRouter.pendingPeerCountForTest().join()).isZero()
+        assertThat(senderRouter.disconnectCount).isEqualTo(1)
         assertThat(writePolicy.unresolvedWriteCount(stalledPeer.peerId)).isZero()
         assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).hasSize(1)
+
+        sender.router.publish(newMessage(TOPIC, 10, "after-timeout".toByteArray()))
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).hasSize(1)
     }
+
+    @Test
+    fun `successful write resets the progress deadline for the next queued write`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(fuzz, writePolicy, params, scoreParams, Duration.ofMillis(100))
+        val stalledPeer = createPeer(fuzz, params, scoreParams)
+
+        stalledPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(stalledPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        writePolicy.stalledPeerId = stalledPeer.peerId
+        writePolicy.clearRecordedWrites(stalledPeer.peerId)
+        senderRouter.enqueueRpcForTest(stalledPeer.peerId, controlRpc())
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        senderRouter.enqueueRpcForTest(stalledPeer.peerId, controlRpc())
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        writePolicy.completeNext(stalledPeer.peerId)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        fuzz.timeController.addTime(Duration.ofMillis(98))
+
+        assertThat(senderRouter.peers).hasSize(1)
+        assertThat(writePolicy.unresolvedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+
+        fuzz.timeController.addTime(Duration.ofMillis(2))
+
+        assertThat(senderRouter.peers).isEmpty()
+        assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+    }
+
+    @Test
+    fun `queued RPC batches are sent sequentially and preserve ordering`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(fuzz, writePolicy, params, scoreParams, Duration.ofSeconds(1))
+        val stalledPeer = createPeer(fuzz, params, scoreParams)
+
+        stalledPeer.router.subscribe(TOPIC)
+        sender.connectSemiDuplex(stalledPeer)
+        fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+        val senderRouter = sender.router as RecordingGossipRouter
+        writePolicy.stalledPeerId = stalledPeer.peerId
+        writePolicy.clearRecordedWrites(stalledPeer.peerId)
+        val first = controlRpc()
+        val second = controlRpc()
+        senderRouter.enqueueRpcForTest(stalledPeer.peerId, first)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        senderRouter.enqueueRpcForTest(stalledPeer.peerId, second)
+        val publication = sender.router.publish(newMessage(TOPIC, 1, "queued".toByteArray()))
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).containsExactly(first)
+        writePolicy.completeNext(stalledPeer.peerId)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId)).containsExactly(first, second)
+        writePolicy.completeNext(stalledPeer.peerId)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+
+        assertThat(writePolicy.messagesSentTo(stalledPeer.peerId))
+            .hasSize(3)
+            .last()
+            .extracting { it.publishList.single().data.toByteArray() }
+            .isEqualTo("queued".toByteArray())
+
+        writePolicy.completeNext(stalledPeer.peerId)
+        fuzz.timeController.addTime(Duration.ofMillis(1))
+        assertThat(publication).isCompleted
+    }
+
+    @Test
+    fun `repeated stalled peer reconnects do not retain router state`() {
+        val fuzz = DeterministicFuzz()
+        val writePolicy = WritePolicy()
+        val params = singlePeerParams()
+        val scoreParams = directPeerScoreParams()
+        val sender = createSender(fuzz, writePolicy, params, scoreParams, Duration.ofMillis(10))
+        val senderRouter = sender.router as RecordingGossipRouter
+
+        repeat(3) { cycle ->
+            val stalledPeer = createPeer(fuzz, params, scoreParams)
+            stalledPeer.router.subscribe(TOPIC)
+            sender.connectSemiDuplex(stalledPeer)
+            fuzz.timeController.addTime(Duration.ofSeconds(2))
+
+            writePolicy.stalledPeerId = stalledPeer.peerId
+            writePolicy.clearRecordedWrites(stalledPeer.peerId)
+            val publication = sender.router.publish(newMessage(TOPIC, cycle.toLong(), "cycle-$cycle".toByteArray()))
+            fuzz.timeController.addTime(Duration.ofMillis(20))
+
+            assertThat(publication).isCompletedExceptionally
+            assertThat(senderRouter.peers).isEmpty()
+            assertThat(senderRouter.pendingPeerCountForTest().join()).isZero()
+            assertThat(writePolicy.failedWriteCount(stalledPeer.peerId)).isEqualTo(1)
+        }
+    }
+
+    private fun createSender(
+        fuzz: DeterministicFuzz,
+        writePolicy: WritePolicy,
+        params: GossipParams,
+        scoreParams: GossipScoreParams,
+        progressTimeout: Duration
+    ): TestRouter = fuzz.createTestRouter(
+        createGossipFuzzRouterFactory {
+            RecordingGossipRouterBuilder(writePolicy, progressTimeout).apply {
+                this.params = params
+                this.scoreParams = scoreParams
+                protocol = PubsubProtocol.Gossip_V_1_2
+            }
+        }
+    )
+
+    private fun singlePeerParams() = GossipParams(
+        D = 1,
+        DLow = 1,
+        DHigh = 1,
+        floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH
+    )
+
+    private fun directPeerScoreParams() = GossipScoreParams(
+        peerScoreParams = GossipPeerScoreParams(isDirect = { true })
+    )
+
+    private fun controlRpc(): Rpc.RPC = Rpc.RPC.newBuilder()
+        .setControl(
+            Rpc.ControlMessage.newBuilder()
+                .addIdontwant(Rpc.ControlIDontWant.getDefaultInstance())
+        )
+        .build()
 
     private fun createPeer(
         fuzz: DeterministicFuzz,
@@ -159,9 +310,8 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         private val sentMessages = mutableMapOf<PeerId, MutableList<Rpc.RPC>>()
 
         fun send(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> {
-            if (peerId != stalledPeerId) return CompletableFuture.completedFuture(Unit)
-
             sentMessages.getOrPut(peerId) { mutableListOf() } += msg
+            if (peerId != stalledPeerId) return CompletableFuture.completedFuture(Unit)
             return CompletableFuture<Unit>().also {
                 unresolvedWrites.getOrPut(peerId) { mutableListOf() } += it
             }
@@ -172,6 +322,16 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
             unresolvedWrites[peerId]?.count { it.isCompletedExceptionally } ?: 0
 
         fun messagesSentTo(peerId: PeerId): List<Rpc.RPC> = sentMessages[peerId] ?: emptyList()
+
+        fun clearRecordedWrites(peerId: PeerId) {
+            unresolvedWrites.remove(peerId)
+            sentMessages.remove(peerId)
+        }
+
+        fun completeNext(peerId: PeerId) {
+            unresolvedWrites[peerId]?.firstOrNull { !it.isDone }?.complete(Unit)
+                ?: throw AssertionError("No pending write for $peerId")
+        }
     }
 
     private class RecordingGossipRouter(
@@ -205,11 +365,34 @@ class GossipOutboundWriteBackpressureTest : GossipTestsBase() {
         seenMessages = seenMessages,
         messageValidator = messageValidator
     ) {
+        var disconnectCount = 0
+            private set
+
+        init {
+            eventBroadcaster.listeners += object : GossipRouterEventListener {
+                override fun notifyDisconnected(peerId: PeerId) {
+                    disconnectCount++
+                }
+
+                override fun notifyConnected(peerId: PeerId, peerAddress: Multiaddr) {}
+                override fun notifyUnseenMessage(peerId: PeerId, msg: PubsubMessage) {}
+                override fun notifySeenMessage(peerId: PeerId, msg: PubsubMessage, validationResult: Optional<ValidationResult>) {}
+                override fun notifyUnseenInvalidMessage(peerId: PeerId, msg: PubsubMessage) {}
+                override fun notifyUnseenValidMessage(peerId: PeerId, msg: PubsubMessage) {}
+                override fun notifyMeshed(peerId: PeerId, topic: Topic) {}
+                override fun notifyPruned(peerId: PeerId, topic: Topic) {}
+                override fun notifyRouterMisbehavior(peerId: PeerId, count: Int) {}
+            }
+        }
+
         override fun send(peer: PeerHandler, msg: Rpc.RPC): CompletableFuture<Unit> =
             writePolicy.send(peer.peerId, msg)
 
         fun enqueueRpcForTest(peerId: PeerId, msg: Rpc.RPC): CompletableFuture<Unit> =
             submitOnEventThread { enqueueRpc(peers.single { it.peerId == peerId }, msg) }
+
+        fun pendingPeerCountForTest(): CompletableFuture<Int> =
+            submitOnEventThread { pendingRpcParts.pendingPeers.size }
     }
 
     private class RecordingGossipRouterBuilder(

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
@@ -53,7 +53,7 @@ class GossipRouterBuilderTest {
         val router = builder.build()
 
         assertThat(router.outboundLimits.maxRetainedBytesPerPeer).isEqualTo(16_428_746)
-        assertThat(router.outboundLimits.maxRetainedEntriesPerPeer).isEqualTo(1024)
+        assertThat(router.outboundLimits.maxRetainedEntriesPerPeer).isEqualTo(10_000)
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
@@ -1,7 +1,9 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.pubsub.PubsubOutboundLimits
 import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test
 
 class GossipRouterBuilderTest {
@@ -41,5 +43,52 @@ class GossipRouterBuilderTest {
         val localSupport = router.gossipExtensionsState.localExtensionSupport
         assertThat(localSupport.testExtension).isTrue()
         assertThat(localSupport.partialMessages).isTrue()
+    }
+
+    @Test
+    fun `outbound byte default uses final gossip params`() {
+        val builder = GossipRouterBuilder()
+        builder.params = GossipParams(maxGossipMessageSize = 12_234_442)
+
+        val router = builder.build()
+
+        assertThat(router.outboundLimits.maxRetainedBytesPerPeer).isEqualTo(16_428_746)
+        assertThat(router.outboundLimits.maxRetainedEntriesPerPeer).isEqualTo(1024)
+    }
+
+    @Test
+    fun `explicit outbound limits are retained`() {
+        val router = GossipRouterBuilder().apply {
+            maxOutboundRetainedBytesPerPeer = 20L * 1024 * 1024
+            maxOutboundRetainedEntriesPerPeer = 256
+        }.build()
+
+        assertThat(router.outboundLimits)
+            .isEqualTo(PubsubOutboundLimits(20L * 1024 * 1024, 256))
+    }
+
+    @Test
+    fun `outbound bytes must fit one maximum gossip message`() {
+        val builder = GossipRouterBuilder(
+            params = GossipParams(maxGossipMessageSize = 1024)
+        ).apply {
+            maxOutboundRetainedBytesPerPeer = 1023
+        }
+
+        assertThatIllegalArgumentException()
+            .isThrownBy(builder::build)
+            .withMessageContaining("1023")
+            .withMessageContaining("1024")
+    }
+
+    @Test
+    fun `outbound entries must be positive`() {
+        val builder = GossipRouterBuilder().apply {
+            maxOutboundRetainedEntriesPerPeer = 0
+        }
+
+        assertThatIllegalArgumentException()
+            .isThrownBy(builder::build)
+            .withMessageContaining("maxOutboundRetainedEntriesPerPeer")
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
@@ -104,14 +104,28 @@ class GossipRouterBuilderTest {
         assertThat(builder.createCount).isZero()
     }
 
+    @Test
+    fun `router construction starts with bounded default outbound limits`() {
+        val params = GossipParams(maxGossipMessageSize = 1024)
+        val builder = CreationTrackingGossipRouterBuilder(params)
+
+        builder.build()
+
+        assertThat(builder.limitsAtCreation)
+            .isEqualTo(PubsubOutboundLimits.defaults(params.maxGossipMessageSize))
+    }
+
     private class CreationTrackingGossipRouterBuilder(
         params: GossipParams
     ) : GossipRouterBuilder(params = params) {
         var createCount = 0
+        var limitsAtCreation: PubsubOutboundLimits? = null
 
         override fun createGossipRouter(): GossipRouter {
             createCount++
-            return super.createGossipRouter()
+            return super.createGossipRouter().also {
+                limitsAtCreation = it.outboundLimits
+            }
         }
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRouterBuilderTest.kt
@@ -91,4 +91,27 @@ class GossipRouterBuilderTest {
             .isThrownBy(builder::build)
             .withMessageContaining("maxOutboundRetainedEntriesPerPeer")
     }
+
+    @Test
+    fun `invalid outbound limits do not construct a router`() {
+        val builder = CreationTrackingGossipRouterBuilder(
+            params = GossipParams(maxGossipMessageSize = 1024)
+        ).apply {
+            maxOutboundRetainedBytesPerPeer = 1023
+        }
+
+        assertThatIllegalArgumentException().isThrownBy(builder::build)
+        assertThat(builder.createCount).isZero()
+    }
+
+    private class CreationTrackingGossipRouterBuilder(
+        params: GossipParams
+    ) : GossipRouterBuilder(params = params) {
+        var createCount = 0
+
+        override fun createGossipRouter(): GossipRouter {
+            createCount++
+            return super.createGossipRouter()
+        }
+    }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -494,4 +494,26 @@ class GossipRpcPartsQueueTest {
         assertThat(merged[1].control.hasExtensions()).isTrue()
         assertThat(merged[1].control.extensions.partialMessages).isTrue()
     }
+
+    @Test
+    fun `complete RPC remains an ordered batching boundary`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+        val directRpc = Rpc.RPC.newBuilder()
+            .setControl(
+                Rpc.ControlMessage.newBuilder()
+                    .addIdontwant(Rpc.ControlIDontWant.getDefaultInstance())
+            )
+            .build()
+
+        partsQueue.addPublish(createRpcMessage("before", "data"))
+        partsQueue.addRpc(directRpc)
+        partsQueue.addPublish(createRpcMessage("after", "data"))
+
+        val messages = partsQueue.takeMerged()
+
+        assertThat(messages).hasSize(3)
+        assertThat(messages[0].publishList.single().topicIDsList).containsExactly("before")
+        assertThat(messages[1]).isEqualTo(directRpc)
+        assertThat(messages[2].publishList.single().topicIDsList).containsExactly("after")
+    }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -7,6 +7,7 @@ import io.libp2p.pubsub.Topic
 import io.libp2p.pubsub.gossip.builders.GossipParamsBuilder
 import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedInvocationConstants
 import org.junit.jupiter.params.ParameterizedTest
@@ -216,6 +217,37 @@ class GossipRpcPartsQueueTest {
         partsQueue.addPublish(createRpcMessage("topic", "data-2"))
 
         assertThat(partsQueue.takeMerged()[0].hasControl()).isFalse()
+    }
+
+    @Test
+    fun `merge splits before maximum serialized size is exceeded`() {
+        val single = createRpcMessage("topic", "x".repeat(32))
+        val oneRpcSize = Rpc.RPC.newBuilder().addPublish(single).build().serializedSize
+        val params = GossipParams(
+            maxGossipMessageSize = oneRpcSize * 2
+        )
+        val queue = DefaultGossipRpcPartsQueue(params)
+        repeat(3) { queue.addPublish(single) }
+
+        val merged = queue.takeMerged()
+
+        assertThat(merged).hasSize(2)
+        assertThat(merged).allMatch { it.serializedSize <= params.maxGossipMessageSize }
+        assertThat(merged.flatMap { it.publishList }).hasSize(3)
+    }
+
+    @Test
+    fun `atomic RPC larger than maximum size is rejected`() {
+        val params = GossipParams(maxGossipMessageSize = 32)
+        val oversized = Rpc.RPC.newBuilder()
+            .addPublish(createRpcMessage("topic", "x".repeat(128)))
+            .build()
+        val queue = DefaultGossipRpcPartsQueue(params)
+        queue.addRpc(oversized)
+
+        assertThatIllegalArgumentException()
+            .isThrownBy(queue::takeMerged)
+            .withMessageContaining("maxGossipMessageSize")
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipTwoHostTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipTwoHostTest.kt
@@ -6,14 +6,23 @@ import io.libp2p.core.pubsub.Topic
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
 import io.libp2p.mux.mplex.DEFAULT_MAX_MPLEX_FRAME_DATA_LENGTH
+import io.netty.channel.ChannelDuplexHandler
+import io.netty.channel.ChannelHandler
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelPromise
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 class GossipTwoHostTest : TwoGossipHostTestBase() {
 
     override val params = GossipParams(maxGossipMessageSize = DEFAULT_MAX_MPLEX_FRAME_DATA_LENGTH * 2)
+    private val outboundWrites = BatchingOutboundWriteHandler()
+    override val gossip1 by lazy { Gossip(router1, debugGossipHandler = outboundWrites) }
 
     @Test
     fun `test message larger than mplex frame`() {
@@ -42,22 +51,85 @@ class GossipTwoHostTest : TwoGossipHostTestBase() {
     }
 
     @Test
-    fun `TCP Mplex preserves healthy gossipsub publication order`() {
+    fun `TCP Mplex preserves healthy gossipsub publication order and batching`() {
         connect()
 
         val topic = Topic("ordered-topic")
-        val received = CopyOnWriteArrayList<MessageApi>()
-        gossip2.subscribe(Subscriber { received += it }, topic)
+        val receivedByHost1 = CopyOnWriteArrayList<MessageApi>()
+        val receivedByHost2 = CopyOnWriteArrayList<MessageApi>()
+        gossip1.subscribe(Subscriber { receivedByHost1 += it }, topic)
+        gossip2.subscribe(Subscriber { receivedByHost2 += it }, topic)
         waitForSubscribed(router1, topic.topic)
+        waitForSubscribed(router2, topic.topic)
 
         val publisher = gossip1.createPublisher(null)
         val payloads = listOf("first", "second", "third")
-        payloads.forEach { payload ->
-            publisher.publish(payload.toByteArray().toByteBuf(), topic).get(10, TimeUnit.SECONDS)
+        outboundWrites.holdNextPublish()
+        val publications = payloads.map { payload ->
+            publisher.publish(payload.toByteArray().toByteBuf(), topic)
+        }
+        outboundWrites.awaitHeldPublish()
+        router1.getPeerTopics().join()
+        outboundWrites.releaseHeldPublish()
+        publications.forEach { it.get(10, TimeUnit.SECONDS) }
+
+        waitFor { receivedByHost2.size == payloads.size }
+
+        assertThat(receivedByHost2.map { it.data.toByteArray().decodeToString() }).containsExactlyElementsOf(payloads)
+        assertThat(outboundWrites.publishBatchSizes).containsExactly(1, 2)
+
+        gossip2.createPublisher(null)
+            .publish("reply".toByteArray().toByteBuf(), topic)
+            .get(10, TimeUnit.SECONDS)
+        waitFor { receivedByHost1.size == 1 }
+        assertThat(receivedByHost1.single().data.toByteArray().decodeToString()).isEqualTo("reply")
+    }
+
+    @ChannelHandler.Sharable
+    private class BatchingOutboundWriteHandler : ChannelDuplexHandler() {
+        data class HeldWrite(
+            val ctx: ChannelHandlerContext,
+            val msg: Any,
+            val promise: ChannelPromise
+        )
+
+        val publishBatchSizes = CopyOnWriteArrayList<Int>()
+        private val heldWrite = AtomicReference<HeldWrite>()
+
+        @Volatile
+        private var holdNextPublish = false
+
+        @Volatile
+        private var heldPublishLatch = CountDownLatch(0)
+
+        fun holdNextPublish() {
+            publishBatchSizes.clear()
+            heldPublishLatch = CountDownLatch(1)
+            holdNextPublish = true
         }
 
-        waitFor { received.size == payloads.size }
+        fun awaitHeldPublish() {
+            assertThat(heldPublishLatch.await(10, TimeUnit.SECONDS)).isTrue()
+        }
 
-        assertThat(received.map { it.data.toByteArray().decodeToString() }).containsExactlyElementsOf(payloads)
+        fun releaseHeldPublish() {
+            val write = heldWrite.getAndSet(null) ?: throw AssertionError("No held publish write")
+            write.ctx.executor().execute {
+                write.ctx.writeAndFlush(write.msg, write.promise)
+            }
+        }
+
+        override fun write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise) {
+            if (msg is Rpc.RPC && msg.publishCount > 0) {
+                publishBatchSizes += msg.publishCount
+                if (holdNextPublish) {
+                    holdNextPublish = false
+                    heldWrite.set(HeldWrite(ctx, msg, promise))
+                    heldPublishLatch.countDown()
+                    return
+                }
+            }
+            ctx.write(msg, promise)
+        }
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipTwoHostTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipTwoHostTest.kt
@@ -8,6 +8,7 @@ import io.libp2p.etc.types.toByteBuf
 import io.libp2p.mux.mplex.DEFAULT_MAX_MPLEX_FRAME_DATA_LENGTH
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 
 class GossipTwoHostTest : TwoGossipHostTestBase() {
@@ -38,5 +39,25 @@ class GossipTwoHostTest : TwoGossipHostTestBase() {
         assertThat(messages)
             .hasSize(1)
             .allMatch { it.data.toByteArray().contentEquals(msgBytes) }
+    }
+
+    @Test
+    fun `TCP Mplex preserves healthy gossipsub publication order`() {
+        connect()
+
+        val topic = Topic("ordered-topic")
+        val received = CopyOnWriteArrayList<MessageApi>()
+        gossip2.subscribe(Subscriber { received += it }, topic)
+        waitForSubscribed(router1, topic.topic)
+
+        val publisher = gossip1.createPublisher(null)
+        val payloads = listOf("first", "second", "third")
+        payloads.forEach { payload ->
+            publisher.publish(payload.toByteArray().toByteBuf(), topic).get(10, TimeUnit.SECONDS)
+        }
+
+        waitFor { received.size == payloads.size }
+
+        assertThat(received.map { it.data.toByteArray().decodeToString() }).containsExactlyElementsOf(payloads)
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/QuicGossipOutboundBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/QuicGossipOutboundBackpressureTest.kt
@@ -1,0 +1,191 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.Host
+import io.libp2p.core.Stream
+import io.libp2p.core.dsl.Builder
+import io.libp2p.core.dsl.host
+import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
+import io.libp2p.transport.quic.QuicConfig
+import io.libp2p.transport.quic.QuicStream
+import io.libp2p.transport.quic.QuicTransport
+import io.netty.channel.Channel
+import io.netty.channel.ChannelDuplexHandler
+import io.netty.channel.ChannelHandler
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelPromise
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
+
+/**
+ * Real QUIC reproduction for outbound gossipsub writes accumulating behind exhausted flow control.
+ *
+ * This is intentionally expected to fail against the unmodified router: every publish can start
+ * another write while the first write remains unresolved.
+ */
+class QuicGossipOutboundBackpressureTest : GossipTestsBase() {
+
+    @Test
+    fun `a stalled QUIC pubsub stream must not accumulate unresolved writes`() {
+        val quicConfig = QuicConfig(
+            maxConnectionData = 4L * 1024 * 1024,
+            maxStreamDataLocal = STREAM_WINDOW,
+            maxStreamDataRemote = STREAM_WINDOW,
+            idleTimeout = Duration.ofSeconds(60)
+        )
+        val senderRouter = createRouter()
+        val receiverRouter = createRouter()
+        val writeRecorder = RecordingOutboundWriteHandler()
+        val senderGossip = Gossip(senderRouter, debugGossipHandler = writeRecorder)
+        val receiverGossip = Gossip(receiverRouter)
+        val senderHost = createHost(senderGossip, quicConfig)
+        val receiverHost = createHost(receiverGossip, quicConfig)
+
+        try {
+            senderHost.start().get(5, TimeUnit.SECONDS)
+            receiverHost.start().get(5, TimeUnit.SECONDS)
+
+            senderHost.network
+                .connect(receiverHost.peerId, receiverHost.listenAddresses().single())
+                .get(10, TimeUnit.SECONDS)
+
+            waitFor("both semi-duplex gossipsub streams") {
+                hasActiveSemiDuplexPeer(senderRouter) && hasActiveSemiDuplexPeer(receiverRouter)
+            }
+
+            senderRouter.subscribe(TOPIC)
+            receiverRouter.subscribe(TOPIC)
+            waitFor("gossipsub subscriptions") {
+                hasPeerSubscription(senderRouter) && hasPeerSubscription(receiverRouter)
+            }
+
+            val senderStream = senderRouter.outboundQuicStream()
+            val receiverStream = receiverRouter.inboundQuicStream()
+            val senderChannel = senderStream.quicStreamChannel
+            val receiverChannel = receiverStream.quicStreamChannel
+            val connectionChannel = senderChannel.parent()
+
+            assertThat(connectionChannel).isNotNull
+            assertThat(connectionChannel.isActive).isTrue()
+            assertThat(senderChannel.isActive).isTrue()
+            assertThat(receiverChannel.isActive).isTrue()
+
+            receiverChannel.eventLoop().submit {
+                receiverChannel.config().isAutoRead = false
+            }.sync()
+            assertThat(receiverChannel.config().isAutoRead).isFalse()
+
+            writeRecorder.begin(senderChannel)
+            val publishFutures = (0 until MESSAGE_COUNT).map { sequence ->
+                senderRouter.publish(
+                    newMessage(TOPIC, sequence.toLong(), ByteArray(MESSAGE_SIZE) { 0x5a })
+                )
+            }
+
+            waitFor("sender QUIC stream to become unwritable") {
+                !senderChannel.isWritable
+            }
+
+            assertThat(connectionChannel.isActive).isTrue()
+            assertThat(senderChannel.isActive).isTrue()
+            assertThat(receiverChannel.isActive).isTrue()
+            assertThat(publishFutures).hasSize(MESSAGE_COUNT)
+
+            val unresolvedWrites = writeRecorder.unresolvedWrites()
+            assertThat(unresolvedWrites)
+                .withFailMessage(
+                    "unresolved write promises reaching the stalled QUIC stream: expected at most 1, " +
+                        "observed ${unresolvedWrites.size}"
+                )
+                .hasSizeLessThanOrEqualTo(1)
+        } finally {
+            senderHost.stop().get(5, TimeUnit.SECONDS)
+            receiverHost.stop().get(5, TimeUnit.SECONDS)
+        }
+    }
+
+    private fun createRouter(): GossipRouter = GossipRouterBuilder(
+        protocol = PubsubProtocol.Gossip_V_1_2,
+        params = GossipParams(
+            D = 1,
+            DLow = 1,
+            DHigh = 1,
+            floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH
+        ),
+        scoreParams = GossipScoreParams(
+            peerScoreParams = GossipPeerScoreParams(isDirect = { true })
+        )
+    ).build()
+
+    private fun createHost(gossip: Gossip, quicConfig: QuicConfig): Host = host(Builder.Defaults.None) {
+        identity { random() }
+        secureTransports {
+            add { key, protocols -> QuicTransport.ECDSA(key, protocols, quicConfig) }
+        }
+        network { listen("/ip4/127.0.0.1/udp/${randomPort()}/quic-v1") }
+        protocols { +gossip }
+    }
+
+    private fun hasActiveSemiDuplexPeer(router: GossipRouter): Boolean {
+        val peer = router.peers.singleOrNull() ?: return false
+        return peer.getInboundHandler()?.ctx != null && peer.getOutboundHandler()?.ctx != null
+    }
+
+    private fun hasPeerSubscription(router: GossipRouter): Boolean =
+        router.getPeerTopics().join().values.any { TOPIC in it }
+
+    private fun GossipRouter.outboundQuicStream(): QuicStream =
+        peers.single().getOutboundHandler()!!.stream.asQuicStream()
+
+    private fun GossipRouter.inboundQuicStream(): QuicStream =
+        peers.single().getInboundHandler()!!.stream.asQuicStream()
+
+    private fun Stream.asQuicStream(): QuicStream = this as? QuicStream
+        ?: throw AssertionError("Expected a QUIC pubsub stream, got $this")
+
+    private fun waitFor(description: String, predicate: () -> Boolean) {
+        val deadline = System.nanoTime() + WAIT_TIMEOUT.toNanos()
+        while (!predicate()) {
+            if (System.nanoTime() >= deadline) {
+                throw AssertionError("Timed out waiting for $description")
+            }
+            Thread.sleep(20)
+        }
+    }
+
+    @ChannelHandler.Sharable
+    private class RecordingOutboundWriteHandler : ChannelDuplexHandler() {
+        private val promises = CopyOnWriteArrayList<ChannelPromise>()
+
+        @Volatile
+        private var target: Channel? = null
+
+        fun begin(channel: Channel) {
+            promises.clear()
+            target = channel
+        }
+
+        override fun write(ctx: ChannelHandlerContext, msg: Any, promise: ChannelPromise) {
+            if (ctx.channel() === target) {
+                promises += promise
+            }
+            ctx.write(msg, promise)
+        }
+
+        fun unresolvedWrites(): List<ChannelPromise> = promises.filterNot { it.isDone }
+    }
+
+    private companion object {
+        const val TOPIC = "quic-backpressure-topic"
+        const val MESSAGE_COUNT = 128
+        const val MESSAGE_SIZE = 8 * 1024
+        const val STREAM_WINDOW = 16L * 1024
+        val WAIT_TIMEOUT: Duration = Duration.ofSeconds(15)
+
+        fun randomPort(): Int = ThreadLocalRandom.current().nextInt(10_000, 60_000)
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/QuicGossipOutboundBackpressureTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/QuicGossipOutboundBackpressureTest.kt
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeUnit
 /**
  * Real QUIC reproduction for outbound gossipsub writes accumulating behind exhausted flow control.
  *
- * This is intentionally expected to fail against the unmodified router: every publish can start
- * another write while the first write remains unresolved.
+ * This verifies that the router keeps one unresolved write during a real QUIC flow-control stall
+ * and resumes the queued publications when the receiver starts reading again.
  */
 class QuicGossipOutboundBackpressureTest : GossipTestsBase() {
 
@@ -102,6 +102,27 @@ class QuicGossipOutboundBackpressureTest : GossipTestsBase() {
                         "observed ${unresolvedWrites.size}"
                 )
                 .hasSizeLessThanOrEqualTo(1)
+
+            val writesBeforeResume = writeRecorder.totalWrites()
+            receiverChannel.eventLoop().submit {
+                receiverChannel.config().isAutoRead = true
+                receiverChannel.read()
+            }.sync()
+
+            waitFor("sender QUIC stream to become writable again") {
+                senderChannel.isWritable
+            }
+            waitFor("all queued publications to complete") {
+                publishFutures.all { it.isDone }
+            }
+
+            assertThat(publishFutures)
+                .allMatch { it.isDone && !it.isCompletedExceptionally }
+            assertThat(writeRecorder.unresolvedWrites()).isEmpty()
+            assertThat(writeRecorder.totalWrites()).isGreaterThan(writesBeforeResume)
+            assertThat(connectionChannel.isActive).isTrue()
+            assertThat(senderChannel.isActive).isTrue()
+            assertThat(receiverChannel.isActive).isTrue()
         } finally {
             senderHost.stop().get(5, TimeUnit.SECONDS)
             receiverHost.stop().get(5, TimeUnit.SECONDS)
@@ -177,6 +198,8 @@ class QuicGossipOutboundBackpressureTest : GossipTestsBase() {
         }
 
         fun unresolvedWrites(): List<ChannelPromise> = promises.filterNot { it.isDone }
+
+        fun totalWrites(): Int = promises.size
     }
 
     private companion object {

--- a/tools/simulator/src/main/kotlin/io/libp2p/simulate/gossip/router/SimGossipRouterBuilder.kt
+++ b/tools/simulator/src/main/kotlin/io/libp2p/simulate/gossip/router/SimGossipRouterBuilder.kt
@@ -30,7 +30,6 @@ class SimGossipRouterBuilder : GossipRouterBuilder() {
             additionalHeartbeatDelay = additionalHeartbeatDelay
         )
 
-        router.eventBroadcaster.listeners += gossipRouterEventListeners
         return router
     }
 }


### PR DESCRIPTION
## Summary

Fix unbounded outbound pubsub writes when a remote peer stops consuming a QUIC stream.

A stalled peer could leave millions of unresolved writes retained by
`QuicheQuicStreamChannel`, causing extreme heap growth. The fix integrates Netty
channel writability with the pubsub outbound pump and bounds retained work per
peer.

## What changed

- Gate outbound pubsub materialization on the outbound stream's `isWritable()`
  state.
- Allow only one unresolved transport write per peer's outbound pubsub stream.
- Resume the pump on `channelWritabilityChanged` when QUIC flow control opens.
- Serialize queued RPC batches while preserving ordering.
- Enforce per-peer retained byte and logical-entry limits.
- Use bounded defaults:
  - bytes: `maxOf(8 MiB, maxGossipMessageSize + 4 MiB)`
  - entries: `10,000`
- Enforce the existing progress deadline when a peer makes no write progress.
  Successful write completion resets the deadline; writability changes alone do
  not.
- On write failure, progress timeout, or queue overflow:
  - fail active and queued publication futures;
  - release per-peer accounting;
  - clear outbound state;
  - reset the outbound pubsub stream.
- Keep reset-on-overflow as the initial bounded policy. Selective message
  eviction for slow peers can be considered separately.

## Verification

- Deterministic tests cover writability gating, queue accounting, overflow,
  write sequencing, deadlines, cleanup, and reconnects.
- Real QUIC coverage verifies flow-control pause and resume, at most one
  unresolved write, completion of queued publications, and connection liveness.
- TCP/Mplex coverage verifies healthy publication ordering and batching remain
  unchanged.
- `spotlessCheck` and `detekt` pass.

The original leak involved approximately 4.1 million pending writes, 1.5 GB of
pending data, and 2.9 GB of heap while QUIC send capacity was exhausted.