### PR TITLE
Fix/510 outbound publish admission

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -71,9 +71,28 @@ abstract class AbstractRouter(
                 completedExceptionally(MessageAlreadySeenException("Msg: $msg"))
             } else {
                 messageValidator.validate(msg) // check ourselves not to be a bad peer
+                validateOutboundMessageSize(msg)
+                val publication = prepareOutboundPublish(msg)
                 seenMessages[msg] = Optional.of(ValidationResult.Valid)
-                broadcastOutbound(msg)
+                publication.publish()
             }
+        }
+    }
+
+    /**
+     * Checks that a locally originated message can be sent as a single outbound RPC.
+     *
+     * Called before any router state is mutated, so an oversized message is never retained: every
+     * publish attempt fails with [TooLargeMessageException] instead of the second and later attempts
+     * failing with [MessageAlreadySeenException].
+     */
+    protected open fun validateOutboundMessageSize(msg: PubsubMessage) {
+        val estimatedSize = estimateStandalonePublishRpcSize(msg.protobufMessage)
+        if (estimatedSize > maxMsgSize) {
+            throw TooLargeMessageException(
+                "Locally published message estimated serialized size $estimatedSize " +
+                    "exceeds max message size $maxMsgSize: $msg"
+            )
         }
     }
 
@@ -137,9 +156,27 @@ abstract class AbstractRouter(
     }
 
     /**
-     * Broadcasts to peers validated unseen messages received from api
+     * A locally originated message which passed outbound admission checks and is ready to be sent.
      */
