### PR TITLE
Gossip backpressure: detect and handle slow peers under outbound backpressure

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -60,6 +60,7 @@ abstract class AbstractRouter(
             .map { it.key }
         fun getOrCreateQueue(peer: PeerHandler) = map.computeIfAbsent(peer) { queueFactory() }
         fun getExistingQueue(peer: PeerHandler) = map[peer]
+        fun getQueues(): Map<PeerHandler, TPartsQueue> = map
         fun onDisconnected(peer: PeerHandler) {
             map.remove(peer)?.abort(ConnectionClosedException())
         }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -62,7 +62,7 @@ abstract class AbstractRouter(
         fun getExistingQueue(peer: PeerHandler) = map[peer]
         fun getQueues(): Map<PeerHandler, TPartsQueue> = map
         fun onDisconnected(peer: PeerHandler) {
-            map.remove(peer)?.abort(ConnectionClosedException())
+            map.remove(peer)?.dropAll(ConnectionClosedException())
         }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/Errors.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/Errors.kt
@@ -26,3 +26,8 @@ class NoPeersForOutboundMessageException(message: String) : PubsubException(mess
  * Thrown when an outbound pubsub message or queued RPC part is too large to fit protocol limits.
  */
 class TooLargeMessageException(message: String) : PubsubException(message)
+
+/**
+ * Thrown when queued RPC parts are dropped before they are written.
+ */
+class DroppedRpcPartsException(message: String = "Queued RPC parts were dropped") : PubsubException(message)

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -1,7 +1,6 @@
 package io.libp2p.pubsub
 
 import io.libp2p.etc.types.forward
-import io.libp2p.pubsub.DefaultRpcPartsQueue.AbstractPart
 import pubsub.pb.Rpc
 import java.util.concurrent.CompletableFuture
 
@@ -79,12 +78,7 @@ interface RpcPartsQueue {
     fun estimateMaxSerializedSize(): Int
 }
 
-/**
- * Default [RpcPartsQueue] implementation
- *
- * NOT thread safe
- */
-open class DefaultRpcPartsQueue : RpcPartsQueue {
+abstract class AbstractRpcPartsQueue : RpcPartsQueue {
 
     protected abstract class AbstractPart {
 
@@ -128,16 +122,23 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         }
     }
 
-    protected open val parts = mutableListOf<AbstractPart>()
     private var estimatedMaxSerializedSizeAccum: Int = 0
 
-    protected open fun addPart(part: AbstractPart) {
-        parts += part
+    protected abstract fun addPart(part: AbstractPart)
+
+    protected open fun addPartSize(part: AbstractPart) {
         estimatedMaxSerializedSizeAccum += part.estimatedMaxSerializedSize
     }
-    protected fun onPartsRemoving(removedParts: List<AbstractPart>) {
-        estimatedMaxSerializedSizeAccum -= removedParts.sumOf { it.estimatedMaxSerializedSize }
+    protected fun removePartsSize(removedParts: List<AbstractPart>) {
+        removedParts.forEach {
+            removePartSize(it)
+        }
     }
+    protected fun removePartSize(removedPart: AbstractPart) {
+        estimatedMaxSerializedSizeAccum -= removedPart.estimatedMaxSerializedSize
+    }
+
+    override fun estimateMaxSerializedSize(): Int = estimatedMaxSerializedSizeAccum
 
     override fun addPublish(message: Rpc.Message) {
         addPart(PublishPart(message))
@@ -154,15 +155,6 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         addPart(SubscriptionPart(topic, status))
     }
 
-    override fun isEmpty(): Boolean = parts.isEmpty()
-    override fun takeBatch(): RpcPartsBatch? {
-        if (parts.isEmpty()) return null
-        val ret = createBatch(parts.toList())
-        onPartsRemoving(parts)
-        parts.clear()
-        return ret
-    }
-
     protected fun createBatch(batchParts: List<AbstractPart>): RpcPartsBatch {
         return RpcPartsBatch(
             mergeRpc(batchParts),
@@ -170,9 +162,7 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
         )
     }
 
-    override fun estimateMaxSerializedSize(): Int = estimatedMaxSerializedSizeAccum
-
-    private fun mergePromises(batchParts: List<AbstractPart>): CompletableFuture<Unit> {
+    protected fun mergePromises(batchParts: List<AbstractPart>): CompletableFuture<Unit> {
         val ret = CompletableFuture<Unit>()
         batchParts.mapNotNull { it.writePromise }.forEach { ret.forward(it) }
         return ret
@@ -187,8 +177,36 @@ open class DefaultRpcPartsQueue : RpcPartsQueue {
     }
 
     override fun abort(exception: Exception) {
-        mergePromises(parts).completeExceptionally(exception)
         estimatedMaxSerializedSizeAccum = 0
+    }
+}
+
+/**
+ * Default [RpcPartsQueue] implementation
+ *
+ * NOT thread safe
+ */
+open class DefaultRpcPartsQueue : AbstractRpcPartsQueue() {
+
+    protected open val parts = mutableListOf<AbstractPart>()
+
+    override fun addPart(part: AbstractPart) {
+        parts += part
+        addPartSize(part)
+    }
+
+    override fun isEmpty(): Boolean = parts.isEmpty()
+    override fun takeBatch(): RpcPartsBatch? {
+        if (parts.isEmpty()) return null
+        val ret = createBatch(parts.toList())
+        removePartsSize(parts)
+        parts.clear()
+        return ret
+    }
+
+    override fun abort(exception: Exception) {
+        mergePromises(parts).completeExceptionally(exception)
+        removePartsSize(parts)
         parts.clear()
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -63,9 +63,18 @@ interface RpcPartsQueue {
     fun takeBatch(): RpcPartsBatch?
 
     /**
+     * Drops queued parts that are considered low priority by this queue implementation.
+     *
+     * Publish promises associated with dropped parts are failed with [DroppedRpcPartsException].
+     * Higher-priority parts, if any, are left queued. Queues without explicit priorities may treat
+     * all queued parts as low priority.
+     */
+    fun dropLowPriority()
+
+    /**
      * Fails all queued publish promises with [exception] and clears this queue.
      */
-    fun abort(exception: Exception)
+    fun dropAll(exception: Exception)
 
     /**
      * Returns a conservative upper bound for the serialized size of all currently queued parts.
@@ -168,6 +177,15 @@ abstract class AbstractRpcPartsQueue : RpcPartsQueue {
         return ret
     }
 
+    protected fun dropParts(droppedParts: MutableList<AbstractPart>) {
+        if (droppedParts.isEmpty()) return
+        mergePromises(droppedParts).completeExceptionally(
+            DroppedRpcPartsException("Queued low priority RPC parts were dropped")
+        )
+        removePartsSize(droppedParts)
+        droppedParts.clear()
+    }
+
     private fun mergeRpc(batchParts: List<AbstractPart>): Rpc.RPC {
         val builder = Rpc.RPC.newBuilder()
         batchParts.forEach {
@@ -176,7 +194,7 @@ abstract class AbstractRpcPartsQueue : RpcPartsQueue {
         return builder.build()
     }
 
-    override fun abort(exception: Exception) {
+    override fun dropAll(exception: Exception) {
         estimatedMaxSerializedSizeAccum = 0
     }
 }
@@ -204,9 +222,13 @@ open class DefaultRpcPartsQueue : AbstractRpcPartsQueue() {
         return ret
     }
 
-    override fun abort(exception: Exception) {
+    override fun dropLowPriority() {
+        dropParts(parts)
+    }
+
+    override fun dropAll(exception: Exception) {
         mergePromises(parts).completeExceptionally(exception)
-        super.abort(exception)
+        super.dropAll(exception)
         parts.clear()
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcPartsQueue.kt
@@ -206,7 +206,7 @@ open class DefaultRpcPartsQueue : AbstractRpcPartsQueue() {
 
     override fun abort(exception: Exception) {
         mergePromises(parts).completeExceptionally(exception)
-        removePartsSize(parts)
+        super.abort(exception)
         parts.clear()
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -244,12 +244,15 @@ data class GossipParams(
 
     /**
      * [maxIDontWantMessageIds] is the maximum number of IDONTWANT message ids allowed per heartbeat per peer
+     * and must be greater than zero.
      */
     val maxIDontWantMessageIds: Int = maxIHaveLength * maxIHaveMessages,
 
     /**
      * [iDontWantMinMessageSizeThreshold] controls the minimum size (in bytes) that an incoming message needs to be so that an IDONTWANT message is sent to mesh peers.
      * The default is 16 KiB.
+     * To disable sending IDONTWANT messages, set this to a value larger than any permitted message size,
+     * such as [Int.MAX_VALUE].
      */
     val iDontWantMinMessageSizeThreshold: Int = 16384,
 
@@ -270,6 +273,7 @@ data class GossipParams(
         check(DHigh >= D, "DHigh should be >= D")
         check(gossipFactor in 0.0..1.0, "gossipFactor should be in range [0.0, 1.0]")
         check(floodPublishMaxMessageSizeThreshold >= 0, "floodPublishMaxMessageSizeThreshold should be >= 0")
+        check(maxIDontWantMessageIds > 0, "maxIDontWantMessageIds should be > 0")
         check(iDontWantMinMessageSizeThreshold >= 0, "iDontWantMinMessageSizeThreshold should be >= 0")
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -260,14 +260,15 @@ data class GossipParams(
 
     /**
      * [slowPeerPendingBytesThreshold] controls when a peer's pending outbound queue is considered
-     * pressured. When unset, slow-peer detection by pending queue size is disabled.
+     * pressured. The default is intentionally very high, which effectively disables slow-peer
+     * detection by pending queue size unless a lower value is configured.
      */
-    val slowPeerPendingBytesThreshold: Int? = null,
+    val slowPeerPendingBytesThreshold: Int = Int.MAX_VALUE,
 
     /**
      * [slowPeerHeartbeatThreshold] controls how many consecutive heartbeats a peer's pending
-     * outbound queue may stay at or above [slowPeerPendingBytesThreshold] before it is reported
-     * through `notifySlowPeer`.
+     * outbound queue may stay at or above [slowPeerPendingBytesThreshold] before it is processed as
+     * slow through `notifySlowPeer`.
      */
     val slowPeerHeartbeatThreshold: Int = 3
 
@@ -284,9 +285,7 @@ data class GossipParams(
         check(gossipFactor in 0.0..1.0, "gossipFactor should be in range [0.0, 1.0]")
         check(floodPublishMaxMessageSizeThreshold >= 0, "floodPublishMaxMessageSizeThreshold should be >= 0")
         check(iDontWantMinMessageSizeThreshold >= 0, "iDontWantMinMessageSizeThreshold should be >= 0")
-        slowPeerPendingBytesThreshold?.let {
-            check(it > 0, "slowPeerPendingBytesThreshold should be > 0")
-        }
+        check(slowPeerPendingBytesThreshold > 0, "slowPeerPendingBytesThreshold should be > 0")
         check(slowPeerHeartbeatThreshold > 0, "slowPeerHeartbeatThreshold should be > 0")
     }
 
@@ -416,6 +415,7 @@ data class GossipPeerScoreParams(
      * router. The router currently applies penalties for the following behaviors:
      * - attempting to re-graft before the prune backoff time has elapsed.
      * - not following up in IWANT requests for messages advertised with IHAVE.
+     * - keeping outbound RPC parts queued above the slow-peer threshold for too many heartbeats.
      *
      * The value of the parameter is the square of the counter over the threshold,
      * which decays with [behaviourPenaltyDecay].

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -256,7 +256,20 @@ data class GossipParams(
     /**
      * [iDontWantTTL] Expiry time for cache of received IDONTWANT messages for peers
      */
-    val iDontWantTTL: Duration = 3.seconds
+    val iDontWantTTL: Duration = 3.seconds,
+
+    /**
+     * [slowPeerPendingBytesThreshold] controls when a peer's pending outbound queue is considered
+     * pressured. When unset, slow-peer detection by pending queue size is disabled.
+     */
+    val slowPeerPendingBytesThreshold: Int? = null,
+
+    /**
+     * [slowPeerHeartbeatThreshold] controls how many consecutive heartbeats a peer's pending
+     * outbound queue may stay at or above [slowPeerPendingBytesThreshold] before it is reported
+     * through `notifySlowPeer`.
+     */
+    val slowPeerHeartbeatThreshold: Int = 3
 
 ) {
     init {
@@ -271,6 +284,10 @@ data class GossipParams(
         check(gossipFactor in 0.0..1.0, "gossipFactor should be in range [0.0, 1.0]")
         check(floodPublishMaxMessageSizeThreshold >= 0, "floodPublishMaxMessageSizeThreshold should be >= 0")
         check(iDontWantMinMessageSizeThreshold >= 0, "iDontWantMinMessageSizeThreshold should be >= 0")
+        slowPeerPendingBytesThreshold?.let {
+            check(it > 0, "slowPeerPendingBytesThreshold should be > 0")
+        }
+        check(slowPeerHeartbeatThreshold > 0, "slowPeerHeartbeatThreshold should be > 0")
     }
 
     companion object {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -275,12 +275,14 @@ open class GossipRouter(
     override fun validateMessageListLimits(msg: Rpc.RPCOrBuilder): Boolean {
         val iWantMessageIdCount = msg.control?.iwantList?.sumOf { w -> w.messageIDsCount } ?: 0
         val iHaveMessageIdCount = msg.control?.ihaveList?.sumOf { w -> w.messageIDsCount } ?: 0
+        val iDontWantMessageIdCount = msg.control?.idontwantList?.sumOf { w -> w.messageIDsCount } ?: 0
 
         return params.maxPublishedMessages?.let { msg.publishCount <= it } ?: true &&
             params.maxTopicsPerPublishedMessage?.let { msg.publishList.none { m -> m.topicIDsCount > it } } ?: true &&
             params.maxSubscriptions?.let { msg.subscriptionsCount <= it } ?: true &&
             params.maxIHaveLength.let { iHaveMessageIdCount <= it } &&
             params.maxIWantMessageIds?.let { iWantMessageIdCount <= it } ?: true &&
+            params.maxIDontWantMessageIds.let { iDontWantMessageIdCount <= it } &&
             params.maxGraftMessages?.let { (msg.control?.graftCount ?: 0) <= it } ?: true &&
             params.maxPruneMessages?.let { (msg.control?.pruneCount ?: 0) <= it } ?: true &&
             params.maxPeersAcceptedInPruneMsg.let { msg.control?.pruneList?.none { p -> p.peersCount > it } } ?: true
@@ -799,7 +801,7 @@ open class GossipRouter(
             .flatten()
             .distinct()
             .minus(setOfNotNull(receivedFrom))
-            .forEach { sendIdontwant(it, msg.messageId) }
+            .forEach { enqueueIDontWant(it, msg.messageId) }
     }
 
     private fun enqueuePrune(peer: PeerHandler, topic: Topic) {
@@ -824,17 +826,11 @@ open class GossipRouter(
     private fun enqueueIhave(peer: PeerHandler, messageIds: List<MessageId>, topic: Topic) =
         pendingRpcParts.getOrCreateQueue(peer).addIHaves(messageIds, topic)
 
-    private fun sendIdontwant(peer: PeerHandler, messageId: MessageId) {
+    private fun enqueueIDontWant(peer: PeerHandler, messageId: MessageId) {
         if (!peer.getPeerProtocol().supportsIDontWant()) {
             return
         }
-        val iDontWant = Rpc.RPC.newBuilder().setControl(
-            Rpc.ControlMessage.newBuilder().addIdontwant(
-                Rpc.ControlIDontWant.newBuilder()
-                    .addMessageIDs(messageId.toProtobuf())
-            )
-        ).build()
-        send(peer, iDontWant)
+        pendingRpcParts.getOrCreateQueue(peer).addIDontWant(messageId)
     }
 
     private fun sendControlExtensions(peer: PeerHandler) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -544,11 +544,11 @@ open class GossipRouter(
             val publishedMessages = peers
                 .filterNot { peerDoesNotWantMessage(it, msg.messageId) }
                 .map { submitPublishMessage(it, msg) }
+            flushAllPending()
             if (publishedMessages.isEmpty()) {
                 // all peers have sent IDONTWANT for this message id
                 CompletableFuture.completedFuture(Unit)
             } else {
-                flushAllPending()
                 anyComplete(publishedMessages)
             }
         } else {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -234,6 +234,7 @@ open class GossipRouter(
     }
 
     open fun notifySlowPeer(peer: PeerHandler) {
+        eventBroadcaster.notifySlowPeer(peer.peerId)
     }
 
     override fun acceptRequestsFrom(peer: PeerHandler): Boolean {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -233,8 +233,24 @@ open class GossipRouter(
         eventBroadcaster.notifyRouterMisbehavior(peer.peerId, penalty)
     }
 
+    /**
+     * Processes a peer whose outbound queue stayed above the slow-peer threshold for the configured
+     * number of heartbeats. The default handling first unloads low-priority queued data, then emits
+     * the slow-peer event so listeners such as [DefaultGossipScore] can apply their own policy.
+     */
     open fun notifySlowPeer(peer: PeerHandler) {
+        trimOutboundQueue(peer)
+        // will be downscored by GossipScore
         eventBroadcaster.notifySlowPeer(peer.peerId)
+    }
+
+    fun trimOutboundQueue(peer: PeerHandler) {
+        val partsQueue = pendingRpcParts.getExistingQueue(peer) ?: return
+        partsQueue.dropLowPriority()
+        if (partsQueue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
+            // last resort is to drop all the queued parts
+            partsQueue.dropAll(DroppedRpcPartsException())
+        }
     }
 
     override fun acceptRequestsFrom(peer: PeerHandler): Boolean {
@@ -760,9 +776,8 @@ open class GossipRouter(
     }
 
     private fun trackSlowPeers() {
-        val threshold = params.slowPeerPendingBytesThreshold ?: return
         pendingRpcParts.getQueues().forEach { (peer, queue) ->
-            if (queue.estimateMaxSerializedSize() >= threshold) {
+            if (queue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
                 val pressure = slowPeerQueuePressure.getOrPut(peer) { SlowPeerQueuePressure() }
                 pressure.heartbeatsAboveThreshold++
                 if (pressure.heartbeatsAboveThreshold >= params.slowPeerHeartbeatThreshold) {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -55,6 +55,7 @@ const val MaxIAskedEntries = 256
 const val MaxPeerIHaveEntries = 256
 const val MaxIWantRequestsEntries = 10 * 1024
 const val MaxPeerIDontWantEntries = 256
+const val MaxSlowPeerPressureEntries = 256
 
 typealias CurrentTimeSupplier = () -> Long
 
@@ -123,6 +124,7 @@ open class GossipRouter(
     private val peerIHave = createLRUMap<PeerHandler, AtomicInteger>(MaxPeerIHaveEntries)
     private val iWantRequests = createLRUMap<Pair<PeerHandler, MessageId>, Long>(MaxIWantRequestsEntries)
     private val peerIDontWant = createLRUMap<PeerHandler, IDontWantCacheEntry>(MaxPeerIDontWantEntries)
+    private val slowPeerQueuePressure = createLRUMap<PeerHandler, SlowPeerQueuePressure>(MaxSlowPeerPressureEntries)
     private val heartbeatTask by lazy {
         executor.scheduleWithFixedDelay(
             ::catchingHeartbeat,
@@ -160,6 +162,7 @@ open class GossipRouter(
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
         acceptRequestsWhitelist -= peer
+        slowPeerQueuePressure -= peer
         gossipExtensionsState.onPeerDisconnected(peer.peerId)
         super.onPeerDisconnected(peer)
     }
@@ -228,6 +231,9 @@ open class GossipRouter(
 
     fun notifyRouterMisbehavior(peer: PeerHandler, penalty: Int) {
         eventBroadcaster.notifyRouterMisbehavior(peer.peerId, penalty)
+    }
+
+    open fun notifySlowPeer(peer: PeerHandler) {
     }
 
     override fun acceptRequestsFrom(peer: PeerHandler): Boolean {
@@ -652,6 +658,7 @@ open class GossipRouter(
         heartbeatsCount++
         iAsked.clear()
         peerIHave.clear()
+        trackSlowPeers()
 
         val staleIWantTime = this.currentTimeSupplier() - params.iWantFollowupTime.toMillis()
         iWantRequests.entries.removeIf { (key, time) ->
@@ -748,6 +755,22 @@ open class GossipRouter(
             flushAllPending()
         } catch (t: Exception) {
             logger.warn("Exception in gossipsub heartbeat", t)
+        }
+    }
+
+    private fun trackSlowPeers() {
+        val threshold = params.slowPeerPendingBytesThreshold ?: return
+        pendingRpcParts.getQueues().forEach { (peer, queue) ->
+            if (queue.estimateMaxSerializedSize() >= threshold) {
+                val pressure = slowPeerQueuePressure.getOrPut(peer) { SlowPeerQueuePressure() }
+                pressure.heartbeatsAboveThreshold++
+                if (pressure.heartbeatsAboveThreshold >= params.slowPeerHeartbeatThreshold) {
+                    notifySlowPeer(peer)
+                    pressure.heartbeatsAboveThreshold = 0
+                }
+            } else {
+                slowPeerQueuePressure -= peer
+            }
         }
     }
 
@@ -863,5 +886,9 @@ open class GossipRouter(
     data class IDontWantCacheEntry(
         var heartbeatMessageIdsCount: Int = 0,
         val messageIdsAndTimeReceived: MutableMap<MessageId, Long> = mutableMapOf()
+    )
+
+    private data class SlowPeerQueuePressure(
+        var heartbeatsAboveThreshold: Int = 0
     )
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -28,6 +28,10 @@ interface GossipRouterEventListener {
 
     fun notifyRouterMisbehavior(peerId: PeerId, count: Int)
 
+    /**
+     * Called when a peer's outbound RPC parts queue remains above the configured slow-peer
+     * threshold for the configured number of heartbeats.
+     */
     fun notifySlowPeer(peerId: PeerId)
 }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouterEventListener.kt
@@ -27,6 +27,8 @@ interface GossipRouterEventListener {
     fun notifyPruned(peerId: PeerId, topic: Topic)
 
     fun notifyRouterMisbehavior(peerId: PeerId, count: Int)
+
+    fun notifySlowPeer(peerId: PeerId)
 }
 
 class GossipRouterEventBroadcaster : GossipRouterEventListener {
@@ -70,5 +72,9 @@ class GossipRouterEventBroadcaster : GossipRouterEventListener {
 
     override fun notifyRouterMisbehavior(peerId: PeerId, count: Int) {
         listeners.forEach { it.notifyRouterMisbehavior(peerId, count) }
+    }
+
+    override fun notifySlowPeer(peerId: PeerId) {
+        listeners.forEach { it.notifySlowPeer(peerId) }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -1,10 +1,8 @@
 package io.libp2p.pubsub.gossip
 
-import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.pubsub.AbstractRpcPartsQueue
-import io.libp2p.pubsub.DefaultRpcPartsQueue
 import io.libp2p.pubsub.MessageId
 import io.libp2p.pubsub.RpcPartsBatch
 import io.libp2p.pubsub.RpcPartsQueue
@@ -128,6 +126,7 @@ open class DefaultGossipRpcPartsQueue(
             )
         }
         priorityPartList(part).add(part)
+        addPartSize(part)
     }
 
     private fun priorityPartList(part: AbstractPart): MutableList<AbstractPart> =
@@ -171,17 +170,14 @@ open class DefaultGossipRpcPartsQueue(
         addPart(ControlExtensionPart(ctrlMessage))
     }
 
-    override fun isEmpty(): Boolean =
-        priorityPartLists.all { it.isEmpty() }
-
+    override fun isEmpty(): Boolean = priorityPartLists.all { it.isEmpty() }
 
     override fun takeBatch(): RpcPartsBatch? {
         val topmostPriorityList = priorityPartLists.firstOrNull { it.isNotEmpty() } ?: return null
         return takeBatch(topmostPriorityList)
     }
 
-    private fun takeBatch(priorityParts: MutableList<AbstractPart>): RpcPartsBatch {
-
+    private fun takeBatch(priorityParts: MutableList<AbstractPart>): RpcPartsBatch? {
         var publishCount = params.maxPublishedMessages ?: Int.MAX_VALUE
         var subscriptionCount = params.maxSubscriptions ?: Int.MAX_VALUE
         var iHaveCount = params.maxIHaveLength
@@ -213,6 +209,8 @@ open class DefaultGossipRpcPartsQueue(
             }
             partIdx++
         }
+        if (partIdx == 0) return null
+
         val batchParts: MutableList<AbstractPart> = priorityParts.subList(0, partIdx)
         val ret = createBatch(batchParts)
         removePartsSize(batchParts)
@@ -221,19 +219,10 @@ open class DefaultGossipRpcPartsQueue(
         return ret
     }
 
-    private fun removePart(part: AbstractPart, from: MutableList<AbstractPart>) {
-        val idx = from.indexOfFirst { it === part }
-        if (idx >= 0) {
-            from.removeAt(idx)
-        }
-    }
-
     override fun abort(exception: Exception) {
+        mergePromises(priorityPartLists.flatten()).completeExceptionally(exception)
         super.abort(exception)
-        priorityPartLists.forEach {
-            removePartsSize(it)
-            it.clear()
-        }
+        priorityPartLists.forEach { it.clear() }
     }
 
     private companion object {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -32,7 +32,6 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
      */
     fun addPrune(topic: Topic, backoffSeconds: Long, backoffPeers: List<PeerId>)
 
-    // TODO Need to check if we should handle when control extension and extension messages could be separated by split  (https://github.com/libp2p/jvm-libp2p/issues/440)
     fun addControlExtensions(ctrlMessage: Rpc.ControlExtensions)
 }
 
@@ -131,9 +130,9 @@ open class DefaultGossipRpcPartsQueue(
 
     private fun priorityPartList(part: AbstractPart): MutableList<AbstractPart> =
         when (part) {
+            is ControlExtensionPart,
             is IDontWantPart -> priorityPartLists[URGENT_CONTROL_PRIORITY]
             is SubscriptionPart,
-            is ControlExtensionPart,
             is GraftPart,
             is PrunePart -> priorityPartLists[STATE_CONTROL_PRIORITY]
             is PublishPart,

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -112,6 +112,11 @@ open class DefaultGossipRpcPartsQueue(
         }
     }
 
+    protected val urgentControlParts = mutableListOf<AbstractPart>()
+    protected val stateControlParts = mutableListOf<AbstractPart>()
+    protected val bulkParts = mutableListOf<AbstractPart>()
+    protected val priorityPartLists = listOf(urgentControlParts, stateControlParts, bulkParts)
+
     override fun addPart(part: AbstractPart) {
         if (part.estimatedMaxSerializedSize > params.maxGossipMessageSize) {
             throw TooLargeMessageException(
@@ -119,8 +124,22 @@ open class DefaultGossipRpcPartsQueue(
                     "maxGossipMessageSize ${params.maxGossipMessageSize}: $part"
             )
         }
+        priorityPartList(part).add(part)
         super.addPart(part)
     }
+
+    private fun priorityPartList(part: AbstractPart): MutableList<AbstractPart> =
+        when (part) {
+            is IDontWantPart -> urgentControlParts
+            is SubscriptionPart,
+            is ControlExtensionPart,
+            is GraftPart,
+            is PrunePart -> stateControlParts
+            is PublishPart,
+            is IHavePart,
+            is IWantPart -> bulkParts
+            else -> bulkParts
+        }
 
     override fun addIHave(messageId: MessageId, topic: Topic) {
         addPart(IHavePart(messageId, topic))
@@ -151,6 +170,7 @@ open class DefaultGossipRpcPartsQueue(
     }
 
     override fun takeBatch(): RpcPartsBatch? {
+        val priorityParts = priorityPartLists.firstOrNull { it.isNotEmpty() } ?: return null
         var publishCount = params.maxPublishedMessages ?: Int.MAX_VALUE
         var subscriptionCount = params.maxSubscriptions ?: Int.MAX_VALUE
         var iHaveCount = params.maxIHaveLength
@@ -162,11 +182,11 @@ open class DefaultGossipRpcPartsQueue(
 
         var partIdx = 0
 
-        while (partIdx < parts.size &&
+        while (partIdx < priorityParts.size &&
             publishCount > 0 && subscriptionCount > 0 && iHaveCount > 0 &&
             iWantCount > 0 && iDontWantCount > 0 && graftCount > 0 && pruneCount > 0
         ) {
-            val part = parts[partIdx]
+            val part = priorityParts[partIdx]
             when (part) {
                 is PublishPart -> publishCount--
                 is SubscriptionPart -> subscriptionCount--
@@ -184,11 +204,24 @@ open class DefaultGossipRpcPartsQueue(
         }
         if (partIdx == 0) return null
 
-        val sliceSublist: MutableList<AbstractPart> = parts.subList(0, partIdx)
-        val ret = createBatch(sliceSublist)
-        onPartsRemoving(sliceSublist)
-        sliceSublist.clear()
+        val batchParts: MutableList<AbstractPart> = priorityParts.subList(0, partIdx)
+        val ret = createBatch(batchParts)
+        onPartsRemoving(batchParts)
+        batchParts.forEach { removePart(it, parts) }
+        batchParts.clear()
 
         return ret
+    }
+
+    private fun removePart(part: AbstractPart, from: MutableList<AbstractPart>) {
+        val idx = from.indexOfFirst { it === part }
+        if (idx >= 0) {
+            from.removeAt(idx)
+        }
+    }
+
+    override fun abort(exception: Exception) {
+        super.abort(exception)
+        priorityPartLists.forEach { it.clear() }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -1,7 +1,9 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.etc.types.toProtobuf
+import io.libp2p.pubsub.AbstractRpcPartsQueue
 import io.libp2p.pubsub.DefaultRpcPartsQueue
 import io.libp2p.pubsub.MessageId
 import io.libp2p.pubsub.RpcPartsBatch
@@ -47,7 +49,7 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
  */
 open class DefaultGossipRpcPartsQueue(
     private val params: GossipParams
-) : DefaultRpcPartsQueue(), GossipRpcPartsQueue {
+) : AbstractRpcPartsQueue(), GossipRpcPartsQueue {
 
     protected data class IHavePart(val messageId: MessageId, val topic: Topic) : AbstractPart() {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
@@ -126,7 +128,6 @@ open class DefaultGossipRpcPartsQueue(
             )
         }
         priorityPartList(part).add(part)
-        super.addPart(part)
     }
 
     private fun priorityPartList(part: AbstractPart): MutableList<AbstractPart> =
@@ -170,8 +171,17 @@ open class DefaultGossipRpcPartsQueue(
         addPart(ControlExtensionPart(ctrlMessage))
     }
 
+    override fun isEmpty(): Boolean =
+        priorityPartLists.all { it.isEmpty() }
+
+
     override fun takeBatch(): RpcPartsBatch? {
-        val priorityParts = priorityPartLists.firstOrNull { it.isNotEmpty() } ?: return null
+        val topmostPriorityList = priorityPartLists.firstOrNull { it.isNotEmpty() } ?: return null
+        return takeBatch(topmostPriorityList)
+    }
+
+    private fun takeBatch(priorityParts: MutableList<AbstractPart>): RpcPartsBatch {
+
         var publishCount = params.maxPublishedMessages ?: Int.MAX_VALUE
         var subscriptionCount = params.maxSubscriptions ?: Int.MAX_VALUE
         var iHaveCount = params.maxIHaveLength
@@ -203,12 +213,9 @@ open class DefaultGossipRpcPartsQueue(
             }
             partIdx++
         }
-        if (partIdx == 0) return null
-
         val batchParts: MutableList<AbstractPart> = priorityParts.subList(0, partIdx)
         val ret = createBatch(batchParts)
-        onPartsRemoving(batchParts)
-        batchParts.forEach { removePart(it, parts) }
+        removePartsSize(batchParts)
         batchParts.clear()
 
         return ret
@@ -223,7 +230,10 @@ open class DefaultGossipRpcPartsQueue(
 
     override fun abort(exception: Exception) {
         super.abort(exception)
-        priorityPartLists.forEach { it.clear() }
+        priorityPartLists.forEach {
+            removePartsSize(it)
+            it.clear()
+        }
     }
 
     private companion object {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -17,6 +17,9 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
     fun addIWant(messageId: MessageId)
     fun addIWants(messageIds: Collection<MessageId>) = messageIds.forEach { addIWant(it) }
 
+    fun addIDontWant(messageId: MessageId)
+    fun addIDontWants(messageIds: Collection<MessageId>) = messageIds.forEach { addIDontWant(it) }
+
     fun addGraft(topic: Topic)
 
     /**
@@ -69,6 +72,18 @@ open class DefaultGossipRpcPartsQueue(
         }
     }
 
+    protected data class IDontWantPart(val messageId: MessageId) : AbstractPart() {
+        override fun appendToBuilder(builder: Rpc.RPC.Builder) {
+            val ctrlBuilder = builder.controlBuilder
+            val iDontWantBuilder = if (ctrlBuilder.idontwantBuilderList.isEmpty()) {
+                ctrlBuilder.addIdontwantBuilder()
+            } else {
+                ctrlBuilder.getIdontwantBuilder(0)
+            }
+            iDontWantBuilder.addMessageIDs(messageId.toProtobuf())
+        }
+    }
+
     protected data class GraftPart(val topic: Topic) : AbstractPart() {
         override fun appendToBuilder(builder: Rpc.RPC.Builder) {
             builder.controlBuilder.addGraftBuilder().setTopicID(topic)
@@ -115,6 +130,10 @@ open class DefaultGossipRpcPartsQueue(
         addPart(IWantPart(messageId))
     }
 
+    override fun addIDontWant(messageId: MessageId) {
+        addPart(IDontWantPart(messageId))
+    }
+
     override fun addGraft(topic: Topic) {
         addPart(GraftPart(topic))
     }
@@ -136,6 +155,7 @@ open class DefaultGossipRpcPartsQueue(
         var subscriptionCount = params.maxSubscriptions ?: Int.MAX_VALUE
         var iHaveCount = params.maxIHaveLength
         var iWantCount = params.maxIWantMessageIds ?: Int.MAX_VALUE
+        var iDontWantCount = params.maxIDontWantMessageIds
         var graftCount = params.maxGraftMessages ?: Int.MAX_VALUE
         var pruneCount = params.maxPruneMessages ?: Int.MAX_VALUE
         var sizeLeft = params.maxGossipMessageSize
@@ -144,7 +164,7 @@ open class DefaultGossipRpcPartsQueue(
 
         while (partIdx < parts.size &&
             publishCount > 0 && subscriptionCount > 0 && iHaveCount > 0 &&
-            iWantCount > 0 && graftCount > 0 && pruneCount > 0
+            iWantCount > 0 && iDontWantCount > 0 && graftCount > 0 && pruneCount > 0
         ) {
             val part = parts[partIdx]
             when (part) {
@@ -152,6 +172,7 @@ open class DefaultGossipRpcPartsQueue(
                 is SubscriptionPart -> subscriptionCount--
                 is IHavePart -> iHaveCount--
                 is IWantPart -> iWantCount--
+                is IDontWantPart -> iDontWantCount--
                 is GraftPart -> graftCount--
                 is PrunePart -> pruneCount--
             }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -176,6 +176,10 @@ open class DefaultGossipRpcPartsQueue(
         return takeBatch(topmostPriorityList)
     }
 
+    override fun dropLowPriority() {
+        dropParts(priorityPartLists[BULK_PRIORITY])
+    }
+
     private fun takeBatch(priorityParts: MutableList<AbstractPart>): RpcPartsBatch? {
         var publishCount = params.maxPublishedMessages ?: Int.MAX_VALUE
         var subscriptionCount = params.maxSubscriptions ?: Int.MAX_VALUE
@@ -218,9 +222,9 @@ open class DefaultGossipRpcPartsQueue(
         return ret
     }
 
-    override fun abort(exception: Exception) {
+    override fun dropAll(exception: Exception) {
         mergePromises(priorityPartLists.flatten()).completeExceptionally(exception)
-        super.abort(exception)
+        super.dropAll(exception)
         priorityPartLists.forEach { it.clear() }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -112,10 +112,11 @@ open class DefaultGossipRpcPartsQueue(
         }
     }
 
-    protected val urgentControlParts = mutableListOf<AbstractPart>()
-    protected val stateControlParts = mutableListOf<AbstractPart>()
-    protected val bulkParts = mutableListOf<AbstractPart>()
-    protected val priorityPartLists = listOf(urgentControlParts, stateControlParts, bulkParts)
+    protected val priorityPartLists = listOf(
+        mutableListOf<AbstractPart>(),
+        mutableListOf(),
+        mutableListOf()
+    )
 
     override fun addPart(part: AbstractPart) {
         if (part.estimatedMaxSerializedSize > params.maxGossipMessageSize) {
@@ -130,15 +131,15 @@ open class DefaultGossipRpcPartsQueue(
 
     private fun priorityPartList(part: AbstractPart): MutableList<AbstractPart> =
         when (part) {
-            is IDontWantPart -> urgentControlParts
+            is IDontWantPart -> priorityPartLists[URGENT_CONTROL_PRIORITY]
             is SubscriptionPart,
             is ControlExtensionPart,
             is GraftPart,
-            is PrunePart -> stateControlParts
+            is PrunePart -> priorityPartLists[STATE_CONTROL_PRIORITY]
             is PublishPart,
             is IHavePart,
-            is IWantPart -> bulkParts
-            else -> bulkParts
+            is IWantPart -> priorityPartLists[BULK_PRIORITY]
+            else -> priorityPartLists[BULK_PRIORITY]
         }
 
     override fun addIHave(messageId: MessageId, topic: Topic) {
@@ -223,5 +224,11 @@ open class DefaultGossipRpcPartsQueue(
     override fun abort(exception: Exception) {
         super.abort(exception)
         priorityPartLists.forEach { it.clear() }
+    }
+
+    private companion object {
+        const val URGENT_CONTROL_PRIORITY = 0
+        const val STATE_CONTROL_PRIORITY = 1
+        const val BULK_PRIORITY = 2
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -308,6 +308,9 @@ class DefaultGossipScore(
         getPeerScores(peerId).behaviorPenalty += count
     }
 
+    override fun notifySlowPeer(peerId: PeerId) {
+    }
+
     fun stop() {
         refreshTask.cancel(false)
     }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipScore.kt
@@ -309,6 +309,7 @@ class DefaultGossipScore(
     }
 
     override fun notifySlowPeer(peerId: PeerId) {
+        notifyRouterMisbehavior(peerId, 1)
     }
 
     fun stop() {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
@@ -78,6 +78,10 @@ class GossipParamsBuilder {
 
     private var iDontWantTTL: Duration? = null
 
+    private var slowPeerPendingBytesThreshold: Int? = null
+
+    private var slowPeerHeartbeatThreshold: Int? = null
+
     init {
         val source = GossipParams()
         this.D = source.D
@@ -109,6 +113,8 @@ class GossipParamsBuilder {
         this.maxIDontWantMessageIds = source.maxIDontWantMessageIds
         this.iDontWantMinMessageSizeThreshold = source.iDontWantMinMessageSizeThreshold
         this.iDontWantTTL = source.iDontWantTTL
+        this.slowPeerPendingBytesThreshold = source.slowPeerPendingBytesThreshold
+        this.slowPeerHeartbeatThreshold = source.slowPeerHeartbeatThreshold
     }
 
     fun D(value: Int): GossipParamsBuilder = apply { D = value }
@@ -187,6 +193,10 @@ class GossipParamsBuilder {
 
     fun iDontWantTTL(value: Duration): GossipParamsBuilder = apply { iDontWantTTL = value }
 
+    fun slowPeerPendingBytesThreshold(value: Int): GossipParamsBuilder = apply { slowPeerPendingBytesThreshold = value }
+
+    fun slowPeerHeartbeatThreshold(value: Int): GossipParamsBuilder = apply { slowPeerHeartbeatThreshold = value }
+
     fun build(): GossipParams {
         calculateMissing()
         checkRequiredFields()
@@ -224,7 +234,9 @@ class GossipParamsBuilder {
             connectCallback = connectCallback!!,
             maxIDontWantMessageIds = maxIDontWantMessageIds!!,
             iDontWantMinMessageSizeThreshold = iDontWantMinMessageSizeThreshold!!,
-            iDontWantTTL = iDontWantTTL!!
+            iDontWantTTL = iDontWantTTL!!,
+            slowPeerPendingBytesThreshold = slowPeerPendingBytesThreshold,
+            slowPeerHeartbeatThreshold = slowPeerHeartbeatThreshold!!
         )
     }
 
@@ -265,5 +277,6 @@ class GossipParamsBuilder {
         check(maxIDontWantMessageIds != null, { "maxIDontWantMessageIds must not be null" })
         check(iDontWantMinMessageSizeThreshold != null, { "iDontWantMinMessageSizeThreshold must not be null" })
         check(iDontWantTTL != null, { "iDontWantTTL must not be null" })
+        check(slowPeerHeartbeatThreshold != null, { "slowPeerHeartbeatThreshold must not be null" })
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
@@ -235,7 +235,7 @@ class GossipParamsBuilder {
             maxIDontWantMessageIds = maxIDontWantMessageIds!!,
             iDontWantMinMessageSizeThreshold = iDontWantMinMessageSizeThreshold!!,
             iDontWantTTL = iDontWantTTL!!,
-            slowPeerPendingBytesThreshold = slowPeerPendingBytesThreshold,
+            slowPeerPendingBytesThreshold = slowPeerPendingBytesThreshold!!,
             slowPeerHeartbeatThreshold = slowPeerHeartbeatThreshold!!
         )
     }
@@ -277,6 +277,7 @@ class GossipParamsBuilder {
         check(maxIDontWantMessageIds != null, { "maxIDontWantMessageIds must not be null" })
         check(iDontWantMinMessageSizeThreshold != null, { "iDontWantMinMessageSizeThreshold must not be null" })
         check(iDontWantTTL != null, { "iDontWantTTL must not be null" })
+        check(slowPeerPendingBytesThreshold != null, { "slowPeerPendingBytesThreshold must not be null" })
         check(slowPeerHeartbeatThreshold != null, { "slowPeerHeartbeatThreshold must not be null" })
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/RpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/RpcPartsQueueTest.kt
@@ -115,7 +115,7 @@ class RpcPartsQueueTest {
     }
 
     @Test
-    fun `abort fails pending publish promises`() {
+    fun `dropAll fails pending publish promises`() {
         val queue = DefaultRpcPartsQueue()
         val publishPromise = CompletableFuture<Unit>()
 
@@ -124,7 +124,7 @@ class RpcPartsQueueTest {
 
         assertThat(queue.estimateMaxSerializedSize()).isGreaterThan(0)
 
-        queue.abort(ConnectionClosedException())
+        queue.dropAll(ConnectionClosedException())
 
         assertThat(queue.isEmpty()).isTrue()
         assertThat(queue.estimateMaxSerializedSize()).isZero()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipParamsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipParamsTest.kt
@@ -165,6 +165,26 @@ class GossipParamsTest {
         assertEquals("gossipFactor should be in range [0.0, 1.0]", exception.message)
     }
 
+    @Test
+    fun `test invalid slow peer pending bytes threshold`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            GossipParams.builder()
+                .slowPeerPendingBytesThreshold(0)
+                .build()
+        }
+        assertEquals("slowPeerPendingBytesThreshold should be > 0", exception.message)
+    }
+
+    @Test
+    fun `test invalid slow peer heartbeat threshold`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            GossipParams.builder()
+                .slowPeerHeartbeatThreshold(0)
+                .build()
+        }
+        assertEquals("slowPeerHeartbeatThreshold should be > 0", exception.message)
+    }
+
     /* GossipScoreParams */
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipParamsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipParamsTest.kt
@@ -85,6 +85,16 @@ class GossipParamsTest {
     }
 
     @Test
+    fun `test invalid max IDONTWANT message IDs is zero`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            GossipParams.builder()
+                .maxIDontWantMessageIds(0)
+                .build()
+        }
+        assertEquals("maxIDontWantMessageIds should be > 0", exception.message)
+    }
+
+    @Test
     fun `test invalid dout same as dlow`() {
         val exception = assertThrows<IllegalArgumentException> {
             GossipParams.builder()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -472,12 +472,13 @@ class GossipRpcPartsQueueTest {
         assertThat(urgentControlRpc.control.idontwantList).hasSize(1)
         assertThat(urgentControlRpc.control.graftList).isEmpty()
         assertThat(urgentControlRpc.control.ihaveList).isEmpty()
+        assertThat(urgentControlRpc.control.hasExtensions()).isTrue()
+        assertThat(urgentControlRpc.control.extensions.partialMessages).isTrue()
 
         val stateControlRpc = merged[1]
         assertThat(stateControlRpc.control.graftList).hasSize(1)
         assertThat(stateControlRpc.control.pruneList).hasSize(1)
-        assertThat(stateControlRpc.control.hasExtensions()).isTrue()
-        assertThat(stateControlRpc.control.extensions.partialMessages).isTrue()
+        assertThat(stateControlRpc.control.hasExtensions()).isFalse()
 
         val bulkRpc = merged[2]
         assertThat(bulkRpc.control.ihaveList).hasSize(1)
@@ -498,13 +499,17 @@ class GossipRpcPartsQueueTest {
         partsQueue.addControlExtensions(extension)
 
         val merged = partsQueue.takeMerged()
-        val stateControlRpc = merged[0]
-        val publishRpc = merged[1]
+        val urgentControlRpc = merged[0]
+        val stateControlRpc = merged[1]
+        val publishRpc = merged[2]
 
+        assertThat(urgentControlRpc.subscriptionsList).isEmpty()
+        assertThat(urgentControlRpc.publishList).isEmpty()
+        assertThat(urgentControlRpc.control.hasExtensions()).isTrue()
+        assertThat(urgentControlRpc.control.extensions.partialMessages).isTrue()
         assertThat(stateControlRpc.subscriptionsList).hasSize(1)
         assertThat(stateControlRpc.publishList).isEmpty()
-        assertThat(stateControlRpc.control.hasExtensions()).isTrue()
-        assertThat(stateControlRpc.control.extensions.partialMessages).isTrue()
+        assertThat(stateControlRpc.control.hasExtensions()).isFalse()
         assertThat(publishRpc.subscriptionsList).isEmpty()
         assertThat(publishRpc.publishList).hasSize(1)
     }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -49,7 +49,8 @@ class GossipRpcPartsQueueTest {
         val iHaves: Int,
         val iWants: Int,
         val grafts: Int,
-        val prunes: Int
+        val prunes: Int,
+        val iDontWants: Int = 0
     ) {
 
         fun generateQueue(params: GossipParams): TestGossipQueue {
@@ -66,6 +67,9 @@ class GossipRpcPartsQueueTest {
             }
             (1..iWants).forEach {
                 queue.addIWant(byteArrayOf(it.toByte()).toWBytes())
+            }
+            (1..iDontWants).forEach {
+                queue.addIDontWant(byteArrayOf(it.toByte()).toWBytes())
             }
             (1..grafts).forEach {
                 queue.addGraft("topic-$it")
@@ -128,6 +132,13 @@ class GossipRpcPartsQueueTest {
                                     controlBuilder.addIwantBuilder().addMessageIDs(it)
                                 }
                             },
+                        idontwantList
+                            .flatMap { it.messageIDsList }
+                            .map {
+                                Rpc.RPC.newBuilder().apply {
+                                    controlBuilder.addIdontwantBuilder().addMessageIDs(it)
+                                }
+                            },
                         graftList
                             .map {
                                 Rpc.RPC.newBuilder().apply {
@@ -175,6 +186,9 @@ class GossipRpcPartsQueueTest {
             PartCounts(0, 0, 0, 15, 0, 0),
             PartCounts(0, 0, 0, 28, 0, 0),
             PartCounts(0, 0, 0, 29, 0, 0),
+            PartCounts(0, 0, 0, 0, 0, 0, 1),
+            PartCounts(0, 0, 0, 0, 0, 0, gossipParamsWithLimits.maxIDontWantMessageIds),
+            PartCounts(0, 0, 0, 0, 0, 0, gossipParamsWithLimits.maxIDontWantMessageIds + 1),
         )
 
         val testCases = partsCases
@@ -433,6 +447,7 @@ class GossipRpcPartsQueueTest {
         // Add various control messages
         partsQueue.addIHave(byteArrayOf(1).toWBytes(), "topic1")
         partsQueue.addIWant(byteArrayOf(2).toWBytes())
+        partsQueue.addIDontWant(byteArrayOf(3).toWBytes())
         partsQueue.addGraft("topic2")
         partsQueue.addPrune("topic3")
 
@@ -448,6 +463,7 @@ class GossipRpcPartsQueueTest {
         assertThat(res.hasControl()).isTrue()
         assertThat(res.control.ihaveList).hasSize(1)
         assertThat(res.control.iwantList).hasSize(1)
+        assertThat(res.control.idontwantList).hasSize(1)
         assertThat(res.control.graftList).hasSize(1)
         assertThat(res.control.pruneList).hasSize(1)
 
@@ -531,6 +547,25 @@ class GossipRpcPartsQueueTest {
         // Note: false flags may or may not be serialized depending on protobuf default behavior
         // But testExtension should definitely be true
         assertThat(res.control.extensions.testExtension).isTrue()
+    }
+
+    @Test
+    fun `addIDontWant() groups message ids in control message`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+        val messageId1 = "1111".toWBytes()
+        val messageId2 = "2222".toWBytes()
+
+        partsQueue.addIDontWant(messageId1)
+        partsQueue.addIDontWant(messageId2)
+
+        val res = partsQueue.takeMerged().first()
+
+        assertThat(res.hasControl()).isTrue()
+        assertThat(res.control.idontwantList).containsExactly(
+            Rpc.ControlIDontWant.newBuilder()
+                .addAllMessageIDs(listOf(messageId1.toProtobuf(), messageId2.toProtobuf()))
+                .build()
+        )
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -614,23 +614,6 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `takeBatch returns null when highest priority part cannot be admitted`() {
-        val partsQueue = TestGossipQueue(
-            GossipParamsBuilder()
-                .maxIDontWantMessageIds(0)
-                .maxIHaveLength(Int.MAX_VALUE)
-                .build()
-        )
-
-        partsQueue.addIDontWant("1111".toWBytes())
-        partsQueue.addPublish(createRpcMessage("topic", "data"))
-
-        assertThat(partsQueue.takeBatch()).isNull()
-        assertThat(partsQueue.isEmpty()).isFalse()
-        assertThat(partsQueue.estimateMaxSerializedSize()).isGreaterThan(0)
-    }
-
-    @Test
     fun `abort clears priority parts and fails pending publish promises`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
         val publishPromise = CompletableFuture<Unit>()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -1,6 +1,8 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.PeerId
+import io.libp2p.etc.types.getX
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.etc.types.toWBytes
 import io.libp2p.pubsub.RpcPartsQueue
@@ -16,6 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import pubsub.pb.Rpc
+import java.util.concurrent.CompletableFuture
 import java.util.stream.Stream
 
 private fun RpcPartsQueue.takeMerged(): List<Rpc.RPC> {
@@ -31,13 +34,12 @@ class GossipRpcPartsQueueTest {
     class TestGossipQueue(params: GossipParams) : DefaultGossipRpcPartsQueue(params) {
 
         fun shuffleParts() {
-            parts.shuffle()
             priorityPartLists.forEach { it.shuffle() }
         }
 
         fun mergedSingle(): Rpc.RPC {
             val builder = Rpc.RPC.newBuilder()
-            parts.forEach {
+            priorityPartLists.flatten().forEach {
                 it.appendToBuilder(builder)
             }
             return builder.build()
@@ -604,6 +606,42 @@ class GossipRpcPartsQueueTest {
         assertThat(secondBatch.subscriptionsList.map { it.topicid }).containsExactly("topic")
         assertThat(secondBatch.publishCount).isZero()
         assertThat(thirdBatch.publishList).containsExactly(publishMessage)
+    }
+
+    @Test
+    fun `takeBatch returns null when highest priority part cannot be admitted`() {
+        val partsQueue = TestGossipQueue(
+            GossipParamsBuilder()
+                .maxIDontWantMessageIds(0)
+                .maxIHaveLength(Int.MAX_VALUE)
+                .build()
+        )
+
+        partsQueue.addIDontWant("1111".toWBytes())
+        partsQueue.addPublish(createRpcMessage("topic", "data"))
+
+        assertThat(partsQueue.takeBatch()).isNull()
+        assertThat(partsQueue.isEmpty()).isFalse()
+        assertThat(partsQueue.estimateMaxSerializedSize()).isGreaterThan(0)
+    }
+
+    @Test
+    fun `abort clears priority parts and fails pending publish promises`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+        val publishPromise = CompletableFuture<Unit>()
+
+        partsQueue.addIDontWant("1111".toWBytes())
+        partsQueue.addSubscribe("topic")
+        partsQueue.addPublish(createRpcMessage("topic", "data"), publishPromise)
+
+        assertThat(partsQueue.estimateMaxSerializedSize()).isGreaterThan(0)
+
+        partsQueue.abort(ConnectionClosedException())
+
+        assertThat(partsQueue.isEmpty()).isTrue()
+        assertThat(partsQueue.estimateMaxSerializedSize()).isZero()
+        assertThat(publishPromise).isCompletedExceptionally
+        assertThrows(ConnectionClosedException::class.java) { publishPromise.getX() }
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -32,6 +32,7 @@ class GossipRpcPartsQueueTest {
 
         fun shuffleParts() {
             parts.shuffle()
+            priorityPartLists.forEach { it.shuffle() }
         }
 
         fun mergedSingle(): Rpc.RPC {
@@ -313,14 +314,15 @@ class GossipRpcPartsQueueTest {
         msgs.forEach {
             assertThat(router.validateMessageListLimits(it)).isTrue()
         }
-        assertThat(msgs).hasSize(2)
+        assertThat(msgs).hasSize(3)
         assertThat(msgs[0].publishCount).isZero()
-        assertThat(msgs[1].publishCount).isEqualTo(1)
+        assertThat(msgs[1].publishCount).isZero()
+        assertThat(msgs[2].publishCount).isEqualTo(1)
         assertThat(msgs.merge()).isEqualTo(single)
     }
 
     @Test
-    fun `mergeMessageParts() test that even when all parts fit to 2 messages the result should be 3 messages`() {
+    fun `mergeMessageParts() test priority batches split independently`() {
         val router = GossipRouterBuilder(params = gossipParamsWithLimits).build()
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
         (0 until maxSubscriptions + 1).forEach {
@@ -337,7 +339,12 @@ class GossipRpcPartsQueueTest {
         msgs.forEach {
             assertThat(router.validateMessageListLimits(it)).isTrue()
         }
-        assertThat(msgs).hasSize(3)
+        assertThat(msgs).hasSize(4)
+        assertThat(msgs.take(2)).allMatch { it.publishCount == 0 }
+        assertThat(msgs.drop(2).map { it.publishCount }).containsExactly(
+            maxPublishedMessages,
+            maxPublishedMessages
+        )
         assertThat(msgs.merge()).isEqualTo(single)
     }
 
@@ -457,19 +464,23 @@ class GossipRpcPartsQueueTest {
             .build()
         partsQueue.addControlExtensions(extension)
 
-        val res = partsQueue.takeMerged().first()
+        val merged = partsQueue.takeMerged()
 
-        // Verify all control messages are present
-        assertThat(res.hasControl()).isTrue()
-        assertThat(res.control.ihaveList).hasSize(1)
-        assertThat(res.control.iwantList).hasSize(1)
-        assertThat(res.control.idontwantList).hasSize(1)
-        assertThat(res.control.graftList).hasSize(1)
-        assertThat(res.control.pruneList).hasSize(1)
+        val urgentControlRpc = merged[0]
+        assertThat(urgentControlRpc.control.idontwantList).hasSize(1)
+        assertThat(urgentControlRpc.control.graftList).isEmpty()
+        assertThat(urgentControlRpc.control.ihaveList).isEmpty()
 
-        // Verify extension is present
-        assertThat(res.control.hasExtensions()).isTrue()
-        assertThat(res.control.extensions.partialMessages).isTrue()
+        val stateControlRpc = merged[1]
+        assertThat(stateControlRpc.control.graftList).hasSize(1)
+        assertThat(stateControlRpc.control.pruneList).hasSize(1)
+        assertThat(stateControlRpc.control.hasExtensions()).isTrue()
+        assertThat(stateControlRpc.control.extensions.partialMessages).isTrue()
+
+        val bulkRpc = merged[2]
+        assertThat(bulkRpc.control.ihaveList).hasSize(1)
+        assertThat(bulkRpc.control.iwantList).hasSize(1)
+        assertThat(bulkRpc.control.idontwantList).isEmpty()
     }
 
     @Test
@@ -484,15 +495,16 @@ class GossipRpcPartsQueueTest {
             .build()
         partsQueue.addControlExtensions(extension)
 
-        val res = partsQueue.takeMerged().first()
+        val merged = partsQueue.takeMerged()
+        val stateControlRpc = merged[0]
+        val publishRpc = merged[1]
 
-        // Verify subscriptions and publishes
-        assertThat(res.subscriptionsList).hasSize(1)
-        assertThat(res.publishList).hasSize(1)
-
-        // Verify extension
-        assertThat(res.control.hasExtensions()).isTrue()
-        assertThat(res.control.extensions.partialMessages).isTrue()
+        assertThat(stateControlRpc.subscriptionsList).hasSize(1)
+        assertThat(stateControlRpc.publishList).isEmpty()
+        assertThat(stateControlRpc.control.hasExtensions()).isTrue()
+        assertThat(stateControlRpc.control.extensions.partialMessages).isTrue()
+        assertThat(publishRpc.subscriptionsList).isEmpty()
+        assertThat(publishRpc.publishList).hasSize(1)
     }
 
     @Test
@@ -515,11 +527,11 @@ class GossipRpcPartsQueueTest {
         // Should be split into multiple RPCs due to maxPublishedMessages limit
         assertThat(merged.size).isGreaterThan(1)
 
-        // Extension should be in the last RPC (since it's added last)
-        val lastRpc = merged.last()
-        assertThat(lastRpc.hasControl()).isTrue()
-        assertThat(lastRpc.control.hasExtensions()).isTrue()
-        assertThat(lastRpc.control.extensions.partialMessages).isTrue()
+        // Extension is state/control priority, so it should go in the first RPC before bulk publishes.
+        val firstRpc = merged.first()
+        assertThat(firstRpc.hasControl()).isTrue()
+        assertThat(firstRpc.control.hasExtensions()).isTrue()
+        assertThat(firstRpc.control.extensions.partialMessages).isTrue()
     }
 
     @Test
@@ -569,7 +581,33 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `control extensions message does not count toward limits but may be split`() {
+    fun `takeBatch drains only highest priority parts`() {
+        val publishMessage = createRpcMessage("topic", "data")
+        val iDontWantMessageId = "1111".toWBytes()
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+
+        partsQueue.addPublish(publishMessage)
+        partsQueue.addSubscribe("topic")
+        partsQueue.addIDontWant(iDontWantMessageId)
+
+        val firstBatch = partsQueue.takeBatch()!!.rpc
+        val secondBatch = partsQueue.takeBatch()!!.rpc
+        val thirdBatch = partsQueue.takeBatch()!!.rpc
+
+        assertThat(firstBatch.publishCount).isZero()
+        assertThat(firstBatch.subscriptionsCount).isZero()
+        assertThat(firstBatch.control.idontwantList).containsExactly(
+            Rpc.ControlIDontWant.newBuilder()
+                .addMessageIDs(iDontWantMessageId.toProtobuf())
+                .build()
+        )
+        assertThat(secondBatch.subscriptionsList.map { it.topicid }).containsExactly("topic")
+        assertThat(secondBatch.publishCount).isZero()
+        assertThat(thirdBatch.publishList).containsExactly(publishMessage)
+    }
+
+    @Test
+    fun `control extensions message is batched separately from publish limits`() {
         val partsQueue = TestGossipQueue(gossipParamsWithLimits)
 
         // Add exactly maxPublishedMessages messages
@@ -585,14 +623,11 @@ class GossipRpcPartsQueueTest {
 
         val merged = partsQueue.takeMerged()
 
-        // Extension doesn't count toward limits, but it may end up in a separate RPC
-        // if it comes after parts that exhaust a limit
         assertThat(merged).hasSize(2)
-        assertThat(merged[0].publishList).hasSize(maxPublishedMessages)
-
-        // Extension should be in the second RPC
-        assertThat(merged[1].control.hasExtensions()).isTrue()
-        assertThat(merged[1].control.extensions.partialMessages).isTrue()
+        assertThat(merged[0].publishCount).isZero()
+        assertThat(merged[0].control.hasExtensions()).isTrue()
+        assertThat(merged[0].control.extensions.partialMessages).isTrue()
+        assertThat(merged[1].publishList).hasSize(maxPublishedMessages)
     }
 
     private fun standaloneGraftRpc(topic: Topic): Rpc.RPC =

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -5,6 +5,8 @@ import io.libp2p.core.PeerId
 import io.libp2p.etc.types.getX
 import io.libp2p.etc.types.toProtobuf
 import io.libp2p.etc.types.toWBytes
+import io.libp2p.pubsub.DefaultRpcPartsQueue
+import io.libp2p.pubsub.DroppedRpcPartsException
 import io.libp2p.pubsub.RpcPartsQueue
 import io.libp2p.pubsub.TooLargeMessageException
 import io.libp2p.pubsub.Topic
@@ -631,7 +633,68 @@ class GossipRpcPartsQueueTest {
     }
 
     @Test
-    fun `abort clears priority parts and fails pending publish promises`() {
+    fun `dropLowPriority drops only bulk priority parts`() {
+        val partsQueue = TestGossipQueue(gossipParamsNoLimits)
+        val publishPromise = CompletableFuture<Unit>()
+        val publishMessage = createRpcMessage("topic", "data")
+        val iHaveMessageId = "2222".toWBytes()
+        val iWantMessageId = "3333".toWBytes()
+        val iDontWantMessageId = "1111".toWBytes()
+
+        partsQueue.addIDontWant(iDontWantMessageId)
+        partsQueue.addSubscribe("topic")
+        partsQueue.addGraft("topic")
+        partsQueue.addPrune("topic")
+        partsQueue.addPublish(publishMessage, publishPromise)
+        partsQueue.addIHave(iHaveMessageId, "topic")
+        partsQueue.addIWant(iWantMessageId)
+
+        val estimateBeforeDrop = partsQueue.estimateMaxSerializedSize()
+
+        partsQueue.dropLowPriority()
+
+        assertThat(partsQueue.isEmpty()).isFalse()
+        assertThat(partsQueue.estimateMaxSerializedSize()).isLessThan(estimateBeforeDrop)
+        assertThat(publishPromise).isCompletedExceptionally
+        assertThrows(DroppedRpcPartsException::class.java) { publishPromise.getX() }
+
+        val merged = partsQueue.takeMerged()
+
+        assertThat(merged).hasSize(2)
+        assertThat(merged[0].control.idontwantList).containsExactly(
+            Rpc.ControlIDontWant.newBuilder()
+                .addMessageIDs(iDontWantMessageId.toProtobuf())
+                .build()
+        )
+        assertThat(merged[1].subscriptionsList.map { it.topicid }).containsExactly("topic")
+        assertThat(merged[1].control.graftList.map { it.topicID }).containsExactly("topic")
+        assertThat(merged[1].control.pruneList.map { it.topicID }).containsExactly("topic")
+        assertThat(merged).allMatch { it.publishCount == 0 }
+        assertThat(merged).allMatch { it.control.ihaveCount == 0 }
+        assertThat(merged).allMatch { it.control.iwantCount == 0 }
+        assertThat(partsQueue.estimateMaxSerializedSize()).isZero()
+    }
+
+    @Test
+    fun `dropLowPriority clears default queue and fails pending publish promises`() {
+        val partsQueue = DefaultRpcPartsQueue()
+        val publishPromise = CompletableFuture<Unit>()
+
+        partsQueue.addSubscribe("topic")
+        partsQueue.addPublish(createRpcMessage("topic", "data"), publishPromise)
+
+        assertThat(partsQueue.estimateMaxSerializedSize()).isGreaterThan(0)
+
+        partsQueue.dropLowPriority()
+
+        assertThat(partsQueue.isEmpty()).isTrue()
+        assertThat(partsQueue.estimateMaxSerializedSize()).isZero()
+        assertThat(publishPromise).isCompletedExceptionally
+        assertThrows(DroppedRpcPartsException::class.java) { publishPromise.getX() }
+    }
+
+    @Test
+    fun `dropAll clears priority parts and fails pending publish promises`() {
         val partsQueue = TestGossipQueue(gossipParamsNoLimits)
         val publishPromise = CompletableFuture<Unit>()
 
@@ -641,7 +704,7 @@ class GossipRpcPartsQueueTest {
 
         assertThat(partsQueue.estimateMaxSerializedSize()).isGreaterThan(0)
 
-        partsQueue.abort(ConnectionClosedException())
+        partsQueue.dropAll(ConnectionClosedException())
 
         assertThat(partsQueue.isEmpty()).isTrue()
         assertThat(partsQueue.estimateMaxSerializedSize()).isZero()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueueTest.kt
@@ -472,12 +472,13 @@ class GossipRpcPartsQueueTest {
         assertThat(urgentControlRpc.control.idontwantList).hasSize(1)
         assertThat(urgentControlRpc.control.graftList).isEmpty()
         assertThat(urgentControlRpc.control.ihaveList).isEmpty()
+        assertThat(urgentControlRpc.control.hasExtensions()).isTrue()
+        assertThat(urgentControlRpc.control.extensions.partialMessages).isTrue()
 
         val stateControlRpc = merged[1]
         assertThat(stateControlRpc.control.graftList).hasSize(1)
         assertThat(stateControlRpc.control.pruneList).hasSize(1)
-        assertThat(stateControlRpc.control.hasExtensions()).isTrue()
-        assertThat(stateControlRpc.control.extensions.partialMessages).isTrue()
+        assertThat(stateControlRpc.control.hasExtensions()).isFalse()
 
         val bulkRpc = merged[2]
         assertThat(bulkRpc.control.ihaveList).hasSize(1)
@@ -498,13 +499,17 @@ class GossipRpcPartsQueueTest {
         partsQueue.addControlExtensions(extension)
 
         val merged = partsQueue.takeMerged()
-        val stateControlRpc = merged[0]
-        val publishRpc = merged[1]
+        val urgentControlRpc = merged[0]
+        val stateControlRpc = merged[1]
+        val publishRpc = merged[2]
 
+        assertThat(urgentControlRpc.subscriptionsList).isEmpty()
+        assertThat(urgentControlRpc.publishList).isEmpty()
+        assertThat(urgentControlRpc.control.hasExtensions()).isTrue()
+        assertThat(urgentControlRpc.control.extensions.partialMessages).isTrue()
         assertThat(stateControlRpc.subscriptionsList).hasSize(1)
         assertThat(stateControlRpc.publishList).isEmpty()
-        assertThat(stateControlRpc.control.hasExtensions()).isTrue()
-        assertThat(stateControlRpc.control.extensions.partialMessages).isTrue()
+        assertThat(stateControlRpc.hasControl()).isFalse()
         assertThat(publishRpc.subscriptionsList).isEmpty()
         assertThat(publishRpc.publishList).hasSize(1)
     }
@@ -529,7 +534,7 @@ class GossipRpcPartsQueueTest {
         // Should be split into multiple RPCs due to maxPublishedMessages limit
         assertThat(merged.size).isGreaterThan(1)
 
-        // Extension is state/control priority, so it should go in the first RPC before bulk publishes.
+        // Extension is urgent-control priority, so it should go in the first RPC before bulk publishes.
         val firstRpc = merged.first()
         assertThat(firstRpc.hasControl()).isTrue()
         assertThat(firstRpc.control.hasExtensions()).isTrue()

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipSlowPeerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipSlowPeerTest.kt
@@ -1,0 +1,144 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.PeerId
+import io.libp2p.etc.types.millis
+import io.libp2p.etc.types.seconds
+import io.libp2p.pubsub.DefaultPubsubMessage
+import io.libp2p.pubsub.DeterministicFuzz
+import io.libp2p.pubsub.NOP_ROUTER_VALIDATOR
+import io.libp2p.pubsub.PubsubProtocol
+import io.libp2p.pubsub.SimpleSeenCache
+import io.libp2p.pubsub.TTLSeenCache
+import io.libp2p.pubsub.TestRouter
+import io.libp2p.pubsub.TopicSubscriptionFilter
+import io.netty.handler.logging.LogLevel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+import java.util.Random
+import java.util.concurrent.ScheduledExecutorService
+
+class GossipSlowPeerTest : GossipTestsBase() {
+
+    @Test
+    fun `notifySlowPeer is called after consecutive heartbeats above pending queue threshold`() {
+        val fuzz = DeterministicFuzz()
+        val params = GossipParams(
+            floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH,
+            slowPeerPendingBytesThreshold = 1,
+            slowPeerHeartbeatThreshold = 2
+        )
+        val gossipRouter = fuzz.createSlowPeerTrackingRouter(params)
+        val mockRouter = fuzz.createMockRouter()
+        val connection = gossipRouter.connectSemiDuplex(mockRouter, pubsubLogs = LogLevel.ERROR)
+        val router = gossipRouter.router as SlowPeerTrackingGossipRouter
+        val outboundChannel = connection.conn1.ch1
+
+        mockRouter.router.subscribe("topic1")
+        fuzz.timeController.addTime(100.millis)
+        outboundChannel.setWritableForTest(false)
+
+        router.publish(newMessage("topic1", 0L, "Hello".toByteArray()))
+        fuzz.timeController.addTime(100.millis)
+
+        fuzz.timeController.addTime(1.seconds)
+        assertThat(router.slowPeers).isEmpty()
+
+        fuzz.timeController.addTime(1.seconds)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+
+        fuzz.timeController.addTime(1.seconds)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+
+        fuzz.timeController.addTime(1.seconds)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId, mockRouter.peerId)
+    }
+
+    @Test
+    fun `slow peer pressure resets after queue shrinks below threshold`() {
+        val fuzz = DeterministicFuzz()
+        val params = GossipParams(
+            floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH,
+            slowPeerPendingBytesThreshold = 1,
+            slowPeerHeartbeatThreshold = 2
+        )
+        val gossipRouter = fuzz.createSlowPeerTrackingRouter(params)
+        val mockRouter = fuzz.createMockRouter()
+        val connection = gossipRouter.connectSemiDuplex(mockRouter, pubsubLogs = LogLevel.ERROR)
+        val router = gossipRouter.router as SlowPeerTrackingGossipRouter
+        val outboundChannel = connection.conn1.ch1
+
+        mockRouter.router.subscribe("topic1")
+        fuzz.timeController.addTime(100.millis)
+        outboundChannel.setWritableForTest(false)
+
+        router.publish(newMessage("topic1", 0L, "Hello-1".toByteArray()))
+        fuzz.timeController.addTime(100.millis)
+        fuzz.timeController.addTime(2.seconds)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+
+        outboundChannel.setWritableForTest(true)
+        outboundChannel.runPendingTasks()
+        fuzz.timeController.addTime(1.seconds)
+
+        outboundChannel.setWritableForTest(false)
+        router.publish(newMessage("topic1", 1L, "Hello-2".toByteArray()))
+        fuzz.timeController.addTime(100.millis)
+        fuzz.timeController.addTime(1.seconds)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+
+        fuzz.timeController.addTime(1.seconds)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId, mockRouter.peerId)
+    }
+
+    private fun DeterministicFuzz.createSlowPeerTrackingRouter(params: GossipParams): TestRouter {
+        return createTestRouter { executor, currentTimeSupplier, random ->
+            val score = DefaultGossipScore(GossipScoreParams(), executor, currentTimeSupplier)
+            SlowPeerTrackingGossipRouter(
+                params = params,
+                scoreParams = GossipScoreParams(),
+                currentTimeSupplier = currentTimeSupplier,
+                random = random,
+                executor = executor,
+                score = score
+            )
+        }
+    }
+
+    private class SlowPeerTrackingGossipRouter(
+        params: GossipParams,
+        scoreParams: GossipScoreParams,
+        currentTimeSupplier: CurrentTimeSupplier,
+        random: Random,
+        executor: ScheduledExecutorService,
+        score: DefaultGossipScore
+    ) : GossipRouter(
+        params = params,
+        scoreParams = scoreParams,
+        currentTimeSupplier = currentTimeSupplier,
+        random = random,
+        name = "SlowPeerTrackingGossipRouter",
+        mCache = MCache(params.gossipSize, params.gossipHistoryLength),
+        score = score,
+        subscriptionTopicSubscriptionFilter = TopicSubscriptionFilter.AllowAllTopicSubscriptionFilter(),
+        protocol = PubsubProtocol.Gossip_V_1_2,
+        executor = executor,
+        messageFactory = { DefaultPubsubMessage(it) },
+        seenMessages = TTLSeenCache(SimpleSeenCache(), params.seenTTL, currentTimeSupplier),
+        messageValidator = NOP_ROUTER_VALIDATOR
+    ) {
+
+        val slowPeers = mutableListOf<PeerId>()
+
+        init {
+            eventBroadcaster.listeners += score
+        }
+
+        override fun notifySlowPeer(peer: PeerHandler) {
+            slowPeers += peer.peerId
+        }
+
+        override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
+        }
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipSlowPeerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipSlowPeerTest.kt
@@ -3,10 +3,14 @@ package io.libp2p.pubsub.gossip
 import io.libp2p.core.PeerId
 import io.libp2p.core.multiformats.Multiaddr
 import io.libp2p.core.pubsub.ValidationResult
+import io.libp2p.etc.types.NonCompleteException
+import io.libp2p.etc.types.getX
 import io.libp2p.etc.types.millis
 import io.libp2p.etc.types.seconds
 import io.libp2p.pubsub.DefaultPubsubMessage
 import io.libp2p.pubsub.DeterministicFuzz
+import io.libp2p.pubsub.DeterministicFuzz.Companion.createGossipFuzzRouterFactory
+import io.libp2p.pubsub.DroppedRpcPartsException
 import io.libp2p.pubsub.NOP_ROUTER_VALIDATOR
 import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.PubsubProtocol
@@ -15,8 +19,10 @@ import io.libp2p.pubsub.TTLSeenCache
 import io.libp2p.pubsub.TestRouter
 import io.libp2p.pubsub.Topic
 import io.libp2p.pubsub.TopicSubscriptionFilter
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.netty.handler.logging.LogLevel
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import pubsub.pb.Rpc
 import java.util.Optional
@@ -24,6 +30,56 @@ import java.util.Random
 import java.util.concurrent.ScheduledExecutorService
 
 class GossipSlowPeerTest : GossipTestsBase() {
+
+    @Test
+    fun `slow gossip peer is downscored and its queued bulk parts are dropped`() {
+        val fuzz = DeterministicFuzz()
+        val params = GossipParams(
+            floodPublishMaxMessageSizeThreshold = ALWAYS_FLOOD_PUBLISH,
+            slowPeerPendingBytesThreshold = 1,
+            slowPeerHeartbeatThreshold = 1
+        )
+        val scoreParams = GossipScoreParams(
+            peerScoreParams = GossipPeerScoreParams(
+                behaviourPenaltyWeight = -1.0,
+                behaviourPenaltyThreshold = 0.0
+            )
+        )
+        val routerFactory = createGossipFuzzRouterFactory {
+            GossipRouterBuilder(
+                protocol = PubsubProtocol.Gossip_V_1_1,
+                params = params,
+                scoreParams = scoreParams,
+                enabledGossipExtensions = emptyList()
+            )
+        }
+        val router1 = fuzz.createTestRouter(routerFactory)
+        val router2 = fuzz.createTestRouter(routerFactory)
+        val connection = router1.connectSemiDuplex(router2, pubsubLogs = LogLevel.ERROR)
+        val gossipRouter1 = router1.router as GossipRouter
+        val gossipRouter2 = router2.router as GossipRouter
+
+        gossipRouter2.subscribe("topic1")
+        fuzz.timeController.addTime(100.millis)
+        connection.conn1.ch1.setWritableForTest(false)
+
+        val scoreBeforeSlowPeer = gossipRouter1.score.score(router2.peerId)
+        val publishFuture = gossipRouter1.publish(newMessage("topic1", 0L, "Hello".toByteArray()))
+        fuzz.timeController.addTime(100.millis)
+
+        assertThat(publishFuture).isNotDone()
+
+        fuzz.timeController.addTime(1.seconds)
+
+        assertThat(publishFuture).isCompletedExceptionally
+        val exception = assertThrows(NonCompleteException::class.java) { publishFuture.getX() }
+        assertThat(exception.cause).isInstanceOf(DroppedRpcPartsException::class.java)
+        assertThat(gossipRouter1.score.score(router2.peerId)).isLessThan(scoreBeforeSlowPeer)
+        assertThat(connection.conn1.ch1.isOpen).isTrue()
+        assertThat(connection.conn1.ch2.isOpen).isTrue()
+        assertThat(connection.conn2.ch1.isOpen).isTrue()
+        assertThat(connection.conn2.ch2.isOpen).isTrue()
+    }
 
     @Test
     fun `notifySlowPeer is called after consecutive heartbeats above pending queue threshold`() {
@@ -60,8 +116,8 @@ class GossipSlowPeerTest : GossipTestsBase() {
         assertThat(listener.slowPeers).containsExactly(mockRouter.peerId)
 
         fuzz.timeController.addTime(1.seconds)
-        assertThat(router.slowPeers).containsExactly(mockRouter.peerId, mockRouter.peerId)
-        assertThat(listener.slowPeers).containsExactly(mockRouter.peerId, mockRouter.peerId)
+        assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+        assertThat(listener.slowPeers).containsExactly(mockRouter.peerId)
     }
 
     @Test

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipSlowPeerTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipSlowPeerTest.kt
@@ -1,20 +1,25 @@
 package io.libp2p.pubsub.gossip
 
 import io.libp2p.core.PeerId
+import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.millis
 import io.libp2p.etc.types.seconds
 import io.libp2p.pubsub.DefaultPubsubMessage
 import io.libp2p.pubsub.DeterministicFuzz
 import io.libp2p.pubsub.NOP_ROUTER_VALIDATOR
+import io.libp2p.pubsub.PubsubMessage
 import io.libp2p.pubsub.PubsubProtocol
 import io.libp2p.pubsub.SimpleSeenCache
 import io.libp2p.pubsub.TTLSeenCache
 import io.libp2p.pubsub.TestRouter
+import io.libp2p.pubsub.Topic
 import io.libp2p.pubsub.TopicSubscriptionFilter
 import io.netty.handler.logging.LogLevel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import pubsub.pb.Rpc
+import java.util.Optional
 import java.util.Random
 import java.util.concurrent.ScheduledExecutorService
 
@@ -32,6 +37,8 @@ class GossipSlowPeerTest : GossipTestsBase() {
         val mockRouter = fuzz.createMockRouter()
         val connection = gossipRouter.connectSemiDuplex(mockRouter, pubsubLogs = LogLevel.ERROR)
         val router = gossipRouter.router as SlowPeerTrackingGossipRouter
+        val listener = SlowPeerTrackingListener()
+        router.eventBroadcaster.listeners += listener
         val outboundChannel = connection.conn1.ch1
 
         mockRouter.router.subscribe("topic1")
@@ -46,12 +53,15 @@ class GossipSlowPeerTest : GossipTestsBase() {
 
         fuzz.timeController.addTime(1.seconds)
         assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+        assertThat(listener.slowPeers).containsExactly(mockRouter.peerId)
 
         fuzz.timeController.addTime(1.seconds)
         assertThat(router.slowPeers).containsExactly(mockRouter.peerId)
+        assertThat(listener.slowPeers).containsExactly(mockRouter.peerId)
 
         fuzz.timeController.addTime(1.seconds)
         assertThat(router.slowPeers).containsExactly(mockRouter.peerId, mockRouter.peerId)
+        assertThat(listener.slowPeers).containsExactly(mockRouter.peerId, mockRouter.peerId)
     }
 
     @Test
@@ -135,10 +145,50 @@ class GossipSlowPeerTest : GossipTestsBase() {
         }
 
         override fun notifySlowPeer(peer: PeerHandler) {
+            super.notifySlowPeer(peer)
             slowPeers += peer.peerId
         }
 
         override fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler) {
+        }
+    }
+
+    private class SlowPeerTrackingListener : GossipRouterEventListener {
+        val slowPeers = mutableListOf<PeerId>()
+
+        override fun notifyDisconnected(peerId: PeerId) {
+        }
+
+        override fun notifyConnected(peerId: PeerId, peerAddress: Multiaddr) {
+        }
+
+        override fun notifyUnseenMessage(peerId: PeerId, msg: PubsubMessage) {
+        }
+
+        override fun notifySeenMessage(
+            peerId: PeerId,
+            msg: PubsubMessage,
+            validationResult: Optional<ValidationResult>
+        ) {
+        }
+
+        override fun notifyUnseenInvalidMessage(peerId: PeerId, msg: PubsubMessage) {
+        }
+
+        override fun notifyUnseenValidMessage(peerId: PeerId, msg: PubsubMessage) {
+        }
+
+        override fun notifyMeshed(peerId: PeerId, topic: Topic) {
+        }
+
+        override fun notifyPruned(peerId: PeerId, topic: Topic) {
+        }
+
+        override fun notifyRouterMisbehavior(peerId: PeerId, count: Int) {
+        }
+
+        override fun notifySlowPeer(peerId: PeerId) {
+            slowPeers += peerId
         }
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_2Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_2Tests.kt
@@ -162,12 +162,12 @@ class GossipV1_2Tests : GossipTestsBase() {
         test.gossipRouter.publish(msgToPublish)
         test.mockRouters.forEach {
             it.waitForMessage { msg ->
-                msg.publishCount > 0 &&
-                    msg.control.idontwantCount == 1 &&
+                msg.control.idontwantCount == 1 &&
                     msg.control.idontwantList.first().messageIDsList
                         .map { mIds -> mIds.toWBytes() }
                         .contains(msgToPublish.messageId)
             }
+            it.waitForMessage { msg -> msg.publishCount > 0 }
         }
     }
 

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_2Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_2Tests.kt
@@ -171,6 +171,36 @@ class GossipV1_2Tests : GossipTestsBase() {
         }
     }
 
+    @Test
+    fun iDontWantIsFlushedWhenAllPublishTargetsOptOut() {
+        val test = startSingleTopicNetwork(
+            params = GossipParams(iDontWantMinMessageSizeThreshold = 5),
+            mockRouterCount = 2
+        )
+
+        val msgToPublish = newMessage("topic1", 0L, "Hello".toByteArray())
+        test.mockRouters.forEach { peer ->
+            peer.sendToSingle(
+                Rpc.RPC.newBuilder().setControl(
+                    Rpc.ControlMessage.newBuilder().addIdontwant(
+                        Rpc.ControlIDontWant.newBuilder().addMessageIDs(msgToPublish.messageId.toProtobuf())
+                    )
+                ).build()
+            )
+        }
+        test.fuzz.timeController.addTime(100.millis)
+
+        test.gossipRouter.publish(msgToPublish)
+
+        test.mockRouters.forEach { peer ->
+            peer.waitForMessage { rpc ->
+                rpc.control.idontwantList.any { idontwant ->
+                    idontwant.messageIDsList.map { it.toWBytes() }.contains(msgToPublish.messageId)
+                }
+            }
+        }
+    }
+
     private fun startSingleTopicNetwork(params: GossipParams, mockRouterCount: Int): ManyRoutersTest {
         val test = ManyRoutersTest(
             protocol = PubsubProtocol.Gossip_V_1_2,

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_2Tests.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipV1_2Tests.kt
@@ -161,13 +161,13 @@ class GossipV1_2Tests : GossipTestsBase() {
         val msgToPublish = newMessage("topic1", 0L, "Hello".toByteArray())
         test.gossipRouter.publish(msgToPublish)
         test.mockRouters.forEach {
-            // IDONTWANT is received
             it.waitForMessage { msg ->
-                msg.control.idontwantCount == 1 &&
-                    msg.control.idontwantList.first().messageIDsList.map { mIds -> mIds.toWBytes() }.contains(msgToPublish.messageId)
+                msg.publishCount > 0 &&
+                    msg.control.idontwantCount == 1 &&
+                    msg.control.idontwantList.first().messageIDsList
+                        .map { mIds -> mIds.toWBytes() }
+                        .contains(msgToPublish.messageId)
             }
-            // msg is received
-            it.waitForMessage { msg -> msg.publishCount > 0 }
         }
     }
 


### PR DESCRIPTION
Followup for #505, #506, #507, #512

## Summary

- Detect peers whose outbound RPC queues remain above a configurable byte threshold for consecutive heartbeats.
- First drop low-priority bulk data while preserving higher-priority control messages.
- Drop all remaining queued data if removing low-priority data does not reduce the queue below the threshold.
- Fail affected publish futures with `DroppedRpcPartsException`.
- Notify router event listeners and apply a behavior penalty through `DefaultGossipScore`.
- Keep slow-peer connections open after trimming their queues.
- Expose slow-peer thresholds through `GossipParams` and `GossipParamsBuilder`; detection remains effectively disabled by default.

## Configuration note

The pending-bytes threshold should not be set too high, because that would allow excessive outbound data to accumulate before backpressure handling starts. It is expected that the threshold may be exceeded occasionally under normal bursty traffic; the consecutive-heartbeat threshold prevents these temporary bursts from classifying a peer as slow.
