### PR TITLE
Bound control-plane size of inbound and outbound pubsub RPCs

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRpcLimits.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/PubsubRpcLimits.kt
@@ -21,6 +21,12 @@ data class PubsubRpcLimits(
     val maxIDontWantMessageIds: Int? = null,
     val rejectEmptyPublishEntries: Boolean = true,
     val rejectEmptyIDontWantEntries: Boolean = true,
+    /**
+     * Cumulative wire size of an inbound RPC's control plane: everything except
+     * `publish` payloads and `RPC.partial`. Bounds allocation shape-agnostically,
+     * since every protobuf envelope costs at least two wire bytes.
+     */
+    val maxControlMessageSize: Int? = null,
 ) {
     /**
      * True when no configured limit or reject-flag can fire. Lets
@@ -39,7 +45,8 @@ data class PubsubRpcLimits(
             maxIDontWantMessages == null &&
             maxIDontWantMessageIds == null &&
             !rejectEmptyPublishEntries &&
-            !rejectEmptyIDontWantEntries
+            !rejectEmptyIDontWantEntries &&
+            maxControlMessageSize == null
 
     companion object {
         val NONE = PubsubRpcLimits(
@@ -55,6 +62,7 @@ data class PubsubRpcLimits(
             maxIDontWantMessageIds = null,
             rejectEmptyPublishEntries = false,
             rejectEmptyIDontWantEntries = false,
+            maxControlMessageSize = null,
         )
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcMessageCountValidator.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/RpcMessageCountValidator.kt
@@ -32,9 +32,15 @@ object RpcMessageCountValidator {
     private const val RPC_SUBSCRIPTIONS = Rpc.RPC.SUBSCRIPTIONS_FIELD_NUMBER
     private const val RPC_PUBLISH = Rpc.RPC.PUBLISH_FIELD_NUMBER
     private const val RPC_CONTROL = Rpc.RPC.CONTROL_FIELD_NUMBER
+    private const val RPC_PARTIAL = Rpc.RPC.PARTIAL_FIELD_NUMBER
 
     // pubsub.Message field numbers
     private const val MESSAGE_TOPIC_IDS = Rpc.Message.TOPICIDS_FIELD_NUMBER
+    private const val MESSAGE_DATA = Rpc.Message.DATA_FIELD_NUMBER
+
+    // pubsub.PartialMessagesExtension field numbers
+    private const val PARTIAL_MESSAGE = Rpc.PartialMessagesExtension.PARTIALMESSAGE_FIELD_NUMBER
+    private const val PARTS_METADATA = Rpc.PartialMessagesExtension.PARTSMETADATA_FIELD_NUMBER
 
     // pubsub.ControlMessage field numbers
     private const val CTRL_IHAVE = Rpc.ControlMessage.IHAVE_FIELD_NUMBER
@@ -96,12 +102,18 @@ object RpcMessageCountValidator {
     private fun validateRpc(input: CodedInputStream, limits: PubsubRpcLimits): Result {
         var publishCount = 0
         var subscriptionCount = 0
+        var controlBytes = 0
         val ctrl = ControlCounters()
+        val budget = limits.maxControlMessageSize
 
         while (!input.isAtEnd) {
+            val fieldStart = input.totalBytesRead
             val tag = input.readTag()
             val fieldNumber = WireFormat.getTagFieldNumber(tag)
             val wireType = WireFormat.getTagWireType(tag)
+            // Bytes consumed by this field that are NOT charged to the control budget.
+            var exemptBytes = 0
+
             when {
                 fieldNumber == RPC_SUBSCRIPTIONS &&
                     wireType == WireFormat.WIRETYPE_LENGTH_DELIMITED -> {
@@ -122,13 +134,9 @@ object RpcMessageCountValidator {
                         if (publishCount > it) return Result.Rejected("publish count > $it")
                     }
                     val oldLimit = input.pushLimit(length)
-                    val maxTopics = limits.maxTopicsPerPublishedMessage
-                    if (maxTopics != null) {
-                        val res = validatePublish(input, maxTopics)
-                        if (res is Result.Rejected) return res
-                    } else {
-                        input.skipMessage()
-                    }
+                    val scan = scanPublish(input, limits.maxTopicsPerPublishedMessage)
+                    scan.rejection?.let { return it }
+                    exemptBytes = scan.dataBytes
                     input.popLimit(oldLimit)
                 }
                 fieldNumber == RPC_CONTROL &&
@@ -139,27 +147,86 @@ object RpcMessageCountValidator {
                     if (res is Result.Rejected) return res
                     input.popLimit(oldLimit)
                 }
+                fieldNumber == RPC_PARTIAL &&
+                    wireType == WireFormat.WIRETYPE_LENGTH_DELIMITED -> {
+                    val length = input.readRawVarint32()
+                    val oldLimit = input.pushLimit(length)
+                    exemptBytes = scanPartial(input)
+                    input.popLimit(oldLimit)
+                }
                 else -> input.skipField(tag)
+            }
+
+            if (budget != null) {
+                controlBytes += (input.totalBytesRead - fieldStart) - exemptBytes
+                if (controlBytes > budget) {
+                    return Result.Rejected("control bytes > $budget")
+                }
             }
         }
         return Result.Accepted
     }
 
-    private fun validatePublish(input: CodedInputStream, maxTopics: Int): Result {
+    private class PublishScan(val rejection: Result.Rejected?, val dataBytes: Int)
+
+    /**
+     * Walks one `publish` entry, enforcing [maxTopics] when configured and accumulating the
+     * length of its `data` payload so the caller can exempt it from the control budget.
+     */
+    private fun scanPublish(input: CodedInputStream, maxTopics: Int?): PublishScan {
         var topicCount = 0
+        var dataBytes = 0
         while (!input.isAtEnd) {
             val tag = input.readTag()
-            if (WireFormat.getTagFieldNumber(tag) == MESSAGE_TOPIC_IDS &&
-                WireFormat.getTagWireType(tag) == WireFormat.WIRETYPE_LENGTH_DELIMITED
+            val fieldNumber = WireFormat.getTagFieldNumber(tag)
+            val wireType = WireFormat.getTagWireType(tag)
+            when {
+                fieldNumber == MESSAGE_TOPIC_IDS &&
+                    wireType == WireFormat.WIRETYPE_LENGTH_DELIMITED -> {
+                    topicCount++
+                    if (maxTopics != null && topicCount > maxTopics) {
+                        return PublishScan(
+                            Result.Rejected("topicIDs per publish > $maxTopics"),
+                            dataBytes
+                        )
+                    }
+                    input.skipField(tag)
+                }
+                fieldNumber == MESSAGE_DATA &&
+                    wireType == WireFormat.WIRETYPE_LENGTH_DELIMITED -> {
+                    val length = input.readRawVarint32()
+                    dataBytes += length
+                    input.skipRawBytes(length)
+                }
+                else -> input.skipField(tag)
+            }
+        }
+        return PublishScan(null, dataBytes)
+    }
+
+    /**
+     * Sums the payload lengths of the opaque byte fields of a partial-messages extension so the
+     * caller can exempt them from the control budget. Everything else inside the extension -
+     * including unknown fields - stays charged, because protobuf-java retains unknown fields in an
+     * UnknownFieldSet and they are not free.
+     */
+    private fun scanPartial(input: CodedInputStream): Int {
+        var payloadBytes = 0
+        while (!input.isAtEnd) {
+            val tag = input.readTag()
+            val fieldNumber = WireFormat.getTagFieldNumber(tag)
+            val wireType = WireFormat.getTagWireType(tag)
+            if ((fieldNumber == PARTIAL_MESSAGE || fieldNumber == PARTS_METADATA) &&
+                wireType == WireFormat.WIRETYPE_LENGTH_DELIMITED
             ) {
-                topicCount++
-                if (topicCount > maxTopics) return Result.Rejected("topicIDs per publish > $maxTopics")
-                input.skipField(tag)
+                val length = input.readRawVarint32()
+                payloadBytes += length
+                input.skipRawBytes(length)
             } else {
                 input.skipField(tag)
             }
         }
-        return Result.Accepted
+        return payloadBytes
     }
 
     private fun validateControl(

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -303,8 +303,10 @@ data class GossipParams(
      * envelope costs at least two wire bytes, this bounds envelope-flooding of every shape with a
      * single counter, enforced before the frame is decoded.
      *
-     * Must stay at or above what our own outbound batcher can emit in one RPC; see
-     * `ControlBytesBudgetMeasurementTest`.
+     * The same value bounds the control bytes our own outbound batcher puts into one RPC:
+     * `DefaultGossipRpcPartsQueue.takeBatch` splits a batch once this budget is spent, so the
+     * library cannot emit a frame its own inbound guard would reject, whatever this is set to.
+     * See `ControlBytesBudgetSymmetryTest`.
      */
     val maxControlMessageSize: Int = 256 * 1024,
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -306,7 +306,14 @@ data class GossipParams(
      * Must stay at or above what our own outbound batcher can emit in one RPC; see
      * `ControlBytesBudgetMeasurementTest`.
      */
-    val maxControlMessageSize: Int = 256 * 1024
+    val maxControlMessageSize: Int = 256 * 1024,
+
+    /**
+     * [maxIDontWantMessageIdsPerRpc] bounds how many IDONTWANT message ids a single outbound RPC
+     * may carry. [maxIDontWantMessageIds] remains the per-heartbeat allowance; this splits that
+     * allowance across RPCs so each one fits inside [maxControlMessageSize].
+     */
+    val maxIDontWantMessageIdsPerRpc: Int = 5000
 
 ) {
     init {
@@ -325,6 +332,7 @@ data class GossipParams(
         check(slowPeerPendingBytesThreshold > 0, "slowPeerPendingBytesThreshold should be > 0")
         check(slowPeerHeartbeatThreshold > 0, "slowPeerHeartbeatThreshold should be > 0")
         check(maxControlMessageSize > 0, "maxControlMessageSize should be > 0")
+        check(maxIDontWantMessageIdsPerRpc > 0, "maxIDontWantMessageIdsPerRpc should be > 0")
     }
 
     companion object {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipParams.kt
@@ -295,7 +295,18 @@ data class GossipParams(
      * outbound queue may stay at or above [slowPeerPendingBytesThreshold] before it is processed as
      * slow through `notifySlowPeer`.
      */
-    val slowPeerHeartbeatThreshold: Int = 3
+    val slowPeerHeartbeatThreshold: Int = 3,
+
+    /**
+     * [maxControlMessageSize] bounds the cumulative wire size of a single inbound RPC's control
+     * plane - everything except `publish` payloads and `RPC.partial`. Because every protobuf
+     * envelope costs at least two wire bytes, this bounds envelope-flooding of every shape with a
+     * single counter, enforced before the frame is decoded.
+     *
+     * Must stay at or above what our own outbound batcher can emit in one RPC; see
+     * `ControlBytesBudgetMeasurementTest`.
+     */
+    val maxControlMessageSize: Int = 256 * 1024
 
 ) {
     init {
@@ -313,6 +324,7 @@ data class GossipParams(
         check(iDontWantMinMessageSizeThreshold >= 0, "iDontWantMinMessageSizeThreshold should be >= 0")
         check(slowPeerPendingBytesThreshold > 0, "slowPeerPendingBytesThreshold should be > 0")
         check(slowPeerHeartbeatThreshold > 0, "slowPeerHeartbeatThreshold should be > 0")
+        check(maxControlMessageSize > 0, "maxControlMessageSize should be > 0")
     }
 
     companion object {

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRouter.kt
@@ -292,6 +292,7 @@ open class GossipRouter(
             maxIDontWantMessageIds = params.maxIDontWantMessageIds,
             rejectEmptyPublishEntries = true,
             rejectEmptyIDontWantEntries = true,
+            maxControlMessageSize = params.maxControlMessageSize,
         )
     }
 

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -185,7 +185,7 @@ open class DefaultGossipRpcPartsQueue(
         var subscriptionCount = params.maxSubscriptions ?: Int.MAX_VALUE
         var iHaveCount = params.maxIHaveLength
         var iWantCount = params.maxIWantMessageIds ?: Int.MAX_VALUE
-        var iDontWantCount = params.maxIDontWantMessageIds
+        var iDontWantCount = params.maxIDontWantMessageIdsPerRpc
         var graftCount = params.maxGraftMessages ?: Int.MAX_VALUE
         var pruneCount = params.maxPruneMessages ?: Int.MAX_VALUE
         var sizeLeft = params.maxGossipMessageSize

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/GossipRpcPartsQueue.kt
@@ -38,9 +38,10 @@ interface GossipRpcPartsQueue : RpcPartsQueue {
 /**
  * Gossip-aware [RpcPartsQueue] implementation.
  *
- * The queue respects gossip message-count limits and [GossipParams.maxGossipMessageSize] when
- * selecting parts for [takeBatch]. Size limiting uses each part's conservative standalone RPC
- * estimate, so a batch can be split before the actual merged protobuf RPC is built.
+ * The queue respects gossip message-count limits, [GossipParams.maxGossipMessageSize] and
+ * [GossipParams.maxControlMessageSize] when selecting parts for [takeBatch]. Size limiting uses
+ * each part's conservative standalone RPC estimate, so a batch can be split before the actual
+ * merged protobuf RPC is built.
  *
  * NOT thread safe
  */
@@ -190,6 +191,20 @@ open class DefaultGossipRpcPartsQueue(
         var pruneCount = params.maxPruneMessages ?: Int.MAX_VALUE
         var sizeLeft = params.maxGossipMessageSize
 
+        /**
+         * Remaining control-plane bytes for this batch, mirroring the inbound
+         * [GossipParams.maxControlMessageSize] guard so we never emit an RPC a peer running this
+         * same code would reject pre-decode. Per-category counters cannot enforce this on their
+         * own: publish, IHAVE and IWANT parts share the BULK priority list and are merged into one
+         * RPC, so only a cumulative byte counter bounds their sum.
+         *
+         * Publish payloads are exempt on the inbound side, so only a publish part's envelope
+         * overhead is charged here. [AbstractPart.estimatedMaxSerializedSize] is a standalone-RPC
+         * estimate and over-counts once parts merge and share protobuf wrappers, which errs towards
+         * splitting a batch earlier than strictly required.
+         */
+        var controlLeft = params.maxControlMessageSize
+
         var partIdx = 0
 
         while (partIdx < priorityParts.size &&
@@ -207,7 +222,13 @@ open class DefaultGossipRpcPartsQueue(
                 is PrunePart -> pruneCount--
             }
             sizeLeft -= part.estimatedMaxSerializedSize
-            if (sizeLeft < 0) {
+            controlLeft -= when (part) {
+                is PublishPart -> part.estimatedMaxSerializedSize - part.message.data.size()
+                else -> part.estimatedMaxSerializedSize
+            }
+            // A part that alone exceeds a budget is still emitted, otherwise the queue would
+            // never drain past it.
+            if (partIdx > 0 && (sizeLeft < 0 || controlLeft < 0)) {
                 break
             }
             partIdx++

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
@@ -82,6 +82,8 @@ class GossipParamsBuilder {
 
     private var slowPeerHeartbeatThreshold: Int? = null
 
+    private var maxControlMessageSize: Int? = null
+
     init {
         val source = GossipParams()
         this.D = source.D
@@ -115,6 +117,7 @@ class GossipParamsBuilder {
         this.iDontWantTTL = source.iDontWantTTL
         this.slowPeerPendingBytesThreshold = source.slowPeerPendingBytesThreshold
         this.slowPeerHeartbeatThreshold = source.slowPeerHeartbeatThreshold
+        this.maxControlMessageSize = source.maxControlMessageSize
     }
 
     fun D(value: Int): GossipParamsBuilder = apply { D = value }
@@ -197,6 +200,8 @@ class GossipParamsBuilder {
 
     fun slowPeerHeartbeatThreshold(value: Int): GossipParamsBuilder = apply { slowPeerHeartbeatThreshold = value }
 
+    fun maxControlMessageSize(value: Int): GossipParamsBuilder = apply { maxControlMessageSize = value }
+
     fun build(): GossipParams {
         calculateMissing()
         checkRequiredFields()
@@ -236,7 +241,8 @@ class GossipParamsBuilder {
             iDontWantMinMessageSizeThreshold = iDontWantMinMessageSizeThreshold!!,
             iDontWantTTL = iDontWantTTL!!,
             slowPeerPendingBytesThreshold = slowPeerPendingBytesThreshold!!,
-            slowPeerHeartbeatThreshold = slowPeerHeartbeatThreshold!!
+            slowPeerHeartbeatThreshold = slowPeerHeartbeatThreshold!!,
+            maxControlMessageSize = maxControlMessageSize!!
         )
     }
 
@@ -279,5 +285,6 @@ class GossipParamsBuilder {
         check(iDontWantTTL != null, { "iDontWantTTL must not be null" })
         check(slowPeerPendingBytesThreshold != null, { "slowPeerPendingBytesThreshold must not be null" })
         check(slowPeerHeartbeatThreshold != null, { "slowPeerHeartbeatThreshold must not be null" })
+        check(maxControlMessageSize != null, { "maxControlMessageSize must not be null" })
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/builders/GossipParamsBuilder.kt
@@ -84,6 +84,8 @@ class GossipParamsBuilder {
 
     private var maxControlMessageSize: Int? = null
 
+    private var maxIDontWantMessageIdsPerRpc: Int? = null
+
     init {
         val source = GossipParams()
         this.D = source.D
@@ -118,6 +120,7 @@ class GossipParamsBuilder {
         this.slowPeerPendingBytesThreshold = source.slowPeerPendingBytesThreshold
         this.slowPeerHeartbeatThreshold = source.slowPeerHeartbeatThreshold
         this.maxControlMessageSize = source.maxControlMessageSize
+        this.maxIDontWantMessageIdsPerRpc = source.maxIDontWantMessageIdsPerRpc
     }
 
     fun D(value: Int): GossipParamsBuilder = apply { D = value }
@@ -202,6 +205,8 @@ class GossipParamsBuilder {
 
     fun maxControlMessageSize(value: Int): GossipParamsBuilder = apply { maxControlMessageSize = value }
 
+    fun maxIDontWantMessageIdsPerRpc(value: Int): GossipParamsBuilder = apply { maxIDontWantMessageIdsPerRpc = value }
+
     fun build(): GossipParams {
         calculateMissing()
         checkRequiredFields()
@@ -242,7 +247,8 @@ class GossipParamsBuilder {
             iDontWantTTL = iDontWantTTL!!,
             slowPeerPendingBytesThreshold = slowPeerPendingBytesThreshold!!,
             slowPeerHeartbeatThreshold = slowPeerHeartbeatThreshold!!,
-            maxControlMessageSize = maxControlMessageSize!!
+            maxControlMessageSize = maxControlMessageSize!!,
+            maxIDontWantMessageIdsPerRpc = maxIDontWantMessageIdsPerRpc!!
         )
     }
 
@@ -286,5 +292,6 @@ class GossipParamsBuilder {
         check(slowPeerPendingBytesThreshold != null, { "slowPeerPendingBytesThreshold must not be null" })
         check(slowPeerHeartbeatThreshold != null, { "slowPeerHeartbeatThreshold must not be null" })
         check(maxControlMessageSize != null, { "maxControlMessageSize must not be null" })
+        check(maxIDontWantMessageIdsPerRpc != null, { "maxIDontWantMessageIdsPerRpc must not be null" })
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/ControlEnvelopeFloodAttackTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/ControlEnvelopeFloodAttackTest.kt
@@ -1,0 +1,288 @@
+package io.libp2p.pubsub
+
+import com.google.protobuf.ByteString
+import io.libp2p.etc.util.netty.protobuf.LimitedProtobufVarint32FrameDecoder
+import io.libp2p.pubsub.gossip.GossipParams
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufAllocator
+import io.netty.channel.embedded.EmbeddedChannel
+import io.netty.handler.codec.protobuf.ProtobufDecoder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+
+/**
+ * Drives raw frames through the real inbound pipeline and asserts that ones whose
+ * control plane exceeds `maxControlMessageSize` are dropped before `ProtobufDecoder`
+ * materialises anything.
+ *
+ * Envelope-heavy frames are the interesting case: per-shape messageID counters do not
+ * bound them, because an empty envelope carries no messageIDs. The byte budget does,
+ * shape-agnostically, since every envelope costs wire bytes.
+ *
+ * Limits are read back off a real [io.libp2p.pubsub.gossip.GossipRouter] rather
+ * than hand-rolled, so these tests follow whatever `GossipRouter.rpcLimits`
+ * actually plumbs and cannot drift from production wiring.
+ */
+class ControlEnvelopeFloodAttackTest {
+
+    /** Teku's gossip configuration, mirroring `LibP2PParamsFactory.addGossipParamsMaxValues`. */
+    private val tekuParams = GossipParams(
+        maxGossipMessageSize = 12_234_442,
+        maxPublishedMessages = 1000,
+        maxTopicsPerPublishedMessage = 1,
+        maxSubscriptions = 200,
+        maxGraftMessages = 200,
+        maxPruneMessages = 200,
+        maxPeersSentInPruneMsg = 0,
+        maxPeersAcceptedInPruneMsg = 0,
+        maxIHaveLength = 5000,
+        maxIWantMessageIds = 5000,
+        maxIDontWantMessageIds = 5000,
+    )
+
+    private val tekuLimits = rpcLimitsOf(tekuParams)
+
+    /** Teku mainnet-preset frame cap. */
+    private val maxMsgSize = 12_234_442
+
+    /**
+     * 200_000 envelopes = 400_000 control bytes, comfortably over the 256 KiB budget.
+     * The budget admits ~131_072 empty envelopes by design (spec D5), so a smaller
+     * frame would legitimately be accepted.
+     */
+    private val entries = 200_000
+
+    // ControlMessage field numbers, length-delimited wire type.
+    private val ihaveTag = 0x0a.toByte()
+    private val iwantTag = 0x12.toByte()
+
+    @Test
+    fun `negative control - empty publish entries are rejected before materialisation`() {
+        val ch = pipeline(tekuLimits)
+
+        // RPC field 2 (publish), length 0, repeated.
+        val body = ByteArray(entries * 2) { if (it % 2 == 0) 0x12.toByte() else 0x00 }
+        ch.writeInbound(framed(body))
+
+        assertThat(ch.readInbound<Any?>()).isNull()
+    }
+
+    @Test
+    fun `empty ControlIHave entries are rejected before materialisation`() {
+        val ch = pipeline(tekuLimits)
+
+        ch.writeInbound(controlFloodFrame(ihaveTag))
+
+        val received: Rpc.RPC? = ch.readInbound()
+        assertThat(received)
+            .withFailMessage(
+                "frame ACCEPTED: ProtobufDecoder materialised ${received?.control?.ihaveCount} " +
+                    "ControlIHave objects from ${entries * 2} bytes of control payload"
+            )
+            .isNull()
+    }
+
+    @Test
+    fun `empty ControlIWant entries are rejected before materialisation`() {
+        val ch = pipeline(tekuLimits)
+
+        ch.writeInbound(controlFloodFrame(iwantTag))
+
+        val received: Rpc.RPC? = ch.readInbound()
+        assertThat(received)
+            .withFailMessage(
+                "frame ACCEPTED: ProtobufDecoder materialised ${received?.control?.iwantCount} " +
+                    "ControlIWant objects from ${entries * 2} bytes of control payload"
+            )
+            .isNull()
+    }
+
+    /**
+     * Pins the wire-bytes-to-object ratio the budget is denominated against, measured
+     * with the validator switched off so it stays valid however the validator changes:
+     * one `ControlIHave` per two wire bytes of control payload.
+     */
+    @Test
+    fun `each empty ControlIHave costs two wire bytes and one allocated object`() {
+        val ch = pipeline(PubsubRpcLimits.NONE)
+
+        ch.writeInbound(controlFloodFrame(ihaveTag))
+
+        val received: Rpc.RPC? = ch.readInbound()
+        assertThat(received!!.control.ihaveCount).isEqualTo(entries)
+    }
+
+    @Test
+    fun `well-formed RPC under the same limits is still delivered`() {
+        val ch = pipeline(tekuLimits)
+
+        val ihave = Rpc.ControlIHave.newBuilder()
+            .addMessageIDs(ByteString.copyFromUtf8("id"))
+        val rpc = Rpc.RPC.newBuilder()
+            .setControl(Rpc.ControlMessage.newBuilder().addIhave(ihave))
+            .build()
+        ch.writeInbound(framed(rpc.toByteArray()))
+
+        assertThat(ch.readInbound<Rpc.RPC?>()).isEqualTo(rpc)
+    }
+
+    /**
+     * Guards the tuning trap in any fix for #35.
+     *
+     * `GossipRpcPartsQueue` emits **one `ControlIHave` envelope per distinct
+     * topic** (`IHavePart.appendToBuilder` merges by `topicID`), and `heartbeat()`
+     * calls `emitGossip` per mesh and per fanout topic before a single
+     * `flushAllPending()`. So one legitimate heartbeat RPC carries as many IHAVE
+     * envelopes as there are topics gossiped that tick — dozens on a Teku node
+     * subscribed to the attestation subnets.
+     *
+     * A per-frame envelope cap rejects the **whole frame**, including any publish
+     * payloads batched alongside. Sizing that cap from
+     * `GossipParams.maxIHaveMessages` (default 10) — which today is a
+     * *per-heartbeat, ignore-the-excess* threshold at `GossipRouter.handleIHave`,
+     * not a per-frame one — would make jvm-libp2p nodes drop each other's normal
+     * heartbeat traffic.
+     */
+    @Test
+    fun `legitimate multi-topic heartbeat RPC is accepted`() {
+        val ch = pipeline(tekuLimits)
+
+        val control = Rpc.ControlMessage.newBuilder()
+        repeat(64) { topic ->
+            control.addIhave(
+                Rpc.ControlIHave.newBuilder()
+                    .setTopicID("/eth2/deadbeef/beacon_attestation_$topic/ssz_snappy")
+                    .addMessageIDs(ByteString.copyFromUtf8("msg-$topic"))
+            )
+        }
+        val rpc = Rpc.RPC.newBuilder().setControl(control).build()
+
+        ch.writeInbound(framed(rpc.toByteArray()))
+
+        assertThat(ch.readInbound<Rpc.RPC?>())
+            .withFailMessage(
+                "a normal 64-topic heartbeat RPC was REJECTED by the pre-decode " +
+                    "validator — the per-frame IHAVE envelope cap is sized too low"
+            )
+            .isEqualTo(rpc)
+    }
+
+    @Test
+    fun `attack frame of empty subscriptions is rejected before materialisation`() {
+        val ch = pipeline(tekuLimits)
+
+        // RPC field 1 (subscriptions), length 0, repeated.
+        val body = ByteArray(entries * 2) { if (it % 2 == 0) 0x0A.toByte() else 0x00 }
+        ch.writeInbound(framed(body))
+
+        assertThat(ch.readInbound<Any?>()).isNull()
+    }
+
+    @Test
+    fun `attack frame of empty grafts is rejected before materialisation`() {
+        val ch = pipeline(tekuLimits)
+        ch.writeInbound(controlFloodFrame(0x1A.toByte())) // ControlMessage field 3
+        assertThat(ch.readInbound<Any?>()).isNull()
+    }
+
+    @Test
+    fun `attack frame of empty prunes is rejected before materialisation`() {
+        val ch = pipeline(tekuLimits)
+        ch.writeInbound(controlFloodFrame(0x22.toByte())) // ControlMessage field 4
+        assertThat(ch.readInbound<Any?>()).isNull()
+    }
+
+    @Test
+    fun `RPC carrying unknown fields under budget is still delivered`() {
+        val ch = pipeline(tekuLimits)
+
+        // A field number jvm-libp2p does not know, as a future libp2p version might add.
+        val rpc = Rpc.RPC.newBuilder()
+            .setControl(
+                Rpc.ControlMessage.newBuilder().addIhave(
+                    Rpc.ControlIHave.newBuilder()
+                        .setTopicID("/eth2/aabbccdd/beacon_block/ssz_snappy")
+                        .addMessageIDs(ByteString.copyFromUtf8("id"))
+                )
+            )
+            .build()
+        val withUnknown = rpc.toByteArray() + byteArrayOf(0x70, 0x01) // field 14, varint
+
+        ch.writeInbound(framed(withUnknown))
+
+        assertThat(ch.readInbound<Any?>())
+            .withFailMessage("unknown fields must be charged to the budget, never rejected outright")
+            .isNotNull()
+    }
+
+    /**
+     * `maxSubscriptions`/`maxGraftMessages`/`maxPruneMessages` are all left `null` here, so only
+     * the control byte budget can reject this frame. Before the budget existed, an equivalent
+     * frame was accepted by an unmodified per-shape validator and materialised one object per two
+     * wire bytes.
+     */
+    @Test
+    fun `control byte budget rejects floods that no per-shape count cap covers`() {
+        val budgetOnly = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 256 * 1024)
+        val ch = pipeline(budgetOnly)
+
+        ch.writeInbound(controlFloodFrame(0x1A.toByte())) // ControlMessage field 3, graft
+
+        assertThat(ch.readInbound<Any?>()).isNull()
+    }
+
+    private fun pipeline(limits: PubsubRpcLimits) = EmbeddedChannel(
+        LimitedProtobufVarint32FrameDecoder(maxMsgSize),
+        RpcCountFrameDecoder(limits),
+        ProtobufDecoder(Rpc.RPC.getDefaultInstance()),
+    )
+
+    /** Reads back the limits a real GossipRouter plumbs for [params]. */
+    private fun rpcLimitsOf(params: GossipParams): PubsubRpcLimits {
+        val builder = GossipRouterBuilder(params = params)
+        try {
+            val getter = AbstractRouter::class.java.getDeclaredMethod("getRpcLimits")
+            getter.isAccessible = true
+            return getter.invoke(builder.build()) as PubsubRpcLimits
+        } finally {
+            builder.scheduledAsyncExecutor.shutdownNow()
+        }
+    }
+
+    /** RPC field 3 (control) holding [entries] empty sub-messages tagged [entryTag]. */
+    private fun controlFloodFrame(entryTag: Byte): ByteBuf {
+        val control = ByteArray(entries * 2) { if (it % 2 == 0) entryTag else 0x00 }
+
+        val body = ByteBufAllocator.DEFAULT.buffer(control.size + 5)
+        body.writeByte(0x1A) // field 3, length-delimited
+        writeVarint32(body, control.size)
+        body.writeBytes(control)
+
+        val framed = ByteBufAllocator.DEFAULT.buffer(body.readableBytes() + 5)
+        writeVarint32(framed, body.readableBytes())
+        framed.writeBytes(body)
+        body.release()
+        return framed
+    }
+
+    private fun framed(body: ByteArray): ByteBuf {
+        val framed = ByteBufAllocator.DEFAULT.buffer(body.size + 5)
+        writeVarint32(framed, body.size)
+        framed.writeBytes(body)
+        return framed
+    }
+
+    private fun writeVarint32(buf: ByteBuf, value: Int) {
+        var v = value
+        while (true) {
+            if (v and 0x7F.inv() == 0) {
+                buf.writeByte(v)
+                return
+            }
+            buf.writeByte((v and 0x7F) or 0x80)
+            v = v ushr 7
+        }
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRpcLimitsDefaultTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRpcLimitsDefaultTest.kt
@@ -1,6 +1,8 @@
 package io.libp2p.pubsub
 
 import io.libp2p.pubsub.flood.FloodRouter
+import io.libp2p.pubsub.gossip.GossipParams
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,6 +18,22 @@ class PubsubRpcLimitsDefaultTest {
     @Test
     fun `FloodRouter inherits NONE rpcLimits from AbstractRouter`() {
         assertThat(FloodRouter().readRpcLimits()).isEqualTo(PubsubRpcLimits.NONE)
+    }
+
+    @Test
+    fun `GossipRouter plumbs the control byte budget`() {
+        val builder = GossipRouterBuilder(params = GossipParams(maxControlMessageSize = 123_456))
+        try {
+            assertThat(builder.build().readRpcLimits().maxControlMessageSize).isEqualTo(123_456)
+        } finally {
+            builder.scheduledAsyncExecutor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `GossipParams defaults the control byte budget to 256 KiB`() {
+        assertThat(GossipParams().maxControlMessageSize).isEqualTo(256 * 1024)
+        assertThat(GossipParams.builder().build().maxControlMessageSize).isEqualTo(256 * 1024)
     }
 
     private fun AbstractRouter.readRpcLimits(): PubsubRpcLimits {

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRpcLimitsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/PubsubRpcLimitsTest.kt
@@ -22,6 +22,23 @@ class PubsubRpcLimitsTest {
         assertThat(mutated.isNoop).isFalse
     }
 
+    @Test
+    fun `maxControlMessageSize defaults to null and is appended last`() {
+        assertThat(PubsubRpcLimits.NONE.maxControlMessageSize).isNull()
+
+        // Positional construction must keep its existing meaning: the new field is appended,
+        // so the first twelve positional arguments are unchanged.
+        val limits = PubsubRpcLimits(
+            null, null, null, null, null, null, null, null,
+            9, 10, false, true,
+        )
+        assertThat(limits.maxIDontWantMessages).isEqualTo(9)
+        assertThat(limits.maxIDontWantMessageIds).isEqualTo(10)
+        assertThat(limits.rejectEmptyPublishEntries).isFalse()
+        assertThat(limits.rejectEmptyIDontWantEntries).isTrue()
+        assertThat(limits.maxControlMessageSize).isNull()
+    }
+
     companion object {
         @JvmStatic
         fun nonNoopMutations(): List<Arguments> = listOf(
@@ -37,6 +54,7 @@ class PubsubRpcLimitsTest {
             Arguments.of("maxIDontWantMessageIds set", PubsubRpcLimits.NONE.copy(maxIDontWantMessageIds = 1)),
             Arguments.of("rejectEmptyPublishEntries=true", PubsubRpcLimits.NONE.copy(rejectEmptyPublishEntries = true)),
             Arguments.of("rejectEmptyIDontWantEntries=true", PubsubRpcLimits.NONE.copy(rejectEmptyIDontWantEntries = true)),
+            Arguments.of("maxControlMessageSize set", PubsubRpcLimits.NONE.copy(maxControlMessageSize = 1)),
         )
     }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/RpcMessageCountValidatorTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/RpcMessageCountValidatorTest.kt
@@ -293,4 +293,160 @@ class RpcMessageCountValidatorTest {
         val result = RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(combined), limits)
         assertThat(result).isInstanceOf(RpcMessageCountValidator.Result.Rejected::class.java)
     }
+
+    @Test
+    fun `rejects when control bytes exceed the budget`() {
+        // 200_000 empty ControlIHave envelopes = 400_000 control bytes.
+        val control = ByteArray(200_000 * 2) { if (it % 2 == 0) 0x0A else 0x00 }
+        val raw = byteArrayOf(0x1A) + varint(control.size) + control
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 256 * 1024)
+
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(raw), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Rejected("control bytes > ${256 * 1024}"))
+    }
+
+    @Test
+    fun `accepts control bytes under the budget`() {
+        val control = ByteArray(1_000 * 2) { if (it % 2 == 0) 0x0A else 0x00 }
+        val raw = byteArrayOf(0x1A) + varint(control.size) + control
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 256 * 1024)
+
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(raw), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+    }
+
+    @Test
+    fun `publish payloads are not charged to the control budget`() {
+        // One publish Message with a 1 MiB data payload, against a 4 KiB budget.
+        val rpc = Rpc.RPC.newBuilder()
+            .addPublish(
+                Rpc.Message.newBuilder()
+                    .setData(ByteString.copyFrom(ByteArray(1024 * 1024)))
+                    .addTopicIDs("t")
+            )
+            .build()
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 4096)
+
+        assertThat(RpcMessageCountValidator.validate(bytesOf(rpc), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+    }
+
+    @Test
+    fun `publish envelope overhead is charged to the control budget`() {
+        // 5000 publish entries, each with a tiny payload: payloads are exempt but the
+        // envelope framing and topicIDs are not, so the budget still trips.
+        val rpc = Rpc.RPC.newBuilder()
+            .also { r ->
+                repeat(5_000) {
+                    r.addPublish(
+                        Rpc.Message.newBuilder()
+                            .setData(ByteString.copyFromUtf8("x"))
+                            .addTopicIDs("/eth2/aabbccdd/beacon_block/ssz_snappy")
+                    )
+                }
+            }
+            .build()
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 4096)
+
+        assertThat(RpcMessageCountValidator.validate(bytesOf(rpc), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Rejected("control bytes > 4096"))
+    }
+
+    @Test
+    fun `unknown fields are charged to the budget, not rejected`() {
+        val small = unknownVarintField(14, 1) + unknownVarintField(15, 1)
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 256 * 1024)
+
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(small), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+
+        // Enough unknown fields to blow the budget are rejected on size, not on being unknown.
+        val many = ByteArray(200_000 * 2) { if (it % 2 == 0) 0x70 else 0x01 }
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(many), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Rejected("control bytes > ${256 * 1024}"))
+    }
+
+    @Test
+    fun `no budget configured means no control byte enforcement`() {
+        val control = ByteArray(200_000 * 2) { if (it % 2 == 0) 0x0A else 0x00 }
+        val raw = byteArrayOf(0x1A) + varint(control.size) + control
+
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(raw), PubsubRpcLimits.NONE))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+    }
+
+    @Test
+    fun `partial extension unknown fields are charged to the budget`() {
+        // 200_000 unknown varint fields inside `partial`, mirroring the top-level unknown-field
+        // case: the exemption only covers opaque payload bytes, not the whole field.
+        val body = ByteArray(200_000 * 2) { if (it % 2 == 0) 0x70 else 0x01 }
+        val raw = byteArrayOf(0x52) + varint(body.size) + body
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 256 * 1024)
+
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(raw), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Rejected("control bytes > ${256 * 1024}"))
+    }
+
+    @Test
+    fun `partial payloads are not charged to the control budget`() {
+        // A partial extension with a 1 MiB partialMessage payload, against a 4 KiB budget.
+        val rpc = Rpc.RPC.newBuilder()
+            .setPartial(
+                Rpc.PartialMessagesExtension.newBuilder()
+                    .setPartialMessage(ByteString.copyFrom(ByteArray(1024 * 1024)))
+            )
+            .build()
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 4096)
+
+        assertThat(RpcMessageCountValidator.validate(bytesOf(rpc), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+    }
+
+    @Test
+    fun `partsMetadata payloads are not charged to the control budget`() {
+        // partsMetadata (field 4) shares the exemption branch with partialMessage (field 3):
+        // a 1 MiB payload against a 4 KiB budget must still be accepted.
+        val rpc = Rpc.RPC.newBuilder()
+            .setPartial(
+                Rpc.PartialMessagesExtension.newBuilder()
+                    .setPartsMetadata(ByteString.copyFrom(ByteArray(1024 * 1024)))
+            )
+            .build()
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 4096)
+
+        assertThat(RpcMessageCountValidator.validate(bytesOf(rpc), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+    }
+
+    @Test
+    fun `partial field at wrong wire type is charged, not exempted`() {
+        val limits = PubsubRpcLimits.NONE.copy(maxControlMessageSize = 256 * 1024)
+
+        val one = byteArrayOf(0x50, 0x01)
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(one), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Accepted)
+
+        // Enough varint-typed `partial` fields to blow the budget confirms they're charged like
+        // any other field, not silently exempted because the field number matches RPC_PARTIAL.
+        val many = ByteArray(200_000 * 2) { if (it % 2 == 0) 0x50 else 0x01 }
+        assertThat(RpcMessageCountValidator.validate(Unpooled.wrappedBuffer(many), limits))
+            .isEqualTo(RpcMessageCountValidator.Result.Rejected("control bytes > ${256 * 1024}"))
+    }
+
+    private fun unknownVarintField(fieldNumber: Int, value: Int): ByteArray =
+        byteArrayOf((fieldNumber shl 3).toByte(), value.toByte())
+
+    private fun varint(value: Int): ByteArray {
+        val out = mutableListOf<Byte>()
+        var v = value
+        while (true) {
+            if (v and 0x7F.inv() == 0) {
+                out.add(v.toByte())
+                break
+            }
+            out.add(((v and 0x7F) or 0x80).toByte())
+            v = v ushr 7
+        }
+        return out.toByteArray()
+    }
 }

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/ControlBytesBudgetSymmetryTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/ControlBytesBudgetSymmetryTest.kt
@@ -1,0 +1,215 @@
+package io.libp2p.pubsub.gossip
+
+import com.google.protobuf.ByteString
+import io.libp2p.core.PeerId
+import io.libp2p.etc.types.toWBytes
+import io.libp2p.pubsub.MessageId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import pubsub.pb.Rpc
+
+/**
+ * Asserts the *symmetry* invariant: every RPC our own outbound batcher emits fits inside the
+ * inbound [GossipParams.maxControlMessageSize] budget, so two peers running this code cannot
+ * reject each other's traffic.
+ *
+ * go-libp2p-pubsub (PR #707) and rust-libp2p (PR #6468) both bound inbound allocation with a
+ * pre-decode cumulative control-byte budget rather than per-shape envelope counters. Adopting the
+ * same rule requires the batcher to respect the same budget, otherwise we repeat the
+ * `maxIHaveMessages = 10` mistake in a new denomination.
+ *
+ * Control bytes are computed the way go does it in `pb/validator.go`: everything except `publish`
+ * payloads and `RPC.partial` counts, and for `publish` only the envelope overhead is charged.
+ *
+ * The categories are drained both separately and *together*. Together is load-bearing:
+ * `DefaultGossipRpcPartsQueue` puts publish, IHAVE and IWANT parts on one shared BULK priority
+ * list and merges them into a single RPC, so per-category drains alone cannot observe the sum.
+ */
+class ControlBytesBudgetSymmetryTest {
+
+    /**
+     * Teku's gossip configuration, mirroring every value
+     * `LibP2PParamsFactory.addGossipParamsMaxValues` sets. Note `maxIDontWantMessageIds`:
+     * Teku overrides it to 5000, well below the library default of
+     * `maxIHaveLength * maxIHaveMessages` = 50 000, so Teku's IDONTWANT frames are far
+     * smaller than a default-configured node's. The library defaults are covered separately
+     * below, because they are the harder case.
+     */
+    private val tekuParams = GossipParams(
+        maxGossipMessageSize = 12_234_442,
+        maxPublishedMessages = 1000,
+        maxTopicsPerPublishedMessage = 1,
+        maxSubscriptions = 200,
+        maxGraftMessages = 200,
+        maxPruneMessages = 200,
+        maxPeersSentInPruneMsg = 0,
+        maxPeersAcceptedInPruneMsg = 0,
+        maxIHaveLength = 5000,
+        maxIWantMessageIds = 5000,
+        maxIDontWantMessageIds = 5000,
+    )
+
+    /**
+     * Library defaults. `maxIWantMessageIds` / `maxPublishedMessages` are `null` here, which
+     * `takeBatch` reads as unbounded, so only the byte budget bounds those categories.
+     */
+    private val defaultParams = GossipParams()
+
+    /** Ethereum gossipsub message IDs are 20 bytes. */
+    private fun messageId(i: Int): MessageId = messageId(i, 20)
+
+    /** The library default `messageId` is `from || seqno`, 46 bytes; see `AbstractRouter`. */
+    private fun messageId(i: Int, size: Int): MessageId =
+        ByteArray(size) { (i + it).toByte() }.toWBytes()
+
+    private fun topic(i: Int) = "/eth2/aabbccdd/beacon_attestation_$i/ssz_snappy"
+
+    private fun publishMessage() = Rpc.Message.newBuilder()
+        .addTopicIDs("/eth2/aabbccdd/beacon_block/ssz_snappy")
+        .setData(ByteString.copyFrom(byteArrayOf(1, 2, 3, 4)))
+        .build()
+
+    private class Queue(params: GossipParams) : DefaultGossipRpcPartsQueue(params)
+
+    private fun varintSize(v: Int): Int {
+        var n = 1
+        var x = v ushr 7
+        while (x != 0) {
+            n++
+            x = x ushr 7
+        }
+        return n
+    }
+
+    /** go-libp2p-pubsub `ValidateRawRPCControlMessageSize` semantics. */
+    private fun controlBytes(rpc: Rpc.RPC): Int {
+        var n = 0
+        rpc.subscriptionsList.forEach {
+            val s = it.serializedSize
+            n += 1 + varintSize(s) + s
+        }
+        if (rpc.hasControl()) {
+            val s = rpc.control.serializedSize
+            n += 1 + varintSize(s) + s
+        }
+        rpc.publishList.forEach {
+            val s = it.serializedSize
+            n += 1 + varintSize(s) + s - it.data.size() // payload not charged
+        }
+        // RPC.partial (tag 10) is NOT fully exempt: the production validator (see
+        // RpcMessageCountValidator.scanPartial) only exempts the payload lengths of
+        // partialMessage (3) and partsMetadata (4) inside it, still charging the envelope
+        // and any unknown fields. No current part type emits RPC.partial, so this
+        // simplification is inert today, but would under-count the budget if one ever did.
+        return n
+    }
+
+    private fun drain(params: GossipParams, label: String, fill: (Queue) -> Unit): Int {
+        val q = Queue(params)
+        fill(q)
+        var batches = 0
+        var worst = 0
+        while (true) {
+            val b = q.takeBatch() ?: break
+            batches++
+            worst = maxOf(worst, controlBytes(b.rpc))
+            if (batches > 1000) break // safety
+        }
+        println("%-44s batches=%3d  worstControlBytes=%9d (%7.1f KiB)".format(label, batches, worst, worst / 1024.0))
+        return worst
+    }
+
+    private fun assertFitsBudget(params: GossipParams, worst: Int) {
+        assertThat(worst)
+            .withFailMessage(
+                "our own batcher emits %d control bytes in one RPC, over the %d byte budget - " +
+                    "peers running this code would reject each other's traffic",
+                worst,
+                params.maxControlMessageSize
+            )
+            .isLessThanOrEqualTo(params.maxControlMessageSize)
+    }
+
+    @Test
+    fun `every batch our own batcher emits fits inside the control byte budget`() {
+        val worst = listOf(
+            drain(tekuParams, "IDONTWANT x maxIDontWantMessageIds") { q ->
+                repeat(tekuParams.maxIDontWantMessageIds) { q.addIDontWant(messageId(it)) }
+            },
+            drain(tekuParams, "IHAVE x maxIHaveLength (64 topics)") { q ->
+                repeat(tekuParams.maxIHaveLength) { q.addIHave(messageId(it), topic(it % 64)) }
+            },
+            drain(tekuParams, "IWANT x maxIWantMessageIds") { q ->
+                repeat(tekuParams.maxIWantMessageIds!!) { q.addIWant(messageId(it)) }
+            },
+            drain(tekuParams, "subscriptions x maxSubscriptions") { q ->
+                repeat(tekuParams.maxSubscriptions!!) { q.addSubscribe(topic(it)) }
+            },
+            drain(tekuParams, "graft x maxGraftMessages") { q ->
+                repeat(tekuParams.maxGraftMessages!!) { q.addGraft(topic(it)) }
+            },
+            drain(tekuParams, "prune x maxPruneMessages") { q ->
+                repeat(tekuParams.maxPruneMessages!!) { q.addPrune(topic(it), 60L, listOf(PeerId.random())) }
+            },
+            drain(tekuParams, "publish x maxPublishedMessages (small messages)") { q ->
+                repeat(tekuParams.maxPublishedMessages!!) { q.addPublish(publishMessage()) }
+            },
+            drain(tekuParams, "control extensions (single envelope)") { q ->
+                q.addControlExtensions(Rpc.ControlExtensions.newBuilder().setPartialMessages(true).build())
+            },
+        ).maxOrNull()!!
+
+        assertFitsBudget(tekuParams, worst)
+    }
+
+    /**
+     * Fills one queue with IHAVE, IWANT and publish parts *interleaved*, as a heartbeat tick
+     * does. Order matters: appending each category as a contiguous run lets the per-category
+     * counters split the batch by accident, hiding the fact that nothing bounds their sum.
+     */
+    private fun Queue.fillInterleaved(iHaves: Int, iWants: Int, publishes: Int, idSize: Int) {
+        val steps = maxOf(iHaves, iWants, publishes)
+        repeat(steps) { i ->
+            if (i * iHaves / steps < (i + 1) * iHaves / steps) addIHave(messageId(i, idSize), topic(i % 64))
+            if (i * iWants / steps < (i + 1) * iWants / steps) addIWant(messageId(i, idSize))
+            if (i * publishes / steps < (i + 1) * publishes / steps) addPublish(publishMessage())
+        }
+    }
+
+    @Test
+    fun `IHAVE, IWANT and publish share one priority list and are bounded together`() {
+        val worst = drain(tekuParams, "IHAVE + IWANT + publish interleaved") { q ->
+            q.fillInterleaved(
+                iHaves = tekuParams.maxIHaveLength,
+                iWants = tekuParams.maxIWantMessageIds!!,
+                publishes = tekuParams.maxPublishedMessages!!,
+                idSize = 20
+            )
+        }
+
+        assertFitsBudget(tekuParams, worst)
+    }
+
+    @Test
+    fun `library defaults with 46 byte message ids stay inside the budget`() {
+        val ids = 5000
+        val worst = listOf(
+            drain(defaultParams, "default: IHAVE x maxIHaveLength (46B ids)") { q ->
+                repeat(defaultParams.maxIHaveLength) { q.addIHave(messageId(it, 46), topic(it % 64)) }
+            },
+            drain(defaultParams, "default: IHAVE + IWANT + publish interleaved") { q ->
+                q.fillInterleaved(
+                    iHaves = defaultParams.maxIHaveLength,
+                    iWants = ids,
+                    publishes = 1000,
+                    idSize = 46
+                )
+            },
+            drain(defaultParams, "default: IDONTWANT x maxIDontWantMessageIds") { q ->
+                repeat(defaultParams.maxIDontWantMessageIds) { q.addIDontWant(messageId(it, 46)) }
+            },
+        ).maxOrNull()!!
+
+        assertFitsBudget(defaultParams, worst)
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipParamsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipParamsTest.kt
@@ -1,5 +1,6 @@
 package io.libp2p.pubsub.gossip
 
+import io.libp2p.etc.types.toWBytes
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -193,6 +194,34 @@ class GossipParamsTest {
                 .build()
         }
         assertEquals("slowPeerHeartbeatThreshold should be > 0", exception.message)
+    }
+
+    @Test
+    fun `maxIDontWantMessageIdsPerRpc defaults to 5000 and is independently settable`() {
+        assertEquals(5000, GossipParams().maxIDontWantMessageIdsPerRpc)
+        assertEquals(5000, GossipParams.builder().build().maxIDontWantMessageIdsPerRpc)
+        assertEquals(
+            77,
+            GossipParams.builder().maxIDontWantMessageIdsPerRpc(77).build().maxIDontWantMessageIdsPerRpc
+        )
+    }
+
+    @Test
+    fun `takeBatch splits IDONTWANT across RPCs at the per-RPC cap`() {
+        val params = GossipParams(maxIDontWantMessageIds = 50_000, maxIDontWantMessageIdsPerRpc = 5_000)
+        val queue = object : DefaultGossipRpcPartsQueue(params) {}
+        repeat(50_000) { queue.addIDontWant(ByteArray(20) { b -> (it + b).toByte() }.toWBytes()) }
+
+        var batches = 0
+        var worst = 0
+        while (true) {
+            val batch = queue.takeBatch() ?: break
+            batches++
+            worst = maxOf(worst, batch.rpc.control.idontwantList.sumOf { it.messageIDsCount })
+        }
+
+        assertEquals(10, batches)
+        assertEquals(5_000, worst)
     }
 
     /* GossipScoreParams */


### PR DESCRIPTION
**Summary**

Our pre-decode validator caps the number of messageIDs inside ihave/iwant, but nothing caps the number of envelopes. Envelopes are cheap on the wire and not cheap to decode, so the counters we have don't bound what a frame actually costs us to materialise.

Similar approaches by other libp2p implementations:
- https://github.com/libp2p/go-libp2p-pubsub/pull/707
- https://github.com/libp2p/rust-libp2p/pull/6468

**What's in here:**

- new PubsubRpcLimits.maxControlMessageSize, appended to the end of the constructor so positional callers still compile
- new GossipParams.maxControlMessageSize, default 256 KiB, plumbed into GossipRouter.rpcLimits
- validator accumulates control-plane bytes during the walk it already does, no second pass, and rejects before ProtobufDecoder runs
- charging rule: subscriptions and control in full, and so is every other top-level field, known or unknown. publish and RPC.partial are charged for their envelope with only their opaque payload lengths exempt (Message.data, partialMessage, partsMetadata)
- unknown fields are charged, never rejected. go retains and re-emits them, so rejecting would break interop the next time anyone adds a field
- takeBatch now bounds control bytes on the way out too. PublishPart, IHavePart and IWantPart share a priority list and get merged into one RPC, so without this we could emit frames we would reject ourselves
- new GossipParams.maxIDontWantMessageIdsPerRpc, default 5000, so a default configured node doesn't put 50k ids in a single RPC. Teku already sets maxIDontWantMessageIds to 5000 so it is unaffected

**Note**

We chose 256KiB by measuring our own batcher emissions through different testing scenarios. Upon further testing we can revisit this value.