-    protected abstract fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit>
+    protected fun interface OutboundPublish {
+        fun publish(): CompletableFuture<Unit>
+    }
+
+    /**
+     * Performs outbound admission checks for a validated unseen message received from api and
+     * selects the target peers.
+     *
+     * Implementations must not mutate router state on any path that can throw (e.g.
+     * [NoPeersForOutboundMessageException] when no peer is eligible), so a failed publish leaves
+     * nothing behind and can be retried. All sending, and all state changes that depend on the
+     * publish actually happening, belong in the returned [OutboundPublish].
+     *
+     * This retryability guarantee only covers admission failures raised here. Once
+     * [OutboundPublish.publish] has queued parts for sending, a later failure (e.g. a peer
+     * disconnecting, or every send failing) leaves the message in the seen cache, so it is not
+     * retryable.
+     */
+    protected abstract fun prepareOutboundPublish(msg: PubsubMessage): OutboundPublish
 
     /**
      * Broadcasts to peers validated unseen messages received from another peer

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -14,6 +14,15 @@ data class RpcPartsBatch(
 )
 
 /**
+ * Conservative upper bound for [message] serialized as a standalone publish RPC.
+ *
+ * This is the same estimate [DefaultRpcPartsQueue] accounts for when a publish part is queued, so
+ * callers can check whether a message can ever be sent before touching any queue.
+ */
+internal fun estimateStandalonePublishRpcSize(message: Rpc.Message): Int =
+    Rpc.RPC.newBuilder().addPublish(message).buildPartial().serializedSize
+
+/**
  * Accumulates outbound pubsub RPC parts before they are written to a peer.
  *
  * Implementations may decide how many queued parts can be sent in a single outbound RPC. For example,

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/flood/FloodRouter.kt
@@ -20,10 +20,10 @@ class FloodRouter(executor: ScheduledExecutorService = Executors.newSingleThread
 ) {
 
     // msg: validated unseen messages received from api
-    override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> {
+    override fun prepareOutboundPublish(msg: PubsubMessage) = OutboundPublish {
         val ret = broadcast(msg, null)
         flushAllPending()
-        return ret
+        ret
     }
 
     // msg: validated unseen messages received from wire

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -523,9 +523,7 @@ open class GossipRouter(
         flushAllPending()
     }
 
-    override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> {
-        msg.topics.forEach { lastPublished[it] = currentTimeSupplier() }
-
+    override fun prepareOutboundPublish(msg: PubsubMessage): OutboundPublish {
         val floodPublish = msg.size <= params.floodPublishMaxMessageSizeThreshold
 
         val peers =
@@ -535,24 +533,28 @@ open class GossipRouter(
                 selectPeersForOutboundBroadcasting(msg)
             }
 
-        mCache += msg
+        if (peers.isEmpty()) {
+            throw NoPeersForOutboundMessageException("No peers for message topics ${msg.topics} found")
+        }
 
-        return if (peers.isNotEmpty()) {
-            iDontWant(msg)
-            val publishedMessages = peers
-                .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
-                .map { submitPublishMessage(it, msg) }
-            if (publishedMessages.isEmpty()) {
-                // all peers have sent IDONTWANT for this message id
-                CompletableFuture.completedFuture(Unit)
-            } else {
-                flushAllPending()
-                anyComplete(publishedMessages)
-            }
+        return OutboundPublish { broadcastOutboundToPeers(msg, peers) }
+    }
+
+    private fun broadcastOutboundToPeers(msg: PubsubMessage, peers: List<PeerHandler>): CompletableFuture<Unit> {
+        msg.topics.forEach { lastPublished[it] = currentTimeSupplier() }
+        mCache += msg
+        iDontWant(msg)
+
+        val publishedMessages = peers
+            .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
+            .map { submitPublishMessage(it, msg) }
+
+        return if (publishedMessages.isEmpty()) {
+            // all peers have sent IDONTWANT for this message id
+            CompletableFuture.completedFuture(Unit)
         } else {
-            completedExceptionally(
-                NoPeersForOutboundMessageException("No peers for message topics ${msg.topics} found")
-            )
+            flushAllPending()
+            anyComplete(publishedMessages)
         }
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubStrictSignSpoofTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubStrictSignSpoofTest.kt
@@ -57,11 +57,11 @@ class PubsubStrictSignSpoofTest {
         seenMessages = LRUSeenCache(SimpleSeenCache(), 1000),
         messageValidator = SIGNATURE_ROUTER_VALIDATOR
     ) {
-        override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> {
+        override fun prepareOutboundPublish(msg: PubsubMessage) = OutboundPublish {
             val peers = msg.topics.flatMap { getTopicPeers(it) }.distinct()
             peers.forEach { submitPublishMessage(it, msg) }
             flushAllPending()
-            return CompletableFuture.completedFuture(null)
+            CompletableFuture.completedFuture(Unit)
         }
 
         override fun broadcastInbound(msgs: List<PubsubMessage>, receivedFrom: PeerHandler) {

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipTestsBase.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipTestsBase.kt
@@ -27,6 +27,12 @@ abstract class GossipTestsBase {
 
     protected fun getMessageId(msg: Rpc.Message): MessageId = msg.from.toWBytes() + msg.seqno.toWBytes()
 
+    protected fun standalonePublishRpcSize(msg: PubsubMessage): Int =
+        Rpc.RPC.newBuilder()
+            .addPublish(msg.protobufMessage)
+            .buildPartial()
+            .serializedSize
+
     class ManyRoutersTest(
         val mockRouterCount: Int = 10,
         val params: GossipParams = GossipParams(),

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_1Tests.kt
@@ -8,6 +8,7 @@ import io.libp2p.core.PeerId
 import io.libp2p.core.pubsub.*
 import io.libp2p.etc.types.*
 import io.libp2p.pubsub.MockRouter
+import io.libp2p.pubsub.NoPeersForOutboundMessageException
 import io.libp2p.pubsub.TooLargeMessageException
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.Unpooled
@@ -63,10 +64,7 @@ class GossipV1_1Tests : GossipTestsBase() {
     @Test
     fun `publishing too large message fails with TooLargeMessageException`() {
         val msg = newMessage("topic1", 0L, "too-large".toByteArray())
-        val standalonePublishSize = Rpc.RPC.newBuilder()
-            .addPublish(msg.protobufMessage)
-            .buildPartial()
-            .serializedSize
+        val standalonePublishSize = standalonePublishRpcSize(msg)
         val test = TwoRoutersTest(GossipParams(maxGossipMessageSize = standalonePublishSize - 1))
 
         test.mockRouter.subscribe("topic1")
@@ -76,6 +74,70 @@ class GossipV1_1Tests : GossipTestsBase() {
         assertThrows(TooLargeMessageException::class.java) {
             publishFuture.getX()
         }
+    }
+
+    @Test
+    fun `publishing too large message doesn't poison seen cache`() {
+        val msg = newMessage("topic1", 0L, "too-large".toByteArray())
+        val standalonePublishSize = standalonePublishRpcSize(msg)
+        val test = TwoRoutersTest(GossipParams(maxGossipMessageSize = standalonePublishSize - 1))
+
+        test.mockRouter.subscribe("topic1")
+
+        assertThrows(TooLargeMessageException::class.java) {
+            test.gossipRouter.publish(msg).getX()
+        }
+
+        // the failed publish must not be retained: the same message fails the same way
+        assertThrows(TooLargeMessageException::class.java) {
+            test.gossipRouter.publish(msg).getX()
+        }
+    }
+
+    @Test
+    fun `failed too large publish leaves no message in mCache`() {
+        val msg = newMessage("topic1", 0L, "too-large".toByteArray())
+        val standalonePublishSize = standalonePublishRpcSize(msg)
+        val test = TwoRoutersTest(GossipParams(maxGossipMessageSize = standalonePublishSize - 1))
+
+        test.mockRouter.subscribe("topic1")
+        test.mockRouter.inboundMessages.clear()
+
+        assertThrows(TooLargeMessageException::class.java) {
+            test.gossipRouter.publish(msg).getX()
+        }
+
+        assertNull(test.gossipRouter.mCache[msg.messageId])
+    }
+
+    @Test
+    fun `publishing message of exactly max size succeeds`() {
+        val msg = newMessage("topic1", 0L, "exact-fit".toByteArray())
+        val standalonePublishSize = standalonePublishRpcSize(msg)
+        val test = TwoRoutersTest(GossipParams(maxGossipMessageSize = standalonePublishSize))
+
+        test.mockRouter.subscribe("topic1")
+        test.gossipRouter.publish(msg).getX()
+
+        test.mockRouter.waitForMessage { it.publishCount > 0 }
+    }
+
+    @Test
+    fun `publishing without outbound peers is retryable`() {
+        val test = TwoRoutersTest()
+        val msg = newMessage("topic1", 0L, "no-peers".toByteArray())
+
+        // mockRouter is connected but not subscribed to topic1: no eligible peer
+        assertThrows(NoPeersForOutboundMessageException::class.java) {
+            test.gossipRouter.publish(msg).getX()
+        }
+        assertNull(test.gossipRouter.mCache[msg.messageId])
+
+        test.mockRouter.subscribe("topic1")
+
+        // the earlier failure must not be retained
+        test.gossipRouter.publish(msg).getX()
+        test.mockRouter.waitForMessage { it.publishCount > 0 }
     }
 
     @Test

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -66,7 +66,7 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
         notifyOutboundDataAvailable(peer)
     }
 
-    override fun broadcastOutbound(msg: PubsubMessage): CompletableFuture<Unit> = CompletableFuture.completedFuture(null)
+    override fun prepareOutboundPublish(msg: PubsubMessage) = OutboundPublish { CompletableFuture.completedFuture(Unit) }
     override fun broadcastInbound(msgs: List<PubsubMessage>, receivedFrom: PeerHandler) {}
     override fun processControl(ctrl: Rpc.ControlMessage, receivedFrom: PeerHandler) {}
     override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {}


### PR DESCRIPTION
Fixes #510.

`publish()` marked a message seen before outbound publication was known to be possible, so a failed publish could never be retried — the next attempt got `MessageAlreadySeenException`. For gossip, `mCache`, `lastPublished`, IDONTWANT and some peer queues had been mutated too, since the size limit was only enforced part-way through the per-peer submit loop.

Outbound publication is now two-phase:

1. **Admission** — message size is checked against `maxMsgSize` (`maxGossipMessageSize` for gossip) using the same estimate the outbound queue enforces, then `prepareOutboundPublish()` selects peers and throws if none is eligible. No router state is touched on either failing path.
2. **Execute** — only after the message is marked seen: `lastPublished`, `mCache`, IDONTWANT, per-peer queues, flush.

Result: an oversized message fails with `TooLargeMessageException` on every attempt, and a publish that failed only for lack of peers is publishable again once peers appear. The queue-level size guard stays as the safeguard for forwarded messages and control parts; inbound handling is unchanged.

### Breaking (advanced API)

`AbstractRouter.broadcastOutbound(msg): CompletableFuture<Unit>` is replaced by `AbstractRouter.prepareOutboundPublish(msg): OutboundPublish`. Users of `GossipRouterBuilder`, `GossipRouter` or `FloodRouter` are unaffected; direct `AbstractRouter` subclasses need:

```kotlin
override fun prepareOutboundPublish(msg: PubsubMessage) = OutboundPublish {
    /* previous broadcastOutbound body */
}
```

Throw from prepareOutboundPublish for conditions that make the message unpublishable at all.

### Other observable changes

- A publish that is both oversized and has no eligible peers now fails with TooLargeMessageException rather than NoPeersForOutboundMessageException.
- An oversized message whose peers had all sent IDONTWANT previously succeeded silently; it now throws.
- A gossip publish with no eligible peers no longer adds the message to mCache or updates lastPublished.
- Retryability covers admission failures only: a publish that fails after its parts were queued (peer disconnect, all writes failing) still leaves the message seen. Documented in the KDoc.

### Tests

GossipV1_1Tests: oversized publish fails identically on retry and leaves no mCache entry; a message of exactly maxGossipMessageSize still publishes; a no-peers publish succeeds after the peer subscribes.