### PR TITLE
fix(quic): run delegated TLS tasks inline, not on shared workerGroup

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/transport/quic/QuicTransport.kt
@@ -31,6 +31,7 @@ import io.netty.channel.nio.NioIoHandler
 import io.netty.channel.socket.nio.NioDatagramChannel
 import io.netty.handler.codec.quic.*
 import io.netty.handler.ssl.ClientAuth
+import io.netty.util.concurrent.ImmediateEventExecutor
 import org.slf4j.LoggerFactory
 import java.net.Inet6Address
 import java.net.InetSocketAddress
@@ -281,7 +282,14 @@ class QuicTransport(
         val sslContext = quicSslContext(true, trustManager)
         val requestsHandler = QuicClientCodecBuilder()
             .sslEngineProvider { q -> sslContext.newEngine(q.alloc()) }
-            .sslTaskExecutor(workerGroup)
+            // Delegated TLS tasks must run on the connection's own event-loop thread, not a
+            // shared multi-thread pool: Netty QUIC only serializes task retrieval (SSL_getTask)
+            // against connection teardown (SSL_cleanup/quiche_conn_free), not the task's native
+            // execution itself, so a task run on a background thread can race a concurrent close
+            // and use freed native SSL/quiche state (see
+            // https://github.com/libp2p/jvm-libp2p/issues/523). ImmediateEventExecutor
+            // makes Netty run tasks inline on the calling (event-loop) thread instead.
+            .sslTaskExecutor(ImmediateEventExecutor.INSTANCE)
             .maxIdleTimeout(config.idleTimeout.toMillis(), TimeUnit.MILLISECONDS)
             .initialMaxData(config.maxConnectionData)
             .initialMaxStreamsBidirectional(config.maxStreamsBidirectional)
@@ -480,7 +488,10 @@ class QuicTransport(
         val sslContext = quicSslContext(false, trustManager)
         return QuicServerCodecBuilder()
             .sslEngineProvider { q -> sslContext.newEngine(q.alloc()) }
-            .sslTaskExecutor(workerGroup)
+            // See the matching comment in dial(): delegated TLS tasks must run inline on the
+            // connection's own event-loop thread, not the shared workerGroup
+            // (https://github.com/libp2p/jvm-libp2p/issues/523).
+            .sslTaskExecutor(ImmediateEventExecutor.INSTANCE)
             .tokenHandler(NoTokenHandler())
             .handler(
                 nettyInitializer {

--- a/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicSslTaskExecutorTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/transport/quic/QuicSslTaskExecutorTest.kt
@@ -1,0 +1,85 @@
+package io.libp2p.transport.quic
+
+import io.libp2p.core.Connection
+import io.libp2p.core.ConnectionHandler
+import io.libp2p.core.crypto.KeyType
+import io.libp2p.core.dsl.HostBuilder
+import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.transport.implementation.ConnectionOverNetty
+import io.netty.util.concurrent.ImmediateEventExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Random
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Regression test for https://github.com/libp2p/jvm-libp2p/issues/523: a shared multi-thread
+ * `sslTaskExecutor` lets delegated TLS tasks run on a thread other than the connection's own
+ * event loop. Netty QUIC only
+ * synchronizes task *retrieval* against connection teardown, not the task's native execution, so
+ * a task left running on a background thread can race a concurrent close and touch freed native
+ * SSL/quiche state (observed as a SIGSEGV in `BoringSSL.SSL_getTask`).
+ *
+ * The fix configures `ImmediateEventExecutor.INSTANCE` so delegated tasks always run inline on
+ * the calling (event-loop) thread. This test asserts that configuration sticks on both the
+ * client-dial and server-accept codecs, rather than trying to reproduce the underlying native
+ * race directly.
+ */
+class QuicSslTaskExecutorTest {
+
+    private fun randomPort(): Int = Random().nextInt(20_000) + 10_000
+
+    private class CapturingConnectionHandler : ConnectionHandler {
+        val connectionFuture = CompletableFuture<Connection>()
+        override fun handleConnection(conn: Connection) {
+            connectionFuture.complete(conn)
+        }
+    }
+
+    private fun sslTaskExecutorOf(connection: Connection): Executor {
+        val quicChannelClass = Class.forName("io.netty.handler.codec.quic.QuicheQuicChannel")
+        val field = quicChannelClass.getDeclaredField("sslTaskExecutor")
+        field.isAccessible = true
+        return field.get((connection as ConnectionOverNetty).nettyChannel) as Executor
+    }
+
+    @Test
+    fun `client and server QUIC connections run delegated TLS tasks inline, not on a shared pool`() {
+        val listenAddress = "/ip4/127.0.0.1/udp/${randomPort()}/quic-v1"
+
+        val clientHandler = CapturingConnectionHandler()
+        val serverHandler = CapturingConnectionHandler()
+
+        val clientHost = HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::ECDSA)
+            .builderModifier { b -> b.connectionHandlers.add(clientHandler) }
+            .build()
+
+        val serverHost = HostBuilder()
+            .keyType(KeyType.ED25519)
+            .secureTransport(QuicTransport::ECDSA)
+            .listen(listenAddress)
+            .builderModifier { b -> b.connectionHandlers.add(serverHandler) }
+            .build()
+
+        try {
+            clientHost.start().get(5, TimeUnit.SECONDS)
+            serverHost.start().get(5, TimeUnit.SECONDS)
+
+            clientHost.network.connect(serverHost.peerId, Multiaddr(listenAddress))
+                .get(10, TimeUnit.SECONDS)
+
+            val clientConn = clientHandler.connectionFuture.get(10, TimeUnit.SECONDS)
+            val serverConn = serverHandler.connectionFuture.get(10, TimeUnit.SECONDS)
+
+            assertThat(sslTaskExecutorOf(clientConn)).isSameAs(ImmediateEventExecutor.INSTANCE)
+            assertThat(sslTaskExecutorOf(serverConn)).isSameAs(ImmediateEventExecutor.INSTANCE)
+        } finally {
+            clientHost.stop().get(5, TimeUnit.SECONDS)
+            serverHost.stop().get(5, TimeUnit.SECONDS)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #523 — a use-after-free race that crashed a mainnet Teku node with `SIGSEGV` in `BoringSSL.SSL_getTask`.

- `QuicheQuicConnection.sslTask()`/`free()` (in netty's QUIC codec) synchronize on the connection object only around *fetching* the delegated task / freeing native state — not around the task's actual native execution.
- `QuicheQuicChannel.connectionSend()` dispatches delegated tasks to whatever thread `sslTaskExecutor` picks, unless that executor is `null`/`ImmediateExecutor`/`ImmediateEventExecutor`, in which case tasks run inline on the calling event-loop thread.
- `QuicTransport` passed the shared multi-thread `workerGroup` as `sslTaskExecutor` for both the client-dial and server codecs, so a delegated task could keep executing on a background worker thread while the connection's own event-loop thread concurrently called `free()` (`SSL_cleanup`/`quiche_conn_free`) — a use-after-free on the native `ssl`/`connection` pointers.

Switches both codecs to `ImmediateEventExecutor.INSTANCE`, so delegated tasks always run inline on the connection's own event-loop thread — the same workaround suggested in #523. jvm-libp2p only configures Ed25519/ECDSA keys with a synchronous JDK trust manager (no async private-key ops, no OCSP), so there is no slow delegated task that would risk blocking the event loop.

Reference from Netty's code: https://github.com/netty/netty/blob/netty-4.2.16.Final/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java#L1194-L1196

## Test plan

- [x] New `QuicSslTaskExecutorTest`: drives a real client↔server QUIC handshake, then reflects into the live `QuicheQuicChannel.sslTaskExecutor` field on both sides and asserts it's `ImmediateEventExecutor.INSTANCE`. The underlying native race is timing-dependent and not deterministically reproducible in a unit test, so this asserts the fix's actual contract (no cross-thread task dispatch) instead.
- [x] `./gradlew :libp2p:test --tests "io.libp2p.transport.quic.*"` — all QUIC tests pass.
- [x] `./gradlew :libp2p:spotlessCheck` — clean.