### PR TITLE
Refactor Gossip router peer state lifecycle

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -66,10 +66,10 @@ abstract class AbstractRouter(
     ) {
         private val byPeer = linkedMapOf<PeerHandler, TState>()
 
-        fun getOrCreate(peer: PeerHandler): TState =
+        fun onConnected(peer: PeerHandler): TState =
             byPeer.computeIfAbsent(peer) { createState(it) }
 
-        fun getExisting(peer: PeerHandler): TState? =
+        fun get(peer: PeerHandler): TState? =
             byPeer[peer]
 
         fun getAllStates(): Collection<TState> = byPeer.values
@@ -92,12 +92,14 @@ abstract class AbstractRouter(
     }
 
     protected open fun submitPublishMessageSilently(toPeer: PeerHandler, msg: PubsubMessage) {
-        peerStates.getOrCreate(toPeer).rpcPartsQueue.addPublish(msg.protobufMessage)
+        peerStates.get(toPeer)?.rpcPartsQueue?.addPublish(msg.protobufMessage)
     }
 
     protected open fun submitPublishMessage(toPeer: PeerHandler, msg: PubsubMessage): CompletableFuture<Unit> {
+        val peerState = peerStates.get(toPeer)
+            ?: return completedExceptionally(ConnectionClosedException())
         val sendPromise = CompletableFuture<Unit>()
-        peerStates.getOrCreate(toPeer).rpcPartsQueue.addPublish(msg.protobufMessage, sendPromise)
+        peerState.rpcPartsQueue.addPublish(msg.protobufMessage, sendPromise)
         return sendPromise
     }
 
@@ -150,6 +152,11 @@ abstract class AbstractRouter(
         }
     }
 
+    override fun streamAdded(streamHandler: StreamHandler) {
+        super.streamAdded(streamHandler)
+        peerStates.onConnected(streamHandler.getPeerHandler())
+    }
+
     override fun removePeer(peer: Stream) {
         peer.close()
     }
