### PR TITLE
Support backpressure in P2PService (Gossipsub base class)

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/core/Libp2pException.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/core/Libp2pException.kt
@@ -71,4 +71,8 @@ open class ProtocolViolationException(message: String) : Libp2pException(message
  * When trying to write a message to a peer within [io.libp2p.etc.util.P2PServiceSemiDuplex]
  * but there is no yet outbound stream created.
  */
-open class SemiDuplexNoOutboundStreamException(message: String) : Libp2pException(message)
+open class SemiDuplexNoOutboundStreamException(message: String = "SDPeerHandler.otherStreamHandler hasn't been initialized") :
+    Libp2pException(message)
+
+open class StreamNotActiveException(message: String = "Stream is either closed already or not activated yet") :
+    Libp2pException(message)

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/NettyExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/NettyExt.kt
@@ -21,7 +21,7 @@ fun ChannelFuture.toCompletableFuture(): CompletableFuture<Channel> {
     return ret
 }
 
-fun ChannelFuture.forwardTo(fut: CompletableFuture<Unit>)=     this.addListener {
+fun ChannelFuture.forwardTo(fut: CompletableFuture<Unit>) = this.addListener {
     if (it.isSuccess) {
         fut.complete(Unit)
     } else {

--- a/libp2p/src/main/kotlin/io/libp2p/etc/types/NettyExt.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/types/NettyExt.kt
@@ -21,6 +21,14 @@ fun ChannelFuture.toCompletableFuture(): CompletableFuture<Channel> {
     return ret
 }
 
+fun ChannelFuture.forwardTo(fut: CompletableFuture<Unit>)=     this.addListener {
+    if (it.isSuccess) {
+        fut.complete(Unit)
+    } else {
+        fut.completeExceptionally(it.cause())
+    }
+}
+
 fun Future<*>.toVoidCompletableFuture(): CompletableFuture<Unit> = toCompletableFuture().thenApply { }
 
 fun <T> Future<T>.toCompletableFuture(): CompletableFuture<T> {

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriter.kt
@@ -1,0 +1,42 @@
+package io.libp2p.etc.util
+
+import io.libp2p.core.SemiDuplexNoOutboundStreamException
+import io.libp2p.core.StreamNotActiveException
+import io.libp2p.etc.types.forwardTo
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+fun interface BackpressureAwareAsyncWriter {
+
+    fun write(message: Any, writePromise: CompletableFuture<Unit>): CompletionStage<Boolean>
+
+    companion object {
+
+        fun createFromStreamHandler(streamHandler: P2PService.PeerHandler): BackpressureAwareAsyncWriter {
+            return object : BackpressureAwareAsyncWriter {
+                override fun write(
+                    message: Any,
+                    writePromise: CompletableFuture<Unit>
+                ): CompletionStage<Boolean> {
+                    val outboundHandler = streamHandler.getOutboundHandler()
+                    if (outboundHandler == null) {
+                        writePromise.completeExceptionally(SemiDuplexNoOutboundStreamException())
+                        return CompletableFuture.failedFuture(SemiDuplexNoOutboundStreamException())
+                    }
+                    val channel = outboundHandler.ctx?.channel()
+                    if (channel == null) {
+                        writePromise.completeExceptionally(StreamNotActiveException())
+                        return CompletableFuture.failedFuture(StreamNotActiveException())
+                    }
+                    val ret = CompletableFuture<Boolean>()
+                    channel.eventLoop().execute {
+                        channel.writeAndFlush(message).forwardTo(writePromise)
+                        ret.complete(channel.isWritable)
+                    }
+                    return ret
+                }
+
+            }
+        }
+    }
+}

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriter.kt
@@ -29,9 +29,14 @@ fun interface BackpressureAwareAsyncWriter {
                         return CompletableFuture.failedFuture(StreamNotActiveException())
                     }
                     val ret = CompletableFuture<Boolean>()
-                    channel.eventLoop().execute {
-                        channel.writeAndFlush(message).forwardTo(writePromise)
-                        ret.complete(channel.isWritable)
+                    try {
+                        channel.eventLoop().execute {
+                            channel.writeAndFlush(message).forwardTo(writePromise)
+                            ret.complete(channel.isWritable)
+                        }
+                    } catch (e: Exception) {
+                        ret.completeExceptionally(e)
+                        writePromise.completeExceptionally(e)
                     }
                     return ret
                 }

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriter.kt
@@ -35,7 +35,6 @@ fun interface BackpressureAwareAsyncWriter {
                     }
                     return ret
                 }
-
             }
         }
     }

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
@@ -3,11 +3,28 @@ package io.libp2p.etc.util
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
+/**
+ * Outbound message together with the promise that should be completed when the write finishes.
+ */
 data class MessageAndPromise(
     val messagePayload: Any,
     val writePromise: CompletableFuture<Unit>,
 )
 
+/**
+ * Drains outbound messages while respecting channel backpressure.
+ *
+ * The pump is driven by two external signals: [onNewOutboundData] tells it that the supplier may
+ * now have another message, and [onChannelWritabilityChanged] tells it whether polling new messages
+ * is currently allowed. Both methods are synchronized and may be called from different threads.
+ *
+ * [messageSupplier] returns the next already-consumed outbound message, or `null` when no message is
+ * ready. Once a non-null message is returned, the pump writes it even if channel writability changes
+ * to false before the supplier future completes. Backpressure only prevents polling the next message.
+ *
+ * [messageWriter] writes one supplied message and completes with the channel writability observed
+ * after that write was scheduled.
+ */
 class BackpressureAwarePump(
     private val messageWriter: BackpressureAwareAsyncWriter,
     private val messageSupplier: () -> CompletionStage<MessageAndPromise?>
@@ -23,7 +40,7 @@ class BackpressureAwarePump(
     private var outboundDataGeneration = 0L
 
     /**
-     * Notified when channel writability changes
+     * Notifies the pump that channel writability changed.
      */
     @Synchronized
     fun onChannelWritabilityChanged(isWritable: Boolean) {
@@ -34,7 +51,7 @@ class BackpressureAwarePump(
     }
 
     /**
-     * Notified when new outbound data is ready to be sent
+     * Notifies the pump that outbound data may now be available from [messageSupplier].
      */
     @Synchronized
     fun onNewOutboundData() {

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
@@ -1,0 +1,97 @@
+package io.libp2p.etc.util
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+data class MessageAndPromise(
+    val messagePayload: Any,
+    val writePromise: CompletableFuture<Unit>,
+)
+
+class BackpressureAwarePump(
+    private val messageWriter: BackpressureAwareAsyncWriter,
+    private val messageSupplier: () -> CompletionStage<MessageAndPromise?>
+) {
+    private enum class State {
+        IDLE,
+        RUNNING,
+        BLOCKED
+    }
+
+    private var state = State.IDLE
+    private var channelWritable = true
+    private var outboundDataGeneration = 0L
+
+    /**
+     * Notified when channel writability changes
+     */
+    @Synchronized
+    fun onChannelWritabilityChanged(isWritable: Boolean) {
+        channelWritable = isWritable
+        if (isWritable && state == State.BLOCKED) {
+            takeNextMessage()
+        }
+    }
+
+    /**
+     * Notified when new outbound data is ready to be sent
+     */
+    @Synchronized
+    fun onNewOutboundData() {
+        outboundDataGeneration++
+        if (state == State.IDLE && channelWritable) {
+            takeNextMessage()
+        } else if (state == State.IDLE) {
+            state = State.BLOCKED
+        }
+    }
+
+    @Synchronized
+    private fun takeNextMessage() {
+        state = State.RUNNING
+        val generationAtStart = outboundDataGeneration
+        messageSupplier().whenComplete { message: MessageAndPromise?, error: Throwable? ->
+            onMessageTaken(message, error, generationAtStart)
+        }
+    }
+
+    @Synchronized
+    private fun onMessageTaken(
+        message: MessageAndPromise?,
+        error: Throwable?,
+        generationAtStart: Long
+    ) {
+        when {
+            error != null -> state = State.IDLE
+            message != null -> writeMessage(message)
+            outboundDataGeneration != generationAtStart && channelWritable -> takeNextMessage()
+            outboundDataGeneration != generationAtStart -> state = State.BLOCKED
+            else -> state = State.IDLE
+        }
+    }
+
+    @Synchronized
+    private fun writeMessage(message: MessageAndPromise) {
+        messageWriter.write(message.messagePayload, message.writePromise)
+            .whenComplete { isWritable: Boolean, error: Throwable? ->
+                onMessageWritten(isWritable, error)
+            }
+    }
+
+    @Synchronized
+    private fun onMessageWritten(
+        isWritable: Boolean,
+        error: Throwable?
+    ) {
+        when {
+            error != null -> state = State.IDLE
+            !isWritable -> {
+                channelWritable = false
+                state = State.BLOCKED
+            }
+
+            channelWritable -> takeNextMessage()
+            else -> state = State.BLOCKED
+        }
+    }
+}

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
@@ -90,19 +90,19 @@ class BackpressureAwarePump(
     @Synchronized
     private fun writeMessage(message: MessageAndPromise) {
         messageWriter.write(message.messagePayload, message.writePromise)
-            .whenComplete { isWritable: Boolean, error: Throwable? ->
+            .whenComplete { isWritable: Boolean?, error: Throwable? ->
                 onMessageWritten(isWritable, error)
             }
     }
 
     @Synchronized
     private fun onMessageWritten(
-        isWritable: Boolean,
+        isWritable: Boolean?,
         error: Throwable?
     ) {
         when {
             error != null -> state = State.IDLE
-            !isWritable -> {
+            isWritable == false -> {
                 channelWritable = false
                 state = State.BLOCKED
             }

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/BackpressureAwarePump.kt
@@ -56,10 +56,12 @@ class BackpressureAwarePump(
     @Synchronized
     fun onNewOutboundData() {
         outboundDataGeneration++
-        if (state == State.IDLE && channelWritable) {
-            takeNextMessage()
-        } else if (state == State.IDLE) {
-            state = State.BLOCKED
+        if (state == State.IDLE) {
+            if (channelWritable) {
+                takeNextMessage()
+            } else {
+                state = State.BLOCKED
+            }
         }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -103,15 +103,6 @@ abstract class P2PService(
             }
         }
 
-        /**
-         * Writes message immediately.
-         * To respect stream backpressure it is recommended to use [backpressureAwarePump] mechanism
-         */
-        fun writeAndFlush(msg: Any): CompletableFuture<Unit> =
-            ctx?.writeAndFlush(msg)?.toVoidCompletableFuture()
-                ?: CompletableFuture.failedFuture(StreamNotActiveException())
-
-
         override fun exceptionCaught(ctx: ChannelHandlerContext?, cause: Throwable) {
             runOnEventThread(peerHandler) {
                 streamException(this, cause)
@@ -149,7 +140,7 @@ abstract class P2PService(
             }
         )
 
-        open fun writeAndFlush(msg: Any): CompletableFuture<Unit> = streamHandler.writeAndFlush(msg)
+        open fun writeAndFlush(msg: Any): CompletableFuture<Unit> = streamHandler.ctx!!.writeAndFlush(msg).toVoidCompletableFuture()
         open fun isActive() = streamHandler.ctx != null
         open fun getInboundHandler(): StreamHandler? = streamHandler
         open fun getOutboundHandler(): StreamHandler? = streamHandler
@@ -195,12 +186,6 @@ abstract class P2PService(
     }
 
     protected open fun createPeerHandler(streamHandler: StreamHandler) = PeerHandler(streamHandler)
-
-    /**
-     * Callback notifies that a stream's outbound writability changed.
-     * Invoked on the service event thread.
-     */
-    protected open fun streamWritabilityChanged(stream: StreamHandler) {}
 
     protected open fun streamActive(stream: StreamHandler) {
         if (stream.aborted) return

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -1,11 +1,8 @@
 package io.libp2p.etc.util
 
-import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
-import io.libp2p.core.StreamNotActiveException
-import io.libp2p.etc.types.forwardTo
 import io.libp2p.etc.types.submitAsync
 import io.libp2p.etc.types.toVoidCompletableFuture
 import io.netty.channel.ChannelHandlerContext
@@ -134,8 +131,8 @@ abstract class P2PService(
         private val backpressureAwarePump = BackpressureAwarePump(
             messageWriter = BackpressureAwareAsyncWriter.createFromStreamHandler(this),
             messageSupplier = {
-                submitOnEventThread() {
-                    maybeTakeOutboundMessage(this)
+                submitOnEventThread {
+                    pollOutboundMessage(this)
                 }
             }
         )
@@ -212,14 +209,21 @@ abstract class P2PService(
         onInbound(stream.getPeerHandler(), msg)
     }
 
-    protected fun notifyWriteDataAvailable(peer: PeerHandler) {
+    /**
+     * Notifies the service that outbound data is ready for [peer].
+     * May be called from any thread; the message will be polled later via [pollOutboundMessage]
+     * on the service event thread when the peer's outbound channel is writable.
+     */
+    protected fun notifyOutboundDataAvailable(peer: PeerHandler) {
         peer.onNewOutboundData()
     }
 
     /**
-     * Invoked on event thread
+     * Invoked on event thread to poll the next outbound message for [peer].
+     * The returned message is considered consumed and will be written exactly once.
+     * Return `null` when there is no outbound message ready for this peer.
      */
-    protected abstract fun maybeTakeOutboundMessage(peer: PeerHandler): MessageAndPromise?
+    protected abstract fun pollOutboundMessage(peer: PeerHandler): MessageAndPromise?
 
     /**
      * Callback notifies that the peer is active and ready for writing data

--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PService.kt
@@ -1,8 +1,11 @@
 package io.libp2p.etc.util
 
+import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
+import io.libp2p.core.StreamNotActiveException
+import io.libp2p.etc.types.forwardTo
 import io.libp2p.etc.types.submitAsync
 import io.libp2p.etc.types.toVoidCompletableFuture
 import io.netty.channel.ChannelHandlerContext
@@ -87,6 +90,11 @@ abstract class P2PService(
                 streamActive(this)
             }
         }
+
+        override fun channelWritabilityChanged(ctx: ChannelHandlerContext) {
+            peerHandler?.onStreamWriteabilityChanged(this, ctx.channel().isWritable)
+        }
+
         override fun channelUnregistered(ctx: ChannelHandlerContext?) {
             closed = true
             runOnEventThread(peerHandler) {
@@ -94,6 +102,15 @@ abstract class P2PService(
                 streamDisconnected(this)
             }
         }
+
+        /**
+         * Writes message immediately.
+         * To respect stream backpressure it is recommended to use [backpressureAwarePump] mechanism
+         */
+        fun writeAndFlush(msg: Any): CompletableFuture<Unit> =
+            ctx?.writeAndFlush(msg)?.toVoidCompletableFuture()
+                ?: CompletableFuture.failedFuture(StreamNotActiveException())
+
 
         override fun exceptionCaught(ctx: ChannelHandlerContext?, cause: Throwable) {
             runOnEventThread(peerHandler) {
@@ -123,10 +140,28 @@ abstract class P2PService(
      */
     open inner class PeerHandler(val streamHandler: StreamHandler) {
         open val peerId = streamHandler.stream.remotePeerId()
-        open fun writeAndFlush(msg: Any): CompletableFuture<Unit> = streamHandler.ctx!!.writeAndFlush(msg).toVoidCompletableFuture()
+        private val backpressureAwarePump = BackpressureAwarePump(
+            messageWriter = BackpressureAwareAsyncWriter.createFromStreamHandler(this),
+            messageSupplier = {
+                submitOnEventThread() {
+                    maybeTakeOutboundMessage(this)
+                }
+            }
+        )
+
+        open fun writeAndFlush(msg: Any): CompletableFuture<Unit> = streamHandler.writeAndFlush(msg)
         open fun isActive() = streamHandler.ctx != null
         open fun getInboundHandler(): StreamHandler? = streamHandler
         open fun getOutboundHandler(): StreamHandler? = streamHandler
+
+        internal fun onStreamWriteabilityChanged(streamHandler: StreamHandler, isWriteable: Boolean) {
+            if (streamHandler == getOutboundHandler()) {
+                backpressureAwarePump.onChannelWritabilityChanged(isWriteable)
+            }
+        }
+        internal fun onNewOutboundData() {
+            backpressureAwarePump.onNewOutboundData()
+        }
         override fun toString(): String {
             return "PeerHandler(peerId=$peerId, stream=${streamHandler.stream})"
         }
@@ -161,6 +196,12 @@ abstract class P2PService(
 
     protected open fun createPeerHandler(streamHandler: StreamHandler) = PeerHandler(streamHandler)
 
+    /**
+     * Callback notifies that a stream's outbound writability changed.
+     * Invoked on the service event thread.
+     */
+    protected open fun streamWritabilityChanged(stream: StreamHandler) {}
+
     protected open fun streamActive(stream: StreamHandler) {
         if (stream.aborted) return
         activePeersMutable += stream.getPeerHandler()
@@ -185,6 +226,15 @@ abstract class P2PService(
         if (stream.aborted) return
         onInbound(stream.getPeerHandler(), msg)
     }
+
+    protected fun notifyWriteDataAvailable(peer: PeerHandler) {
+        peer.onNewOutboundData()
+    }
+
+    /**
+     * Invoked on event thread
+     */
+    protected abstract fun maybeTakeOutboundMessage(peer: PeerHandler): MessageAndPromise?
 
     /**
      * Callback notifies that the peer is active and ready for writing data

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -345,7 +345,7 @@ abstract class AbstractRouter(
     protected fun getTopicPeers(topic: Topic) = peersTopics.getBySecond(topic)
 
     override fun pollOutboundMessage(peer: PeerHandler): MessageAndPromise? {
-        return pendingOutboundMessages[peer]?.removeFirst()
+        return pendingOutboundMessages[peer]?.pollFirst()
     }
 
     override fun subscribe(vararg topics: Topic) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -1,6 +1,7 @@
 package io.libp2p.pubsub
 
 import io.libp2p.core.BadPeerException
+import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.ValidationResult
@@ -314,7 +315,9 @@ abstract class AbstractRouter(
     override fun onPeerDisconnected(peer: PeerHandler) {
         super.onPeerDisconnected(peer)
         peersTopics.removeAllByFirst(peer)
-        pendingOutboundMessages.remove(peer)
+        pendingOutboundMessages.remove(peer)?.forEach {
+            it.writePromise.completeExceptionally(ConnectionClosedException())
+        }
     }
 
     override fun onPeerWireException(peer: PeerHandler?, cause: Throwable) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -5,6 +5,7 @@ import io.libp2p.core.PeerId
 import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.*
+import io.libp2p.etc.util.MessageAndPromise
 import io.libp2p.etc.util.P2PServiceSemiDuplex
 import io.libp2p.etc.util.netty.protobuf.LimitedProtobufVarint32FrameDecoder
 import io.netty.channel.ChannelHandler
@@ -13,6 +14,7 @@ import io.netty.handler.codec.protobuf.ProtobufEncoder
 import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender
 import org.slf4j.LoggerFactory
 import pubsub.pb.Rpc
+import java.util.ArrayDeque
 import java.util.Collections.singletonList
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -48,6 +50,7 @@ abstract class AbstractRouter(
     protected open val subscribedTopics = linkedSetOf<Topic>()
     protected open val pendingRpcParts = PendingRpcPartsMap<RpcPartsQueue> { DefaultRpcPartsQueue() }
     protected open val pendingMessagePromises = MultiSet<PeerHandler, CompletableFuture<Unit>>()
+    private val pendingOutboundMessages = mutableMapOf<PeerHandler, ArrayDeque<MessageAndPromise>>()
 
     protected class PendingRpcPartsMap<out TPartsQueue : RpcPartsQueue>(
         private val queueFactory: () -> TPartsQueue
@@ -101,10 +104,18 @@ abstract class AbstractRouter(
 
     protected fun flushPending(peer: PeerHandler) {
         val peerMessages = pendingRpcParts.popQueue(peer).takeMerged()
-        val allSendPromise = peerMessages.map { send(peer, it) }.thenApplyAll { }
+        val messageAndPromises = peerMessages.map { message ->
+            MessageAndPromise(message, CompletableFuture())
+        }
+        val allSendPromise = messageAndPromises.map { it.writePromise }.thenApplyAll { }
         pendingMessagePromises.removeAll(peer)?.forEach {
             allSendPromise.forward(it)
         }
+        pendingOutboundMessages
+            .getOrPut(peer) { ArrayDeque() }
+            .addAll(messageAndPromises)
+
+        notifyOutboundDataAvailable(peer)
     }
 
     override fun addPeer(peer: Stream) = addPeerWithDebugHandler(peer, null)
@@ -303,6 +314,7 @@ abstract class AbstractRouter(
     override fun onPeerDisconnected(peer: PeerHandler) {
         super.onPeerDisconnected(peer)
         peersTopics.removeAllByFirst(peer)
+        pendingOutboundMessages.remove(peer)
     }
 
     override fun onPeerWireException(peer: PeerHandler?, cause: Throwable) {
@@ -328,6 +340,10 @@ abstract class AbstractRouter(
     }
 
     protected fun getTopicPeers(topic: Topic) = peersTopics.getBySecond(topic)
+
+    override fun pollOutboundMessage(peer: PeerHandler): MessageAndPromise? {
+        return pendingOutboundMessages[peer]?.removeFirst()
+    }
 
     override fun subscribe(vararg topics: Topic) {
         runOnEventThread {

--- a/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwareAsyncWriterTest.kt
@@ -1,0 +1,51 @@
+package io.libp2p.etc.util
+
+import io.mockk.every
+import io.mockk.mockk
+import io.netty.channel.Channel
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.EventLoop
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.RejectedExecutionException
+
+class BackpressureAwareAsyncWriterTest {
+
+    @Test
+    fun `completes both futures when event loop rejects write task`() {
+        val rejection = RejectedExecutionException("event loop is shutting down")
+        val eventLoop = mockk<EventLoop>()
+        val channel = mockk<Channel>()
+        val ctx = mockk<ChannelHandlerContext>()
+        val streamHandler = mockk<P2PService.StreamHandler>()
+        val peerHandler = mockk<P2PService.PeerHandler>()
+        val writePromise = CompletableFuture<Unit>()
+
+        every { peerHandler.getOutboundHandler() } returns streamHandler
+        every { streamHandler.ctx } returns ctx
+        every { ctx.channel() } returns channel
+        every { channel.eventLoop() } returns eventLoop
+        every { eventLoop.execute(any()) } throws rejection
+
+        val result = BackpressureAwareAsyncWriter
+            .createFromStreamHandler(peerHandler)
+            .write("message", writePromise)
+            .toCompletableFuture()
+
+        assertThat(result).isCompletedExceptionally
+        assertThat(writePromise).isCompletedExceptionally
+        assertThat(result.exception()).isSameAs(rejection)
+        assertThat(writePromise.exception()).isSameAs(rejection)
+    }
+
+    private fun CompletableFuture<*>.exception(): Throwable {
+        return try {
+            get()
+            throw AssertionError("Future completed successfully")
+        } catch (e: ExecutionException) {
+            e.cause!!
+        }
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwarePumpTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwarePumpTest.kt
@@ -14,8 +14,8 @@ class BackpressureAwarePumpTest {
         val writes = ConcurrentLinkedQueue<Pair<Any, CompletableFuture<Boolean>>>()
         val writer =
             BackpressureAwarePump(
-                { message ->
-                    CompletableFuture<Boolean>().also { writes.add(message.message to it) }
+                { message, _ ->
+                    CompletableFuture<Boolean>().also { writes.add(message to it) }
                 },
                 {
                     CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
@@ -48,7 +48,7 @@ class BackpressureAwarePumpTest {
         val writes = ConcurrentLinkedQueue<CompletableFuture<Boolean>>()
         val writer =
             BackpressureAwarePump(
-                {
+                { _, _ ->
                     CompletableFuture<Boolean>().also(writes::add)
                 },
                 {
@@ -72,7 +72,7 @@ class BackpressureAwarePumpTest {
         val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
         val writer =
             BackpressureAwarePump(
-                { CompletableFuture.completedFuture(true) },
+                { _, _ -> CompletableFuture.completedFuture(true) },
                 {
                     CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
                 }
@@ -92,8 +92,8 @@ class BackpressureAwarePumpTest {
         val writes = ConcurrentLinkedQueue<Any>()
         val writer =
             BackpressureAwarePump(
-                { message ->
-                    writes.add(message.message)
+                { message, _ ->
+                    writes.add(message)
                     CompletableFuture<Boolean>()
                 },
                 {
@@ -113,7 +113,7 @@ class BackpressureAwarePumpTest {
         val writes = ConcurrentLinkedQueue<CompletableFuture<Boolean>>()
         val writer =
             BackpressureAwarePump(
-                {
+                { _, _ ->
                     CompletableFuture<Boolean>().also(writes::add)
                 },
                 {
@@ -136,7 +136,7 @@ class BackpressureAwarePumpTest {
         val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
         val writer =
             BackpressureAwarePump(
-                { CompletableFuture.completedFuture(true) },
+                { _, _ -> CompletableFuture.completedFuture(true) },
                 {
                     CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
                 }
@@ -158,7 +158,7 @@ class BackpressureAwarePumpTest {
         val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
         val writer =
             BackpressureAwarePump(
-                { CompletableFuture.completedFuture(true) },
+                { _, _ -> CompletableFuture.completedFuture(true) },
                 {
                     CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
                 }

--- a/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwarePumpTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwarePumpTest.kt
@@ -182,5 +182,25 @@ class BackpressureAwarePumpTest {
         assertThat(suppliedMessages).hasSize(1)
     }
 
+    @Test
+    fun `recovers after writer failure`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writer =
+            BackpressureAwarePump(
+                { _, _ ->
+                    CompletableFuture.failedFuture(IllegalStateException("write failed"))
+                },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onNewOutboundData()
+        suppliedMessages.remove().complete(message("first"))
+        writer.onNewOutboundData()
+
+        assertThat(suppliedMessages).hasSize(1)
+    }
+
     private fun message(value: String) = MessageAndPromise(value, CompletableFuture())
 }

--- a/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwarePumpTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/etc/util/BackpressureAwarePumpTest.kt
@@ -1,0 +1,186 @@
+package io.libp2p.etc.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class BackpressureAwarePumpTest {
+    @Test
+    fun `drains messages until the supplier is empty`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writes = ConcurrentLinkedQueue<Pair<Any, CompletableFuture<Boolean>>>()
+        val writer =
+            BackpressureAwarePump(
+                { message ->
+                    CompletableFuture<Boolean>().also { writes.add(message.message to it) }
+                },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onNewOutboundData()
+        assertThat(suppliedMessages).hasSize(1)
+
+        suppliedMessages.remove().complete(message("first"))
+        assertThat(writes.map { it.first }).containsExactly("first")
+
+        writes.remove().second.complete(true)
+        assertThat(suppliedMessages).hasSize(1)
+
+        suppliedMessages.remove().complete(message("second"))
+        assertThat(writes.map { it.first }).containsExactly("second")
+
+        writes.remove().second.complete(true)
+        suppliedMessages.remove().complete(null)
+        assertThat(suppliedMessages).isEmpty()
+
+        writer.onNewOutboundData()
+        assertThat(suppliedMessages).hasSize(1)
+    }
+
+    @Test
+    fun `waits for channel availability after backpressure`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writes = ConcurrentLinkedQueue<CompletableFuture<Boolean>>()
+        val writer =
+            BackpressureAwarePump(
+                {
+                    CompletableFuture<Boolean>().also(writes::add)
+                },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onNewOutboundData()
+        suppliedMessages.remove().complete(message("message"))
+        writes.remove().complete(false)
+
+        writer.onNewOutboundData()
+        assertThat(suppliedMessages).isEmpty()
+
+        writer.onChannelWritabilityChanged(true)
+        assertThat(suppliedMessages).hasSize(1)
+    }
+
+    @Test
+    fun `does not poll while the channel is not writable`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writer =
+            BackpressureAwarePump(
+                { CompletableFuture.completedFuture(true) },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onChannelWritabilityChanged(false)
+        writer.onNewOutboundData()
+        assertThat(suppliedMessages).isEmpty()
+
+        writer.onChannelWritabilityChanged(true)
+        assertThat(suppliedMessages).hasSize(1)
+    }
+
+    @Test
+    fun `writes a message taken while the channel becomes not writable`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writes = ConcurrentLinkedQueue<Any>()
+        val writer =
+            BackpressureAwarePump(
+                { message ->
+                    writes.add(message.message)
+                    CompletableFuture<Boolean>()
+                },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onNewOutboundData()
+        writer.onChannelWritabilityChanged(false)
+        suppliedMessages.remove().complete(message("message"))
+        assertThat(writes).containsExactly("message")
+    }
+
+    @Test
+    fun `stops draining when writability changes during a write`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writes = ConcurrentLinkedQueue<CompletableFuture<Boolean>>()
+        val writer =
+            BackpressureAwarePump(
+                {
+                    CompletableFuture<Boolean>().also(writes::add)
+                },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onNewOutboundData()
+        suppliedMessages.remove().complete(message("message"))
+        writer.onChannelWritabilityChanged(false)
+        writes.remove().complete(true)
+        assertThat(suppliedMessages).isEmpty()
+
+        writer.onChannelWritabilityChanged(true)
+        assertThat(suppliedMessages).hasSize(1)
+    }
+
+    @Test
+    fun `does not lose data notification while a poll is in flight`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writer =
+            BackpressureAwarePump(
+                { CompletableFuture.completedFuture(true) },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+
+        writer.onNewOutboundData()
+        val firstPoll = suppliedMessages.remove()
+        writer.onNewOutboundData()
+
+        firstPoll.complete(null)
+        assertThat(suppliedMessages).hasSize(1)
+
+        suppliedMessages.remove().complete(null)
+        assertThat(suppliedMessages).isEmpty()
+    }
+
+    @Test
+    fun `serializes notifications from different threads`() {
+        val suppliedMessages = ConcurrentLinkedQueue<CompletableFuture<MessageAndPromise?>>()
+        val writer =
+            BackpressureAwarePump(
+                { CompletableFuture.completedFuture(true) },
+                {
+                    CompletableFuture<MessageAndPromise?>().also(suppliedMessages::add)
+                }
+            )
+        writer.onNewOutboundData()
+        val firstPoll = suppliedMessages.remove()
+
+        val executor = Executors.newFixedThreadPool(8)
+        try {
+            repeat(1_000) {
+                executor.execute(writer::onNewOutboundData)
+            }
+            executor.shutdown()
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue()
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertThat(suppliedMessages).isEmpty()
+        firstPoll.complete(null)
+        assertThat(suppliedMessages).hasSize(1)
+    }
+
+    private fun message(value: String) = MessageAndPromise(value, CompletableFuture())
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -399,6 +399,34 @@ abstract class PubsubRouterTest(val routerFactory: DeterministicFuzzRouterFactor
     }
 
     @Test
+    fun `publish waits until outbound channel becomes writable`() {
+        val fuzz = DeterministicFuzz()
+
+        val router1 = fuzz.createTestRouter(routerFactory)
+        val router2 = fuzz.createTestRouter(routerFactory)
+        router2.router.subscribe("topic1")
+
+        val connection = router1.connectSemiDuplex(router2, LogLevel.ERROR, LogLevel.ERROR)
+        val router1OutboundChannel = connection.conn1.ch1
+        router1OutboundChannel.setWritableForTest(false)
+        assertThat(router1OutboundChannel.isWritable).isFalse()
+
+        val msg = newMessage("topic1", 1L, "Hello".toByteArray())
+        val publishFut = router1.router.publish(msg)
+
+        assertThat(publishFut).isNotDone()
+        assertThat(router2.inboundMessages.poll(100, TimeUnit.MILLISECONDS)).isNull()
+
+        router1OutboundChannel.setWritableForTest(true)
+        router1OutboundChannel.runPendingTasks()
+
+        publishFut.get(5, TimeUnit.SECONDS)
+        assertThat(router2.inboundMessages.poll(5, TimeUnit.SECONDS)).isEqualTo(msg)
+        assertThat(router1.inboundMessages).isEmpty()
+        assertThat(router2.inboundMessages).isEmpty()
+    }
+
+    @Test
     fun validateTest() {
         val fuzz = DeterministicFuzz()
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -414,6 +414,7 @@ abstract class PubsubRouterTest(val routerFactory: DeterministicFuzzRouterFactor
         val msg = newMessage("topic1", 1L, "Hello".toByteArray())
         val publishFut = router1.router.publish(msg)
 
+        router1OutboundChannel.runPendingTasks()
         assertThat(publishFut).isNotDone()
         assertThat(router2.inboundMessages.poll(100, TimeUnit.MILLISECONDS)).isNull()
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRouterTest.kt
@@ -550,4 +550,27 @@ abstract class PubsubRouterTest(val routerFactory: DeterministicFuzzRouterFactor
         assertThat(peerTopics1SetIt.next()).isEqualTo("topic1")
         assertThat(peerTopics1SetIt.hasNext()).isFalse()
     }
+
+    @Test
+    fun `queued publish completes when peer disconnects`() {
+        val fuzz = DeterministicFuzz()
+
+        val router1 = fuzz.createTestRouter(routerFactory)
+        val router2 = fuzz.createTestRouter(routerFactory)
+        router2.router.subscribe("topic1")
+
+        val connection = router1.connectSemiDuplex(router2, LogLevel.ERROR, LogLevel.ERROR)
+        val router1OutboundChannel = connection.conn1.ch1
+        router1OutboundChannel.setWritableForTest(false)
+
+        val msg = newMessage("topic1", 2L, "Hello".toByteArray())
+        val publishFut = router1.router.publish(msg)
+        router1OutboundChannel.runPendingTasks()
+        assertThat(publishFut).isNotDone()
+
+        connection.disconnect()
+        router1OutboundChannel.runPendingTasks()
+
+        assertThat(publishFut).isDone()
+    }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -1458,6 +1458,20 @@ class GossipV1_1Tests : GossipTestsBase() {
         assertEquals(expectedPublishedCount, publishedCount)
     }
 
+    @Test
+    fun `pollOutboundMessages should return null when empty instead of exception`() {
+        val test = TwoRoutersTest()
+        val peer = test.mockRouter.peers.single()
+        test.connection.conn2.ch1.setWritableForTest(false)
+
+        assertNull(test.mockRouter.pollOutboundMessage(peer))
+
+        test.mockRouter.enqueuePublishForTest(peer, newProtoMessage("topic1", 0L, "Hello".toByteArray()))
+
+        assertNotNull(test.mockRouter.pollOutboundMessage(peer))
+        assertNull(test.mockRouter.pollOutboundMessage(peer))
+    }
+
     private fun createGraftMessage(topic: String): Rpc.RPC {
         return Rpc.RPC.newBuilder().setControl(
             Rpc.ControlMessage.newBuilder().addGraft(

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub
 
+import io.libp2p.etc.util.MessageAndPromise
 import pubsub.pb.Rpc
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.CompletableFuture
@@ -51,6 +52,15 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
     override fun onInbound(peer: PeerHandler, msg: Any) {
         super.onInbound(peer, msg)
         inboundMessages += msg as Rpc.RPC
+    }
+
+    public override fun pollOutboundMessage(peer: PeerHandler): MessageAndPromise? {
+        return super.pollOutboundMessage(peer)
+    }
+
+    fun enqueuePublishForTest(peer: PeerHandler, msg: Rpc.Message) {
+        pendingRpcParts.getQueue(peer).addPublish(msg)
+        flushPending(peer)
     }
 
     override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> = CompletableFuture.completedFuture(null)

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TestChannel.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TestChannel.kt
@@ -63,6 +63,12 @@ class TestChannel(
         return CompletableFuture.supplyAsync({ task(this) }, executor)
     }
 
+    @Suppress("DEPRECATION")
+    fun setWritableForTest(isWritable: Boolean) {
+        unsafe().outboundBuffer().setUserDefinedWritability(1, isWritable)
+        pipeline().fireChannelWritabilityChanged()
+    }
+
     @Synchronized
     fun connect(other: TestChannel) {
         link = other

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TestChannel.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/tools/TestChannel.kt
@@ -9,6 +9,7 @@ import io.libp2p.etc.util.netty.nettyInitializer
 import io.libp2p.transport.implementation.ConnectionOverNetty
 import io.netty.channel.ChannelHandler
 import io.netty.channel.ChannelId
+import io.netty.channel.EventLoop
 import io.netty.channel.embedded.EmbeddedChannel
 import org.slf4j.LoggerFactory
 import java.net.InetSocketAddress
@@ -61,6 +62,16 @@ class TestChannel(
 
     fun <TRet> onChannelThread(task: (EmbeddedChannel) -> TRet): CompletableFuture<TRet> {
         return CompletableFuture.supplyAsync({ task(this) }, executor)
+    }
+
+    override fun eventLoop(): EventLoop {
+        val delegate = super.eventLoop()
+        return object : EventLoop by delegate {
+            override fun execute(command: Runnable) {
+                delegate.execute(command)
+                runPendingTasks()
+            }
+        }
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
This is alternative to #504 with narrower scope. 

This PR extracts generic outbound backpressure support into `P2PService`.

The main change is the new `BackpressureAwarePump`, which serializes outbound polling/writes across threads and pauses polling while the peer outbound channel is not writable. `P2PService` now exposes this through `notifyOutboundDataAvailable(peer)` and `pollOutboundMessage(peer)`.

Pubsub routers were wired through this new mechanism, and shared router tests now cover the basic backpressure behavior for both Flood and Gossip.

Note: the Gossip backpressure integration is intentionally very naive. It only stops polling new outbound RPCs while the channel is not writable; it does not provide bounded queues or prevent router-side buffer growth/overflow under sustained pressure.