### PR TITLE
close UDP channel immediately on cancellation (QUIC)

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -301,9 +301,11 @@ class QuicTransport(
         // (which runs a QUIC *server* codec), silently breaking the handshake. NAT-consistent
         // dialing for hole punching is handled separately by dialAsListener, which reuses the
         // listener socket directly.
-        val quicConnFuture: CompletableFuture<QuicChannel> = client.clone()
+        val udpBindFuture = client.clone()
             .handler(requestsHandler)
             .bind(InetSocketAddress(0))
+
+        val quicConnFuture: CompletableFuture<QuicChannel> = udpBindFuture
             .toCompletableFuture()
             .thenCompose { udpChannel ->
                 QuicChannel.newBootstrap(udpChannel)
@@ -394,11 +396,12 @@ class QuicTransport(
         // NetworkImpl.connect() cancels losing dial futures in the multi-address race. Cancelling
         // this dependent future does NOT propagate upstream to quicConnFuture, so if the handshake
         // later completes, the thenApply body above is skipped and the established QuicChannel is
-        // never registered, handed to the caller, nor closed. Close it explicitly on cancellation
-        // so neither it nor its underlying datagram channel is leaked (mirrors the TCP transport).
+        // never registered, handed to the caller, nor closed. Close the datagram channel immediately
+        // and also close any QuicChannel that won the completion race (mirrors the TCP transport).
         connectionFuture.whenComplete { _, _ ->
             if (connectionFuture.isCancelled) {
                 quicConnFuture.thenAccept { it.close() }
+                udpBindFuture.channel().close()
             }
         }
         return connectionFuture

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -1146,8 +1146,7 @@ public class QuicServerTestJava {
     try (DatagramSocket blackhole =
         new DatagramSocket(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))) {
       blackhole.setSoTimeout(5_000);
-      String targetAddress =
-          "/ip4/127.0.0.1/udp/" + blackhole.getLocalPort() + "/quic-v1";
+      String targetAddress = "/ip4/127.0.0.1/udp/" + blackhole.getLocalPort() + "/quic-v1";
 
       CompletableFuture<Connection> dial =
           clientTransport.dial(new Multiaddr(targetAddress), conn -> {}, null);

--- a/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
+++ b/libp2p/src/test/java/io/libp2p/transport/quic/QuicServerTestJava.java
@@ -34,6 +34,12 @@ import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.handler.codec.quic.QuicStreamResetException;
 import io.netty.handler.logging.LogLevel;
+import java.net.BindException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -1128,5 +1134,58 @@ public class QuicServerTestJava {
 
     clientTransport.close().get(5, TimeUnit.SECONDS);
     serverTransport.close().get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void cancelledPendingDialPromptlyReleasesUdpSocket() throws Exception {
+    Pair<PrivKey, PubKey> clientKeyPair = KeyKt.generateKeyPair(KeyType.ED25519);
+    List<io.libp2p.core.multistream.ProtocolBinding<?>> emptyProtocols = new ArrayList<>();
+    QuicTransport clientTransport = QuicTransport.ECDSA(clientKeyPair.component1(), emptyProtocols);
+    clientTransport.initialize();
+
+    try (DatagramSocket blackhole =
+        new DatagramSocket(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))) {
+      blackhole.setSoTimeout(5_000);
+      String targetAddress =
+          "/ip4/127.0.0.1/udp/" + blackhole.getLocalPort() + "/quic-v1";
+
+      CompletableFuture<Connection> dial =
+          clientTransport.dial(new Multiaddr(targetAddress), conn -> {}, null);
+
+      DatagramPacket firstPacket = new DatagramPacket(new byte[2_048], 2_048);
+      blackhole.receive(firstPacket);
+      int clientPort = firstPacket.getPort();
+
+      Assertions.assertTrue(dial.cancel(true));
+
+      long releaseMillis = awaitUdpPortReusable(clientPort, Duration.ofSeconds(6));
+      System.out.println(
+          "Cancelled pending QUIC dial released UDP port after " + releaseMillis + " ms");
+      Assertions.assertTrue(
+          releaseMillis < Duration.ofSeconds(5).toMillis(),
+          "cancelled pending QUIC dial did not promptly release its UDP socket");
+    } finally {
+      clientTransport.close().get(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private static long awaitUdpPortReusable(int port, Duration timeout) throws Exception {
+    long startedAt = System.nanoTime();
+    long deadline = startedAt + timeout.toNanos();
+    BindException lastBindFailure = null;
+
+    while (System.nanoTime() < deadline) {
+      try (DatagramSocket probe = new DatagramSocket(null)) {
+        probe.setReuseAddress(false);
+        probe.bind(new InetSocketAddress(port));
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+      } catch (BindException e) {
+        lastBindFailure = e;
+        Thread.sleep(50);
+      }
+    }
+
+    throw new AssertionError(
+        "UDP port " + port + " was not released within " + timeout, lastBindFailure);
   }
 }


### PR DESCRIPTION
- cancelled QUIC dials retained UDP sockets for 30,022 ms, not indefinitely.
- Cause: cancellation waited for the QUIC future instead of closing the parent UDP channel.
- Fix: QuicTransport.kt now closes that channel immediately.
- Added a blackhole regression test requiring release within 5 seconds.