@@ -175,7 +182,7 @@ abstract class AbstractRouter(
     protected abstract fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler)
 
     override fun onPeerActive(peer: PeerHandler) {
-        val partsQueue = peerStates.getOrCreate(peer).rpcPartsQueue
+        val partsQueue = peerStates.onConnected(peer).rpcPartsQueue
         subscribedTopics.forEach {
             partsQueue.addSubscribe(it)
         }
@@ -351,7 +358,7 @@ abstract class AbstractRouter(
     protected fun getTopicPeers(topic: Topic) = peersTopics.getBySecond(topic)
 
     override fun pollOutboundMessage(peer: PeerHandler): MessageAndPromise? {
-        val batch = peerStates.getExisting(peer)?.rpcPartsQueue?.takeBatch() ?: return null
+        val batch = peerStates.get(peer)?.rpcPartsQueue?.takeBatch() ?: return null
         return MessageAndPromise(batch.rpc, batch.writePromise)
     }
 
@@ -363,7 +370,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun subscribe(topic: Topic) {
-        activePeers.forEach { peerStates.getOrCreate(it).rpcPartsQueue.addSubscribe(topic) }
+        activePeers.forEach { peerStates.get(it)?.rpcPartsQueue?.addSubscribe(topic) }
         subscribedTopics += topic
     }
 
@@ -375,7 +382,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun unsubscribe(topic: Topic) {
-        activePeers.forEach { peerStates.getOrCreate(it).rpcPartsQueue.addUnsubscribe(topic) }
+        activePeers.forEach { peerStates.get(it)?.rpcPartsQueue?.addUnsubscribe(topic) }
         subscribedTopics -= topic
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -72,12 +72,7 @@ abstract class AbstractRouter(
         fun getExisting(peer: PeerHandler): TState? =
             byPeer[peer]
 
-        fun getPeersWithPendingOutboundData(): List<PeerHandler> =
-            byPeer.values
-                .filter { !it.rpcPartsQueue.isEmpty() }
-                .map { it.peer }
-
-        fun getStates(): Collection<TState> = byPeer.values
+        fun getAllStates(): Collection<TState> = byPeer.values
 
         fun onDisconnected(peer: PeerHandler) {
             byPeer.remove(peer)?.onDisconnected()
@@ -123,7 +118,11 @@ abstract class AbstractRouter(
      * Flushes all pending message parts for all peers
      */
     protected fun flushAllPending() {
-        peerStates.getPeersWithPendingOutboundData().forEach {
+        val peersWithPendingOutboundData: List<PeerHandler> =
+            peerStates.getAllStates()
+                .filter { !it.rpcPartsQueue.isEmpty() }
+                .map { it.peer }
+        peersWithPendingOutboundData.forEach {
             notifyOutboundDataAvailable(it)
         }
     }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -7,11 +7,8 @@ import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.*
 import io.libp2p.etc.util.MessageAndPromise
-import io.libp2p.etc.util.P2PService
 import io.libp2p.etc.util.P2PServiceSemiDuplex
 import io.libp2p.etc.util.netty.protobuf.LimitedProtobufVarint32FrameDecoder
-import io.libp2p.pubsub.AbstractRouter.PubsubPeerState
-import io.libp2p.pubsub.gossip.DefaultGossipRpcPartsQueue
 import io.netty.channel.ChannelHandler
 import io.netty.handler.codec.protobuf.ProtobufDecoder
 import io.netty.handler.codec.protobuf.ProtobufEncoder
@@ -51,7 +48,6 @@ abstract class AbstractRouter(
 
     protected open val peersTopics = mutableMultiBiMap<PeerHandler, Topic>()
     protected open val subscribedTopics = linkedSetOf<Topic>()
-    protected open val pendingRpcParts = PendingRpcPartsMap<RpcPartsQueue> { DefaultRpcPartsQueue() }
 
     protected open val peerStates = PubsubPeerStates(::PubsubPeerState)
 
@@ -68,7 +64,7 @@ abstract class AbstractRouter(
     protected class PubsubPeerStates<out TState : PubsubPeerState>(
         private val createState: (PeerHandler) -> TState
     ) {
-        private val byPeer = linkedMapOf<P2PService.PeerHandler, TState>()
+        private val byPeer = linkedMapOf<PeerHandler, TState>()
 
         fun getOrCreate(peer: PeerHandler): TState =
             byPeer.computeIfAbsent(peer) { createState(it) }
@@ -88,22 +84,6 @@ abstract class AbstractRouter(
         }
     }
 
-    protected class PendingRpcPartsMap<out TPartsQueue : RpcPartsQueue>(
-        private val queueFactory: () -> TPartsQueue
-    ) {
-        private val map = linkedMapOf<PeerHandler, TPartsQueue>()
-
-        fun getPeersWithPendingOutboundData() = map.entries
-            .filter { !it.value.isEmpty() }
-            .map { it.key }
-        fun getOrCreateQueue(peer: PeerHandler) = map.computeIfAbsent(peer) { queueFactory() }
-        fun getExistingQueue(peer: PeerHandler) = map[peer]
-        fun getQueues(): Map<PeerHandler, TPartsQueue> = map
-        fun onDisconnected(peer: PeerHandler) {
-            map.remove(peer)?.dropAll(ConnectionClosedException())
-        }
-    }
-
     override fun publish(msg: PubsubMessage): CompletableFuture<Unit> {
         return submitAsyncOnEventThread {
             if (msg in seenMessages) {
@@ -117,12 +97,12 @@ abstract class AbstractRouter(
     }
 
     protected open fun submitPublishMessageSilently(toPeer: PeerHandler, msg: PubsubMessage) {
-        pendingRpcParts.getOrCreateQueue(toPeer).addPublish(msg.protobufMessage)
+        peerStates.getOrCreate(toPeer).rpcPartsQueue.addPublish(msg.protobufMessage)
     }
 
     protected open fun submitPublishMessage(toPeer: PeerHandler, msg: PubsubMessage): CompletableFuture<Unit> {
         val sendPromise = CompletableFuture<Unit>()
-        pendingRpcParts.getOrCreateQueue(toPeer).addPublish(msg.protobufMessage, sendPromise)
+        peerStates.getOrCreate(toPeer).rpcPartsQueue.addPublish(msg.protobufMessage, sendPromise)
         return sendPromise
     }
 
@@ -143,7 +123,7 @@ abstract class AbstractRouter(
      * Flushes all pending message parts for all peers
      */
     protected fun flushAllPending() {
-        pendingRpcParts.getPeersWithPendingOutboundData().forEach {
+        peerStates.getPeersWithPendingOutboundData().forEach {
             notifyOutboundDataAvailable(it)
         }
     }
@@ -196,7 +176,7 @@ abstract class AbstractRouter(
     protected abstract fun processExtensions(msg: Rpc.RPC, receivedFrom: PeerHandler)
 
     override fun onPeerActive(peer: PeerHandler) {
-        val partsQueue = pendingRpcParts.getOrCreateQueue(peer)
+        val partsQueue = peerStates.getOrCreate(peer).rpcPartsQueue
         subscribedTopics.forEach {
             partsQueue.addSubscribe(it)
         }
@@ -344,7 +324,7 @@ abstract class AbstractRouter(
     override fun onPeerDisconnected(peer: PeerHandler) {
         super.onPeerDisconnected(peer)
         peersTopics.removeAllByFirst(peer)
-        pendingRpcParts.onDisconnected(peer)
+        peerStates.onDisconnected(peer)
     }
 
     override fun onPeerWireException(peer: PeerHandler?, cause: Throwable) {
@@ -372,7 +352,7 @@ abstract class AbstractRouter(
     protected fun getTopicPeers(topic: Topic) = peersTopics.getBySecond(topic)
 
     override fun pollOutboundMessage(peer: PeerHandler): MessageAndPromise? {
-        val batch = pendingRpcParts.getExistingQueue(peer)?.takeBatch() ?: return null
+        val batch = peerStates.getExisting(peer)?.rpcPartsQueue?.takeBatch() ?: return null
         return MessageAndPromise(batch.rpc, batch.writePromise)
     }
 
@@ -384,7 +364,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun subscribe(topic: Topic) {
-        activePeers.forEach { pendingRpcParts.getOrCreateQueue(it).addSubscribe(topic) }
+        activePeers.forEach { peerStates.getOrCreate(it).rpcPartsQueue.addSubscribe(topic) }
         subscribedTopics += topic
     }
 
@@ -396,7 +376,7 @@ abstract class AbstractRouter(
     }
 
     protected open fun unsubscribe(topic: Topic) {
-        activePeers.forEach { pendingRpcParts.getOrCreateQueue(it).addUnsubscribe(topic) }
+        activePeers.forEach { peerStates.getOrCreate(it).rpcPartsQueue.addUnsubscribe(topic) }
         subscribedTopics -= topic
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/AbstractRouter.kt
@@ -7,8 +7,11 @@ import io.libp2p.core.Stream
 import io.libp2p.core.pubsub.ValidationResult
 import io.libp2p.etc.types.*
 import io.libp2p.etc.util.MessageAndPromise
+import io.libp2p.etc.util.P2PService
 import io.libp2p.etc.util.P2PServiceSemiDuplex
 import io.libp2p.etc.util.netty.protobuf.LimitedProtobufVarint32FrameDecoder
+import io.libp2p.pubsub.AbstractRouter.PubsubPeerState
+import io.libp2p.pubsub.gossip.DefaultGossipRpcPartsQueue
 import io.netty.channel.ChannelHandler
 import io.netty.handler.codec.protobuf.ProtobufDecoder
 import io.netty.handler.codec.protobuf.ProtobufEncoder
@@ -49,6 +52,41 @@ abstract class AbstractRouter(
     protected open val peersTopics = mutableMultiBiMap<PeerHandler, Topic>()
     protected open val subscribedTopics = linkedSetOf<Topic>()
     protected open val pendingRpcParts = PendingRpcPartsMap<RpcPartsQueue> { DefaultRpcPartsQueue() }
+
+    protected open val peerStates = PubsubPeerStates(::PubsubPeerState)
+
+    protected open class PubsubPeerState(
+        val peer: PeerHandler
+    ) {
+        open val rpcPartsQueue: RpcPartsQueue = DefaultRpcPartsQueue()
+
+        open fun onDisconnected() {
+            rpcPartsQueue.dropAll(ConnectionClosedException())
+        }
+    }
+
+    protected class PubsubPeerStates<out TState : PubsubPeerState>(
+        private val createState: (PeerHandler) -> TState
+    ) {
+        private val byPeer = linkedMapOf<P2PService.PeerHandler, TState>()
+
+        fun getOrCreate(peer: PeerHandler): TState =
+            byPeer.computeIfAbsent(peer) { createState(it) }
+
+        fun getExisting(peer: PeerHandler): TState? =
+            byPeer[peer]
+
+        fun getPeersWithPendingOutboundData(): List<PeerHandler> =
+            byPeer.values
+                .filter { !it.rpcPartsQueue.isEmpty() }
+                .map { it.peer }
+
+        fun getStates(): Collection<TState> = byPeer.values
+
+        fun onDisconnected(peer: PeerHandler) {
+            byPeer.remove(peer)?.onDisconnected()
+        }
+    }
 
     protected class PendingRpcPartsMap<out TPartsQueue : RpcPartsQueue>(
         private val queueFactory: () -> TPartsQueue

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -677,7 +677,7 @@ open class GossipRouter(
         val curTime = this.currentTimeSupplier()
         val staleIWantTime = curTime - params.iWantFollowupTime.toMillis()
         val staleIDontWantTime = curTime - params.iDontWantTTL.toMillis()
-        peerStates.getStates().forEach { peerState ->
+        peerStates.getAllStates().forEach { peerState ->
             peerState.iHaveMessagesReceived = 0
             peerState.iHaveMessageIdsAsked = 0
             peerState.iWantRequests.entries.removeIf { (messageId, time) ->
@@ -777,7 +777,7 @@ open class GossipRouter(
     }
 
     private fun trackSlowPeers() {
-        peerStates.getStates().forEach { peerState ->
+        peerStates.getAllStates().forEach { peerState ->
             val queue = peerState.rpcPartsQueue
             if (queue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
                 peerState.slowPeerHeartbeatsAboveThreshold++

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -131,10 +131,10 @@ open class GossipRouter(
 
         var iHaveMessagesReceived: Int = 0
         var iHaveMessageIdsAsked: Int = 0
-        val iWantRequests: MutableMap<MessageId, Long> = mutableMapOf()
-        val iDontWant: IDontWantCacheEntry = IDontWantCacheEntry()
+        val iWantRequestTimes: MutableMap<MessageId, Long> = mutableMapOf()
+        val iDontWantState: IDontWantState = IDontWantState()
         val backoffExpireTimes: MutableMap<Topic, Long> = mutableMapOf()
-        var acceptRequestsWhitelistEntry: AcceptRequestsWhitelistEntry? = null
+        var acceptRequestsWhitelistState: AcceptRequestsWhitelistState? = null
         var slowPeerHeartbeatsAboveThreshold: Int = 0
     }
 
@@ -204,7 +204,7 @@ open class GossipRouter(
     }
 
     protected open fun notifyAnyMessage(peer: PeerHandler, msg: PubsubMessage) {
-        if (peerStates.getExisting(peer)?.iWantRequests?.remove(msg.messageId) != null) {
+        if (peerStates.getExisting(peer)?.iWantRequestTimes?.remove(msg.messageId) != null) {
             notifyIWantComplete(peer, msg)
         }
     }
@@ -258,20 +258,20 @@ open class GossipRouter(
 
         val curTime = currentTimeSupplier()
         val peerState = peerStates.getOrCreate(peer)
-        val whitelistEntry = peerState.acceptRequestsWhitelistEntry
+        val whitelistEntry = peerState.acceptRequestsWhitelistState
         if (whitelistEntry != null &&
             curTime <= whitelistEntry.whitelistedTill &&
             whitelistEntry.messagesAccepted < acceptRequestsWhitelistMaxMessages
         ) {
-            peerState.acceptRequestsWhitelistEntry = whitelistEntry.incrementMessageCount()
+            peerState.acceptRequestsWhitelistState = whitelistEntry.incrementMessageCount()
             return true
         }
 
         val peerScore = score.score(peer.peerId)
         if (peerScore >= acceptRequestsWhitelistThresholdScore) {
-            peerState.acceptRequestsWhitelistEntry = AcceptRequestsWhitelistEntry(curTime + acceptRequestsWhitelistDuration.toMillis())
+            peerState.acceptRequestsWhitelistState = AcceptRequestsWhitelistState(curTime + acceptRequestsWhitelistDuration.toMillis())
         } else {
-            peerState.acceptRequestsWhitelistEntry = null
+            peerState.acceptRequestsWhitelistState = null
         }
 
         return peerScore >= scoreParams.graylistThreshold
@@ -407,7 +407,7 @@ open class GossipRouter(
         if (!this.protocol.supportsIDontWant()) return
         val peerScore = score.score(peer.peerId)
         if (peerScore < scoreParams.gossipThreshold) return
-        val iDontWantCacheEntry = peerStates.getOrCreate(peer).iDontWant
+        val iDontWantCacheEntry = peerStates.getOrCreate(peer).iDontWantState
         iDontWantCacheEntry.heartbeatMessageIdsCount += msg.messageIDsCount
         if (iDontWantCacheEntry.heartbeatMessageIdsCount > params.maxIDontWantMessageIds) {
             return
@@ -680,15 +680,15 @@ open class GossipRouter(
         peerStates.getAllStates().forEach { peerState ->
             peerState.iHaveMessagesReceived = 0
             peerState.iHaveMessageIdsAsked = 0
-            peerState.iWantRequests.entries.removeIf { (messageId, time) ->
+            peerState.iWantRequestTimes.entries.removeIf { (messageId, time) ->
                 (time < staleIWantTime)
                     .whenTrue { notifyIWantTimeout(peerState.peer, messageId) }
             }
             peerState.backoffExpireTimes.entries.removeIf { (_, expireTime) ->
                 expireTime <= curTime
             }
-            peerState.iDontWant.heartbeatMessageIdsCount = 0
-            peerState.iDontWant.messageIdsAndTimeReceived.values.removeIf { timeReceived ->
+            peerState.iDontWantState.heartbeatMessageIdsCount = 0
+            peerState.iDontWantState.messageIdsAndTimeReceived.values.removeIf { timeReceived ->
                 timeReceived < staleIDontWantTime
             }
         }
@@ -822,13 +822,13 @@ open class GossipRouter(
     }
 
     private fun peerDoesNotWantMessage(peer: PeerHandler, messageId: MessageId): Boolean {
-        return peerStates.getExisting(peer)?.iDontWant?.messageIdsAndTimeReceived?.contains(messageId) == true
+        return peerStates.getExisting(peer)?.iDontWantState?.messageIdsAndTimeReceived?.contains(messageId) == true
     }
 
     private fun iWant(peer: PeerHandler, messageIds: List<MessageId>) {
         if (messageIds.isEmpty()) return
         messageIds[random.nextInt(messageIds.size)]
-            .also { peerStates.getOrCreate(peer).iWantRequests[it] = currentTimeSupplier() }
+            .also { peerStates.getOrCreate(peer).iWantRequestTimes[it] = currentTimeSupplier() }
         enqueueIwant(peer, messageIds)
     }
 
@@ -896,11 +896,11 @@ open class GossipRouter(
         gossipExtensionsState.registerControlExtensionMessageSentToPeers(peer.peerId)
     }
 
-    data class AcceptRequestsWhitelistEntry(val whitelistedTill: Long, val messagesAccepted: Int = 0) {
-        fun incrementMessageCount() = AcceptRequestsWhitelistEntry(whitelistedTill, messagesAccepted + 1)
+    data class AcceptRequestsWhitelistState(val whitelistedTill: Long, val messagesAccepted: Int = 0) {
+        fun incrementMessageCount() = AcceptRequestsWhitelistState(whitelistedTill, messagesAccepted + 1)
     }
 
-    data class IDontWantCacheEntry(
+    data class IDontWantState(
         var heartbeatMessageIdsCount: Int = 0,
         val messageIdsAndTimeReceived: MutableMap<MessageId, Long> = mutableMapOf()
     )

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -672,11 +672,9 @@ open class GossipRouter(
 
     private fun heartbeat() {
         heartbeatsCount++
-        trackSlowPeers()
 
-        val curTime = this.currentTimeSupplier()
-        val staleIWantTime = curTime - params.iWantFollowupTime.toMillis()
-        val staleIDontWantTime = curTime - params.iDontWantTTL.toMillis()
+        val staleIWantTime = currentTimeSupplier() - params.iWantFollowupTime.toMillis()
+        val staleIDontWantTime = currentTimeSupplier() - params.iDontWantTTL.toMillis()
         peerStates.getAllStates().forEach { peerState ->
             peerState.iHaveMessagesReceived = 0
             peerState.iHaveMessageIdsAsked = 0
@@ -684,13 +682,11 @@ open class GossipRouter(
                 (time < staleIWantTime)
                     .whenTrue { notifyIWantTimeout(peerState.peer, messageId) }
             }
-            peerState.backoffExpireTimes.entries.removeIf { (_, expireTime) ->
-                expireTime <= curTime
-            }
             peerState.iDontWantState.heartbeatMessageIdsCount = 0
             peerState.iDontWantState.messageIdsAndTimeReceived.values.removeIf { timeReceived ->
                 timeReceived < staleIDontWantTime
             }
+            trackSlowPeer(peerState)
         }
 
         try {
@@ -776,18 +772,16 @@ open class GossipRouter(
         }
     }
 
-    private fun trackSlowPeers() {
-        peerStates.getAllStates().forEach { peerState ->
-            val queue = peerState.rpcPartsQueue
-            if (queue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
-                peerState.slowPeerHeartbeatsAboveThreshold++
-                if (peerState.slowPeerHeartbeatsAboveThreshold >= params.slowPeerHeartbeatThreshold) {
-                    notifySlowPeer(peerState.peer)
-                    peerState.slowPeerHeartbeatsAboveThreshold = 0
-                }
-            } else {
+    private fun trackSlowPeer(peerState: GossipPeerState) {
+        val queue = peerState.rpcPartsQueue
+        if (queue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
+            peerState.slowPeerHeartbeatsAboveThreshold++
+            if (peerState.slowPeerHeartbeatsAboveThreshold >= params.slowPeerHeartbeatThreshold) {
+                notifySlowPeer(peerState.peer)
                 peerState.slowPeerHeartbeatsAboveThreshold = 0
             }
+        } else {
+            peerState.slowPeerHeartbeatsAboveThreshold = 0
         }
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -140,14 +140,14 @@ open class GossipRouter(
 
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
-        peerStates.getOrCreate(peer).backoffExpireTimes[topic] = currentTimeSupplier() + delay
+        peerStates.get(peer)?.backoffExpireTimes?.set(topic, currentTimeSupplier() + delay)
     }
 
     private fun isBackOff(peer: PeerHandler, topic: Topic) =
-        currentTimeSupplier() < (peerStates.getExisting(peer)?.backoffExpireTimes?.get(topic) ?: 0)
+        currentTimeSupplier() < (peerStates.get(peer)?.backoffExpireTimes?.get(topic) ?: 0)
 
     private fun isBackOffFlood(peer: PeerHandler, topic: Topic): Boolean {
-        val expire = peerStates.getExisting(peer)?.backoffExpireTimes?.get(topic) ?: return false
+        val expire = peerStates.get(peer)?.backoffExpireTimes?.get(topic) ?: return false
         return currentTimeSupplier() < expire - (params.pruneBackoff + params.graftFloodThreshold).toMillis()
     }
 
@@ -204,7 +204,7 @@ open class GossipRouter(
     }
 
     protected open fun notifyAnyMessage(peer: PeerHandler, msg: PubsubMessage) {
-        if (peerStates.getExisting(peer)?.iWantRequestTimes?.remove(msg.messageId) != null) {
+        if (peerStates.get(peer)?.iWantRequestTimes?.remove(msg.messageId) != null) {
             notifyIWantComplete(peer, msg)
         }
     }
@@ -243,7 +243,7 @@ open class GossipRouter(
     }
 
     fun trimOutboundQueue(peer: PeerHandler) {
-        val partsQueue = peerStates.getExisting(peer)?.rpcPartsQueue ?: return
+        val partsQueue = peerStates.get(peer)?.rpcPartsQueue ?: return
         partsQueue.dropLowPriority()
         if (partsQueue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
             // last resort is to drop all the queued parts
@@ -257,7 +257,7 @@ open class GossipRouter(
         }
 
         val curTime = currentTimeSupplier()
-        val peerState = peerStates.getOrCreate(peer)
+        val peerState = peerStates.get(peer) ?: return false
         val whitelistEntry = peerState.acceptRequestsWhitelistState
         if (whitelistEntry != null &&
             curTime <= whitelistEntry.whitelistedTill &&
@@ -375,7 +375,7 @@ open class GossipRouter(
         val peerScore = score.score(peer.peerId)
         // we ignore IHAVE gossip from any peer whose score is below the gossip threshold
         if (peerScore < scoreParams.gossipThreshold) return
-        val peerState = peerStates.getOrCreate(peer)
+        val peerState = peerStates.get(peer) ?: return
         peerState.iHaveMessagesReceived++
         if (peerState.iHaveMessagesReceived > params.maxIHaveMessages) {
             // peer has advertised too many times within this heartbeat interval, ignoring
@@ -407,7 +407,7 @@ open class GossipRouter(
         if (!this.protocol.supportsIDontWant()) return
         val peerScore = score.score(peer.peerId)
         if (peerScore < scoreParams.gossipThreshold) return
-        val iDontWantCacheEntry = peerStates.getOrCreate(peer).iDontWantState
+        val iDontWantCacheEntry = peerStates.get(peer)?.iDontWantState ?: return
         iDontWantCacheEntry.heartbeatMessageIdsCount += msg.messageIDsCount
         if (iDontWantCacheEntry.heartbeatMessageIdsCount > params.maxIDontWantMessageIds) {
             return
@@ -816,13 +816,13 @@ open class GossipRouter(
     }
 
     private fun peerDoesNotWantMessage(peer: PeerHandler, messageId: MessageId): Boolean {
-        return peerStates.getExisting(peer)?.iDontWantState?.messageIdsAndTimeReceived?.contains(messageId) == true
+        return peerStates.get(peer)?.iDontWantState?.messageIdsAndTimeReceived?.contains(messageId) == true
     }
 
     private fun iWant(peer: PeerHandler, messageIds: List<MessageId>) {
         if (messageIds.isEmpty()) return
         messageIds[random.nextInt(messageIds.size)]
-            .also { peerStates.getOrCreate(peer).iWantRequestTimes[it] = currentTimeSupplier() }
+            .also { peerStates.get(peer)?.iWantRequestTimes?.set(it, currentTimeSupplier()) }
         enqueueIwant(peer, messageIds)
     }
 
@@ -839,7 +839,7 @@ open class GossipRouter(
     }
 
     private fun enqueuePrune(peer: PeerHandler, topic: Topic) {
-        val peerQueue = peerStates.getOrCreate(peer).rpcPartsQueue
+        val peerQueue = peerStates.get(peer)?.rpcPartsQueue ?: return
         if (peer.getPeerProtocol().supportsBackoffAndPX() && this.protocol.supportsBackoffAndPX()) {
             val backoffPeers = (getTopicPeers(topic) - peer)
                 .take(params.maxPeersSentInPruneMsg)
@@ -852,19 +852,19 @@ open class GossipRouter(
     }
 
     private fun enqueueGraft(peer: PeerHandler, topic: Topic) =
-        peerStates.getOrCreate(peer).rpcPartsQueue.addGraft(topic)
+        peerStates.get(peer)?.rpcPartsQueue?.addGraft(topic)
 
     private fun enqueueIwant(peer: PeerHandler, messageIds: List<MessageId>) =
-        peerStates.getOrCreate(peer).rpcPartsQueue.addIWants(messageIds)
+        peerStates.get(peer)?.rpcPartsQueue?.addIWants(messageIds)
 
     private fun enqueueIhave(peer: PeerHandler, messageIds: List<MessageId>, topic: Topic) =
-        peerStates.getOrCreate(peer).rpcPartsQueue.addIHaves(messageIds, topic)
+        peerStates.get(peer)?.rpcPartsQueue?.addIHaves(messageIds, topic)
 
     private fun enqueueIDontWant(peer: PeerHandler, messageId: MessageId) {
         if (!peer.getPeerProtocol().supportsIDontWant()) {
             return
         }
-        peerStates.getOrCreate(peer).rpcPartsQueue.addIDontWant(messageId)
+        peerStates.get(peer)?.rpcPartsQueue?.addIDontWant(messageId)
     }
 
     private fun sendControlExtensions(peer: PeerHandler) {
@@ -885,8 +885,8 @@ open class GossipRouter(
 
         logger.trace("Sending control extensions message to peer {}", peer.peerId)
 
-        peerStates.getOrCreate(peer).rpcPartsQueue
-            .addControlExtensions(gossipExtensionsState.localExtensionSupport)
+        val peerQueue = peerStates.get(peer)?.rpcPartsQueue ?: return
+        peerQueue.addControlExtensions(gossipExtensionsState.localExtensionSupport)
         gossipExtensionsState.registerControlExtensionMessageSentToPeers(peer.peerId)
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -1,6 +1,5 @@
 package io.libp2p.pubsub.gossip
 
-import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.core.multiformats.Multiaddr
@@ -16,7 +15,6 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.collections.Collection
 import kotlin.collections.List
 import kotlin.collections.MutableMap
@@ -50,13 +48,6 @@ import kotlin.collections.take
 import kotlin.collections.toMutableSet
 import kotlin.math.max
 import kotlin.math.min
-
-const val MaxBackoffEntries = 10 * 1024
-const val MaxIAskedEntries = 256
-const val MaxPeerIHaveEntries = 256
-const val MaxIWantRequestsEntries = 10 * 1024
-const val MaxPeerIDontWantEntries = 256
-const val MaxSlowPeerPressureEntries = 256
 
 typealias CurrentTimeSupplier = () -> Long
 
@@ -120,12 +111,6 @@ open class GossipRouter(
 
     private val lastPublished = linkedMapOf<Topic, Long>()
     private var heartbeatsCount = 0
-    private val backoffExpireTimes = createLRUMap<Pair<PeerId, Topic>, Long>(MaxBackoffEntries)
-    private val iAsked = createLRUMap<PeerHandler, AtomicInteger>(MaxIAskedEntries)
-    private val peerIHave = createLRUMap<PeerHandler, AtomicInteger>(MaxPeerIHaveEntries)
-    private val iWantRequests = createLRUMap<Pair<PeerHandler, MessageId>, Long>(MaxIWantRequestsEntries)
-    private val peerIDontWant = createLRUMap<PeerHandler, IDontWantCacheEntry>(MaxPeerIDontWantEntries)
-    private val slowPeerQueuePressure = createLRUMap<PeerHandler, SlowPeerQueuePressure>(MaxSlowPeerPressureEntries)
     private val heartbeatTask by lazy {
         executor.scheduleWithFixedDelay(
             ::catchingHeartbeat,
@@ -134,11 +119,8 @@ open class GossipRouter(
             TimeUnit.MILLISECONDS
         )
     }
-    private val acceptRequestsWhitelist = mutableMapOf<PeerHandler, AcceptRequestsWhitelistEntry>()
-    override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
     val gossipExtensionsState = GossipExtensionsState(gossipExtensionsConfig)
-
 
     override val peerStates = PubsubPeerStates(::GossipPeerState)
 
@@ -147,22 +129,25 @@ open class GossipRouter(
     ) : PubsubPeerState(peer) {
         override val rpcPartsQueue: GossipRpcPartsQueue = DefaultGossipRpcPartsQueue(params)
 
-        override fun onDisconnected() {
-            rpcPartsQueue.dropAll(ConnectionClosedException())
-        }
+        var iHaveMessagesReceived: Int = 0
+        var iHaveMessageIdsAsked: Int = 0
+        val iWantRequests: MutableMap<MessageId, Long> = mutableMapOf()
+        val iDontWant: IDontWantCacheEntry = IDontWantCacheEntry()
+        val backoffExpireTimes: MutableMap<Topic, Long> = mutableMapOf()
+        var acceptRequestsWhitelistEntry: AcceptRequestsWhitelistEntry? = null
+        var slowPeerHeartbeatsAboveThreshold: Int = 0
     }
-
 
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {
-        backoffExpireTimes[peer.peerId to topic] = currentTimeSupplier() + delay
+        peerStates.getOrCreate(peer).backoffExpireTimes[topic] = currentTimeSupplier() + delay
     }
 
     private fun isBackOff(peer: PeerHandler, topic: Topic) =
-        currentTimeSupplier() < (backoffExpireTimes[peer.peerId to topic] ?: 0)
+        currentTimeSupplier() < (peerStates.getExisting(peer)?.backoffExpireTimes?.get(topic) ?: 0)
 
     private fun isBackOffFlood(peer: PeerHandler, topic: Topic): Boolean {
-        val expire = backoffExpireTimes[peer.peerId to topic] ?: return false
+        val expire = peerStates.getExisting(peer)?.backoffExpireTimes?.get(topic) ?: return false
         return currentTimeSupplier() < expire - (params.pruneBackoff + params.graftFloodThreshold).toMillis()
     }
 
@@ -176,8 +161,6 @@ open class GossipRouter(
         eventBroadcaster.notifyDisconnected(peer.peerId)
         mesh.values.forEach { it.remove(peer) }
         fanout.values.forEach { it.remove(peer) }
-        acceptRequestsWhitelist -= peer
-        slowPeerQueuePressure -= peer
         gossipExtensionsState.onPeerDisconnected(peer.peerId)
         super.onPeerDisconnected(peer)
     }
@@ -221,7 +204,7 @@ open class GossipRouter(
     }
 
     protected open fun notifyAnyMessage(peer: PeerHandler, msg: PubsubMessage) {
-        if (iWantRequests.remove(peer to msg.messageId) != null) {
+        if (peerStates.getExisting(peer)?.iWantRequests?.remove(msg.messageId) != null) {
             notifyIWantComplete(peer, msg)
         }
     }
@@ -260,7 +243,7 @@ open class GossipRouter(
     }
 
     fun trimOutboundQueue(peer: PeerHandler) {
-        val partsQueue = pendingRpcParts.getExistingQueue(peer) ?: return
+        val partsQueue = peerStates.getExisting(peer)?.rpcPartsQueue ?: return
         partsQueue.dropLowPriority()
         if (partsQueue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
             // last resort is to drop all the queued parts
@@ -274,21 +257,21 @@ open class GossipRouter(
         }
 
         val curTime = currentTimeSupplier()
-        val whitelistEntry = acceptRequestsWhitelist[peer]
+        val peerState = peerStates.getOrCreate(peer)
+        val whitelistEntry = peerState.acceptRequestsWhitelistEntry
         if (whitelistEntry != null &&
             curTime <= whitelistEntry.whitelistedTill &&
             whitelistEntry.messagesAccepted < acceptRequestsWhitelistMaxMessages
         ) {
-            acceptRequestsWhitelist[peer] = whitelistEntry.incrementMessageCount()
+            peerState.acceptRequestsWhitelistEntry = whitelistEntry.incrementMessageCount()
             return true
         }
 
         val peerScore = score.score(peer.peerId)
         if (peerScore >= acceptRequestsWhitelistThresholdScore) {
-            acceptRequestsWhitelist[peer] =
-                AcceptRequestsWhitelistEntry(curTime + acceptRequestsWhitelistDuration.toMillis())
+            peerState.acceptRequestsWhitelistEntry = AcceptRequestsWhitelistEntry(curTime + acceptRequestsWhitelistDuration.toMillis())
         } else {
-            acceptRequestsWhitelist -= peer
+            peerState.acceptRequestsWhitelistEntry = null
         }
 
         return peerScore >= scoreParams.graylistThreshold
@@ -392,12 +375,13 @@ open class GossipRouter(
         val peerScore = score.score(peer.peerId)
         // we ignore IHAVE gossip from any peer whose score is below the gossip threshold
         if (peerScore < scoreParams.gossipThreshold) return
-        if (peerIHave.computeIfAbsent(peer) { AtomicInteger() }.incrementAndGet() > params.maxIHaveMessages) {
+        val peerState = peerStates.getOrCreate(peer)
+        peerState.iHaveMessagesReceived++
+        if (peerState.iHaveMessagesReceived > params.maxIHaveMessages) {
             // peer has advertised too many times within this heartbeat interval, ignoring
             return
         }
-        val asked = iAsked.computeIfAbsent(peer) { AtomicInteger() }
-        if (asked.get() >= params.maxIHaveLength) {
+        if (peerState.iHaveMessageIdsAsked >= params.maxIHaveLength) {
             // peer has already advertised too many messages, ignoring
             return
         }
@@ -405,8 +389,8 @@ open class GossipRouter(
         val iWant = msg.messageIDsList
             .map { it.toWBytes() }
             .filterNot { seenMessages.isSeen(it) }
-        val maxToAsk = min(iWant.size, params.maxIHaveLength - asked.get())
-        asked.addAndGet(maxToAsk)
+        val maxToAsk = min(iWant.size, params.maxIHaveLength - peerState.iHaveMessageIdsAsked)
+        peerState.iHaveMessageIdsAsked += maxToAsk
         iWant(peer, iWant.shuffled(random).subList(0, maxToAsk))
     }
 
@@ -423,7 +407,7 @@ open class GossipRouter(
         if (!this.protocol.supportsIDontWant()) return
         val peerScore = score.score(peer.peerId)
         if (peerScore < scoreParams.gossipThreshold) return
-        val iDontWantCacheEntry = peerIDontWant.computeIfAbsent(peer) { IDontWantCacheEntry() }
+        val iDontWantCacheEntry = peerStates.getOrCreate(peer).iDontWant
         iDontWantCacheEntry.heartbeatMessageIdsCount += msg.messageIDsCount
         if (iDontWantCacheEntry.heartbeatMessageIdsCount > params.maxIDontWantMessageIds) {
             return
@@ -688,23 +672,25 @@ open class GossipRouter(
 
     private fun heartbeat() {
         heartbeatsCount++
-        iAsked.clear()
-        peerIHave.clear()
         trackSlowPeers()
 
-        val staleIWantTime = this.currentTimeSupplier() - params.iWantFollowupTime.toMillis()
-        iWantRequests.entries.removeIf { (key, time) ->
-            (time < staleIWantTime)
-                .whenTrue { notifyIWantTimeout(key.first, key.second) }
-        }
-
-        val staleIDontWantTime = this.currentTimeSupplier() - params.iDontWantTTL.toMillis()
-        peerIDontWant.entries.removeIf { (_, cacheEntry) ->
-            // reset on heartbeat
-            cacheEntry.heartbeatMessageIdsCount = 0
-            cacheEntry.messageIdsAndTimeReceived.values.removeIf { timeReceived -> timeReceived < staleIDontWantTime }
-            // remove entry for peer if no IDONTWANT message ids are left in the cache
-            cacheEntry.messageIdsAndTimeReceived.isEmpty()
+        val curTime = this.currentTimeSupplier()
+        val staleIWantTime = curTime - params.iWantFollowupTime.toMillis()
+        val staleIDontWantTime = curTime - params.iDontWantTTL.toMillis()
+        peerStates.getStates().forEach { peerState ->
+            peerState.iHaveMessagesReceived = 0
+            peerState.iHaveMessageIdsAsked = 0
+            peerState.iWantRequests.entries.removeIf { (messageId, time) ->
+                (time < staleIWantTime)
+                    .whenTrue { notifyIWantTimeout(peerState.peer, messageId) }
+            }
+            peerState.backoffExpireTimes.entries.removeIf { (_, expireTime) ->
+                expireTime <= curTime
+            }
+            peerState.iDontWant.heartbeatMessageIdsCount = 0
+            peerState.iDontWant.messageIdsAndTimeReceived.values.removeIf { timeReceived ->
+                timeReceived < staleIDontWantTime
+            }
         }
 
         try {
@@ -791,16 +777,16 @@ open class GossipRouter(
     }
 
     private fun trackSlowPeers() {
-        pendingRpcParts.getQueues().forEach { (peer, queue) ->
+        peerStates.getStates().forEach { peerState ->
+            val queue = peerState.rpcPartsQueue
             if (queue.estimateMaxSerializedSize() >= params.slowPeerPendingBytesThreshold) {
-                val pressure = slowPeerQueuePressure.getOrPut(peer) { SlowPeerQueuePressure() }
-                pressure.heartbeatsAboveThreshold++
-                if (pressure.heartbeatsAboveThreshold >= params.slowPeerHeartbeatThreshold) {
-                    notifySlowPeer(peer)
-                    pressure.heartbeatsAboveThreshold = 0
+                peerState.slowPeerHeartbeatsAboveThreshold++
+                if (peerState.slowPeerHeartbeatsAboveThreshold >= params.slowPeerHeartbeatThreshold) {
+                    notifySlowPeer(peerState.peer)
+                    peerState.slowPeerHeartbeatsAboveThreshold = 0
                 }
             } else {
-                slowPeerQueuePressure -= peer
+                peerState.slowPeerHeartbeatsAboveThreshold = 0
             }
         }
     }
@@ -836,13 +822,13 @@ open class GossipRouter(
     }
 
     private fun peerDoesNotWantMessage(peer: PeerHandler, messageId: MessageId): Boolean {
-        return peerIDontWant[peer]?.messageIdsAndTimeReceived?.contains(messageId) == true
+        return peerStates.getExisting(peer)?.iDontWant?.messageIdsAndTimeReceived?.contains(messageId) == true
     }
 
     private fun iWant(peer: PeerHandler, messageIds: List<MessageId>) {
         if (messageIds.isEmpty()) return
         messageIds[random.nextInt(messageIds.size)]
-            .also { iWantRequests[peer to it] = currentTimeSupplier() }
+            .also { peerStates.getOrCreate(peer).iWantRequests[it] = currentTimeSupplier() }
         enqueueIwant(peer, messageIds)
     }
 
@@ -859,7 +845,7 @@ open class GossipRouter(
     }
 
     private fun enqueuePrune(peer: PeerHandler, topic: Topic) {
-        val peerQueue = pendingRpcParts.getOrCreateQueue(peer)
+        val peerQueue = peerStates.getOrCreate(peer).rpcPartsQueue
         if (peer.getPeerProtocol().supportsBackoffAndPX() && this.protocol.supportsBackoffAndPX()) {
             val backoffPeers = (getTopicPeers(topic) - peer)
                 .take(params.maxPeersSentInPruneMsg)
@@ -872,19 +858,19 @@ open class GossipRouter(
     }
 
     private fun enqueueGraft(peer: PeerHandler, topic: Topic) =
-        pendingRpcParts.getOrCreateQueue(peer).addGraft(topic)
+        peerStates.getOrCreate(peer).rpcPartsQueue.addGraft(topic)
 
     private fun enqueueIwant(peer: PeerHandler, messageIds: List<MessageId>) =
-        pendingRpcParts.getOrCreateQueue(peer).addIWants(messageIds)
+        peerStates.getOrCreate(peer).rpcPartsQueue.addIWants(messageIds)
 
     private fun enqueueIhave(peer: PeerHandler, messageIds: List<MessageId>, topic: Topic) =
-        pendingRpcParts.getOrCreateQueue(peer).addIHaves(messageIds, topic)
+        peerStates.getOrCreate(peer).rpcPartsQueue.addIHaves(messageIds, topic)
 
     private fun enqueueIDontWant(peer: PeerHandler, messageId: MessageId) {
         if (!peer.getPeerProtocol().supportsIDontWant()) {
             return
         }
-        pendingRpcParts.getOrCreateQueue(peer).addIDontWant(messageId)
+        peerStates.getOrCreate(peer).rpcPartsQueue.addIDontWant(messageId)
     }
 
     private fun sendControlExtensions(peer: PeerHandler) {
@@ -905,7 +891,7 @@ open class GossipRouter(
 
         logger.trace("Sending control extensions message to peer {}", peer.peerId)
 
-        pendingRpcParts.getOrCreateQueue(peer)
+        peerStates.getOrCreate(peer).rpcPartsQueue
             .addControlExtensions(gossipExtensionsState.localExtensionSupport)
         gossipExtensionsState.registerControlExtensionMessageSentToPeers(peer.peerId)
     }
@@ -919,7 +905,4 @@ open class GossipRouter(
         val messageIdsAndTimeReceived: MutableMap<MessageId, Long> = mutableMapOf()
     )
 
-    private data class SlowPeerQueuePressure(
-        var heartbeatsAboveThreshold: Int = 0
-    )
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.core.ConnectionClosedException
 import io.libp2p.core.InternalErrorException
 import io.libp2p.core.PeerId
 import io.libp2p.core.multiformats.Multiaddr
@@ -137,6 +138,20 @@ open class GossipRouter(
     override val pendingRpcParts = PendingRpcPartsMap<GossipRpcPartsQueue> { DefaultGossipRpcPartsQueue(params) }
 
     val gossipExtensionsState = GossipExtensionsState(gossipExtensionsConfig)
+
+
+    override val peerStates = PubsubPeerStates(::GossipPeerState)
+
+    protected open inner class GossipPeerState(
+        peer: PeerHandler
+    ) : PubsubPeerState(peer) {
+        override val rpcPartsQueue: GossipRpcPartsQueue = DefaultGossipRpcPartsQueue(params)
+
+        override fun onDisconnected() {
+            rpcPartsQueue.dropAll(ConnectionClosedException())
+        }
+    }
+
 
     private fun setBackOff(peer: PeerHandler, topic: Topic) = setBackOff(peer, topic, params.pruneBackoff.toMillis())
     private fun setBackOff(peer: PeerHandler, topic: Topic, delay: Long) {

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -58,11 +58,14 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
         return super.pollOutboundMessage(peer)
     }
 
-    fun pendingPeerCountForTest(): Int = peerStates.getPeersWithPendingOutboundData().size
-    fun getRpcQueueIfExist(peer: PeerHandler) = peerStates.getExisting(peer)?.rpcPartsQueue
+    fun pendingPeerCountForTest(): Int =
+        peerStates.getAllStates().count { !it.rpcPartsQueue.isEmpty() }
+
+    fun getRpcQueueIfExist(peer: PeerHandler) = peerStates.get(peer)?.rpcPartsQueue
 
     fun enqueuePublishForTest(peer: PeerHandler, msg: Rpc.Message) {
-        peerStates.getOrCreate(peer).rpcPartsQueue.addPublish(msg)
+        val peerQueue = peerStates.get(peer)?.rpcPartsQueue ?: return
+        peerQueue.addPublish(msg)
         notifyOutboundDataAvailable(peer)
     }
 

--- a/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
+++ b/libp2p/src/testFixtures/kotlin/io/libp2p/pubsub/MockRouter.kt
@@ -58,11 +58,11 @@ open class MockRouter(executor: ScheduledExecutorService) : AbstractRouter(
         return super.pollOutboundMessage(peer)
     }
 
-    fun pendingPeerCountForTest(): Int = pendingRpcParts.getPeersWithPendingOutboundData().size
-    fun getRpcQueueIfExist(peer: PeerHandler) = pendingRpcParts.getExistingQueue(peer)
+    fun pendingPeerCountForTest(): Int = peerStates.getPeersWithPendingOutboundData().size
+    fun getRpcQueueIfExist(peer: PeerHandler) = peerStates.getExisting(peer)?.rpcPartsQueue
 
     fun enqueuePublishForTest(peer: PeerHandler, msg: Rpc.Message) {
-        pendingRpcParts.getOrCreateQueue(peer).addPublish(msg)
+        peerStates.getOrCreate(peer).rpcPartsQueue.addPublish(msg)
         notifyOutboundDataAvailable(peer)
     }
 


### PR DESCRIPTION
This PR refactors pubsub and Gossip router peer-owned state into explicit lifecycle-bound peer state objects.

Changes:
- Replace `PendingRpcPartsMap` with `PubsubPeerStates` in `AbstractRouter`.
- Create peer state when a stream is added/activated and remove it on disconnect.
- Store each peer’s RPC parts queue in `PubsubPeerState`.
- Add `GossipPeerState` to group Gossip per-peer state:
    - RPC parts queue
    - PRUNE backoff times
    - IHAVE/IWANT heartbeat counters
    - IWANT request follow-up tracking
    - IDONTWANT cache
    - accept-request whitelist state
    - slow-peer heartbeat pressure counter
- Update Gossip heartbeat cleanup to iterate connected peer states instead of global peer maps.
- Avoid creating outbound queues for disconnected peers; publish attempts to missing peer state now fail/skip cleanly.
- Update `MockRouter` test fixtures to inspect/enqueue through peer state.
