### PR TITLE
fix(gossip): open a single outbound stream per peer

### DIFF
--- a/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/etc/util/P2PServiceSemiDuplex.kt
@@ -41,11 +41,17 @@ abstract class P2PServiceSemiDuplex(executor: ScheduledExecutorService) : P2PSer
             when {
                 peerHandler.otherStreamHandler != null -> {
                     streamHandler.closeAbruptly()
-                    throw BadPeerException("Duplicate steam for peer ${peerHandler.peerId}. Closing it silently")
+                    throw BadPeerException(
+                        "Third stream $stream for peer ${peerHandler.peerId} which already has " +
+                            "${peerHandler.streamHandler.stream} and ${peerHandler.otherStreamHandler?.stream}. Closing it"
+                    )
                 }
                 peerHandler.streamHandler.stream.isInitiator == stream.isInitiator -> {
                     streamHandler.closeAbruptly()
-                    throw BadPeerException("Duplicate stream with initiator = ${stream.isInitiator} for peer ${peerHandler.peerId}")
+                    throw BadPeerException(
+                        "Duplicate stream $stream with initiator = ${stream.isInitiator} for peer " +
+                            "${peerHandler.peerId} which already has ${peerHandler.streamHandler.stream}. Closing it"
+                    )
                 }
                 else -> {
                     peerHandler.otherStreamHandler = streamHandler

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -24,16 +24,9 @@ class Gossip @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(Gossip::class.java)
 
-    /**
-     * Live connections per peer.
-     *
-     * libp2p allows more than one connection to the same peer - most commonly when both sides dial
-     * each other at the same time - while gossipsub, like go-libp2p-pubsub, keeps a single outbound
-     * stream per peer id. Opening a stream on every connection makes both peers see same-direction
-     * duplicates and drop them, which leaves the peering permanently unable to write. So the stream
-     * is opened on one connection only and reopened on another one when that connection goes away.
-     */
-    private val peerConnections = mutableMapOf<PeerId, MutableList<Connection>>()
+    private val outboundStreams = SingleOutboundStreamPerPeer { conn ->
+        conn.muxerSession().createStream(listOf(this)).stream
+    }
 
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
         router.score.updateTopicParams(scoreParams)
@@ -71,54 +64,11 @@ class Gossip @JvmOverloads constructor(
             }
         }
 
-    override fun handleConnection(conn: Connection) {
-        val peerId = conn.secureSession().remoteId
-        val isOnlyConnection = synchronized(peerConnections) {
-            val connections = peerConnections.getOrPut(peerId) { mutableListOf() }
-            connections += conn
-            connections.size == 1
-        }
-        conn.closeFuture().thenRun {
-            synchronized(peerConnections) {
-                peerConnections[peerId]?.also { it -= conn }?.takeIf { it.isEmpty() }
-                    ?.also { peerConnections -= peerId }
-            }
-        }
-        // Gossipsub keeps a single outbound stream per peer, so a second connection to a peer
-        // we already opened a stream to doesn't get one of its own.
-        if (isOnlyConnection) {
-            createStream(conn)
-        }
-    }
+    override fun handleConnection(conn: Connection) = outboundStreams.handleConnection(conn)
 
     override fun initChannel(ch: P2PChannel, selectedProtocol: String): CompletableFuture<out Unit> {
         logger.trace("Gossip initChannel - selected protocol: {}", selectedProtocol)
-        val stream = ch as Stream
-        router.addPeerWithDebugHandler(stream, debugGossipHandler)
-        if (stream.isInitiator) {
-            stream.closeFuture().thenRun { reopenStream(stream.remotePeerId()) }
-        }
+        router.addPeerWithDebugHandler(ch as Stream, debugGossipHandler)
         return CompletableFuture.completedFuture(Unit)
-    }
-
-    /**
-     * Reopens our outbound stream to [peerId] if we are still connected to it. This is what keeps
-     * the peering alive when the connection carrying the stream is closed while another connection
-     * to the same peer remains, and when the peer resets the stream on its side.
-     */
-    private fun reopenStream(peerId: PeerId) {
-        val conn = synchronized(peerConnections) {
-            peerConnections[peerId]?.firstOrNull { !it.closeFuture().isDone }
-        } ?: return
-        logger.debug("Reopening the gossip stream to {}", peerId)
-        createStream(conn)
-    }
-
-    private fun createStream(conn: Connection) {
-        conn.muxerSession().createStream(listOf(this)).stream.whenComplete { _, err ->
-            if (err != null) {
-                logger.debug("Couldn't open a gossip stream to {}", conn.secureSession().remoteId, err)
-            }
-        }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/Gossip.kt
@@ -24,6 +24,17 @@ class Gossip @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(Gossip::class.java)
 
+    /**
+     * Live connections per peer.
+     *
+     * libp2p allows more than one connection to the same peer - most commonly when both sides dial
+     * each other at the same time - while gossipsub, like go-libp2p-pubsub, keeps a single outbound
+     * stream per peer id. Opening a stream on every connection makes both peers see same-direction
+     * duplicates and drop them, which leaves the peering permanently unable to write. So the stream
+     * is opened on one connection only and reopened on another one when that connection goes away.
+     */
+    private val peerConnections = mutableMapOf<PeerId, MutableList<Connection>>()
+
     fun updateTopicScoreParams(scoreParams: Map<String, GossipTopicScoreParams>) {
         router.score.updateTopicParams(scoreParams)
     }
@@ -61,12 +72,53 @@ class Gossip @JvmOverloads constructor(
         }
 
     override fun handleConnection(conn: Connection) {
-        conn.muxerSession().createStream(listOf(this))
+        val peerId = conn.secureSession().remoteId
+        val isOnlyConnection = synchronized(peerConnections) {
+            val connections = peerConnections.getOrPut(peerId) { mutableListOf() }
+            connections += conn
+            connections.size == 1
+        }
+        conn.closeFuture().thenRun {
+            synchronized(peerConnections) {
+                peerConnections[peerId]?.also { it -= conn }?.takeIf { it.isEmpty() }
+                    ?.also { peerConnections -= peerId }
+            }
+        }
+        // Gossipsub keeps a single outbound stream per peer, so a second connection to a peer
+        // we already opened a stream to doesn't get one of its own.
+        if (isOnlyConnection) {
+            createStream(conn)
+        }
     }
 
     override fun initChannel(ch: P2PChannel, selectedProtocol: String): CompletableFuture<out Unit> {
         logger.trace("Gossip initChannel - selected protocol: {}", selectedProtocol)
-        router.addPeerWithDebugHandler(ch as Stream, debugGossipHandler)
+        val stream = ch as Stream
+        router.addPeerWithDebugHandler(stream, debugGossipHandler)
+        if (stream.isInitiator) {
+            stream.closeFuture().thenRun { reopenStream(stream.remotePeerId()) }
+        }
         return CompletableFuture.completedFuture(Unit)
+    }
+
+    /**
+     * Reopens our outbound stream to [peerId] if we are still connected to it. This is what keeps
+     * the peering alive when the connection carrying the stream is closed while another connection
+     * to the same peer remains, and when the peer resets the stream on its side.
+     */
+    private fun reopenStream(peerId: PeerId) {
+        val conn = synchronized(peerConnections) {
+            peerConnections[peerId]?.firstOrNull { !it.closeFuture().isDone }
+        } ?: return
+        logger.debug("Reopening the gossip stream to {}", peerId)
+        createStream(conn)
+    }
+
+    private fun createStream(conn: Connection) {
+        conn.muxerSession().createStream(listOf(this)).stream.whenComplete { _, err ->
+            if (err != null) {
+                logger.debug("Couldn't open a gossip stream to {}", conn.secureSession().remoteId, err)
+            }
+        }
     }
 }

--- a/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/SingleOutboundStreamPerPeer.kt
+++ b/libp2p/src/main/kotlin/io/libp2p/pubsub/gossip/SingleOutboundStreamPerPeer.kt
@@ -1,0 +1,83 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.Connection
+import io.libp2p.core.ConnectionHandler
+import io.libp2p.core.PeerId
+import io.libp2p.core.Stream
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Maintains a single outbound [Stream] per remote peer id, whatever number of [Connection]s
+ * there is to that peer.
+ *
+ * libp2p may hold more than one connection to the same peer - most commonly when both sides dial
+ * each other at the same time - while gossipsub, like go-libp2p-pubsub, expects a single outbound
+ * stream per peer id. Opening a stream on every connection makes both peers see same-direction
+ * duplicates and drop them, which leaves the peering permanently unable to write.
+ *
+ * [handleConnection] opens a stream when this is the first connection to the peer. Every stream
+ * opened is then watched and reopened over any connection to the peer which is still alive, be it
+ * closed together with the connection carrying it or reset by the remote peer.
+ *
+ * The [streamOpener] future is expected to complete only when the stream is ready to be used, so
+ * that a peer not supporting the protocol doesn't make us reopen the stream over and over.
+ *
+ * Thread safe.
+ */
+class SingleOutboundStreamPerPeer(
+    private val streamOpener: (Connection) -> CompletableFuture<Stream>
+) : ConnectionHandler {
+
+    private val connectionsByPeer = mutableMapOf<PeerId, MutableList<Connection>>()
+
+    override fun handleConnection(conn: Connection) {
+        val peerId = conn.remotePeerId
+        val isFirstConnection = synchronized(connectionsByPeer) {
+            val connections = connectionsByPeer.getOrPut(peerId) { mutableListOf() }
+            connections += conn
+            connections.size == 1
+        }
+        conn.closeFuture().thenRun { forgetConnection(peerId, conn) }
+        if (isFirstConnection) {
+            openStream(conn)
+        }
+    }
+
+    private fun forgetConnection(peerId: PeerId, conn: Connection) {
+        synchronized(connectionsByPeer) {
+            val connections = connectionsByPeer[peerId] ?: return
+            connections -= conn
+            if (connections.isEmpty()) {
+                connectionsByPeer -= peerId
+            }
+        }
+    }
+
+    private fun reopenStream(peerId: PeerId) {
+        val conn = aliveConnection(peerId) ?: return
+        logger.debug("Reopening the outbound stream to {}", peerId)
+        openStream(conn)
+    }
+
+    private fun aliveConnection(peerId: PeerId): Connection? =
+        synchronized(connectionsByPeer) {
+            connectionsByPeer[peerId]?.firstOrNull { !it.closeFuture().isDone }
+        }
+
+    private fun openStream(conn: Connection) {
+        streamOpener(conn).whenComplete { stream, err ->
+            if (err != null) {
+                logger.debug("Couldn't open an outbound stream to {}", conn.remotePeerId, err)
+            } else {
+                stream.closeFuture().thenRun { reopenStream(conn.remotePeerId) }
+            }
+        }
+    }
+
+    private val Connection.remotePeerId: PeerId get() = secureSession().remoteId
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SingleOutboundStreamPerPeer::class.java)
+    }
+}

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipMultipleConnectionsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipMultipleConnectionsTest.kt
@@ -83,6 +83,10 @@ class GossipMultipleConnectionsTest {
 
         waitFor { gossipConnected(router1) && gossipConnected(router2) }
         waitFor { router1.getPeerTopics().join().values.any { topic.topic in it } }
+        // Wait for the peer to be grafted rather than just re-subscribed. The peer handler is
+        // rebuilt on the remaining connection, so publishing straight after the subscription
+        // arrives can still find `peersTopics` empty for the new handler.
+        waitFor { meshed(router1) && meshed(router2) }
 
         val msgBytes = ByteArray(32) { 0xab.toByte() }
         gossip1.createPublisher(null).publish(msgBytes.toByteBuf(), topic).get(10, TimeUnit.SECONDS)
@@ -102,6 +106,9 @@ class GossipMultipleConnectionsTest {
         waitFor { host2.network.connections.count { it.secureSession().remoteId == host1.peerId } == 2 }
         return connection
     }
+
+    private fun meshed(router: GossipRouter) =
+        router.submitOnEventThread { router.mesh[topic.topic]?.isNotEmpty() == true }.join()
 
     private fun gossipConnected(router: GossipRouter) =
         router.peers.size == 1 &&

--- a/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipMultipleConnectionsTest.kt
+++ b/libp2p/src/test/kotlin/io/libp2p/pubsub/gossip/GossipMultipleConnectionsTest.kt
@@ -1,0 +1,118 @@
+package io.libp2p.pubsub.gossip
+
+import io.libp2p.core.Connection
+import io.libp2p.core.Host
+import io.libp2p.core.dsl.host
+import io.libp2p.core.multiformats.Multiaddr
+import io.libp2p.core.mux.StreamMuxerProtocol
+import io.libp2p.core.pubsub.MessageApi
+import io.libp2p.core.pubsub.Subscriber
+import io.libp2p.core.pubsub.Topic
+import io.libp2p.etc.types.toByteArray
+import io.libp2p.etc.types.toByteBuf
+import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
+import io.libp2p.security.noise.NoiseXXSecureChannel
+import io.libp2p.transport.tcp.TcpTransport
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * libp2p allows several connections to the same peer, most commonly when both peers dial each other
+ * at the same time, while gossipsub keeps a single outbound stream per peer id.
+ *
+ * See https://github.com/libp2p/jvm-libp2p/issues/526
+ */
+class GossipMultipleConnectionsTest {
+
+    private val topic = Topic("topic")
+
+    private val router1 = GossipRouterBuilder().build()
+    private val router2 = GossipRouterBuilder().build()
+    private val gossip1 = Gossip(router1)
+    private val gossip2 = Gossip(router2)
+
+    private val host1 = newHost(40011, gossip1)
+    private val host2 = newHost(40012, gossip2)
+
+    private val host2Address get() = Multiaddr.fromString("/ip4/127.0.0.1/tcp/40012/p2p/${host2.peerId}")
+
+    private fun newHost(port: Int, gossip: Gossip): Host = host {
+        identity { random() }
+        transports { add(::TcpTransport) }
+        network { listen("/ip4/127.0.0.1/tcp/$port") }
+        secureChannels { add(::NoiseXXSecureChannel) }
+        muxers { +StreamMuxerProtocol.Mplex }
+        protocols { +gossip }
+    }
+
+    @BeforeEach
+    fun startHosts() {
+        host1.start().get(5, TimeUnit.SECONDS)
+        host2.start().get(5, TimeUnit.SECONDS)
+    }
+
+    @AfterEach
+    fun stopHosts() {
+        host1.stop().get(5, TimeUnit.SECONDS)
+        host2.stop().get(5, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `gossip survives closing the connection its stream was opened on`() {
+        val messages = mutableListOf<MessageApi>()
+        gossip1.subscribe(Subscriber { }, topic)
+        gossip2.subscribe(Subscriber { messages += it }, topic)
+
+        val connections = listOf(
+            host1.network.connect(host2.peerId, host2Address).get(10, TimeUnit.SECONDS),
+            dialAdditionalConnection()
+        )
+
+        waitFor { gossipConnected(router1) && gossipConnected(router2) }
+
+        // Closing the connection which carries our outbound stream leaves us without one while we
+        // are still connected to the peer via the other connection.
+        val streamConnection = router1.peers[0].getOutboundHandler()!!.stream.connection
+        val remainingConnection = connections.first { it !== streamConnection }
+        streamConnection.close().get(5, TimeUnit.SECONDS)
+        assertThat(remainingConnection.closeFuture()).isNotDone
+
+        waitFor { gossipConnected(router1) && gossipConnected(router2) }
+        waitFor { router1.getPeerTopics().join().values.any { topic.topic in it } }
+
+        val msgBytes = ByteArray(32) { 0xab.toByte() }
+        gossip1.createPublisher(null).publish(msgBytes.toByteBuf(), topic).get(10, TimeUnit.SECONDS)
+
+        waitFor { messages.isNotEmpty() }
+        assertThat(messages).hasSize(1).allMatch { it.data.toByteArray().contentEquals(msgBytes) }
+    }
+
+    /**
+     * [io.libp2p.core.Network.connect] reuses an existing connection, so a second one to the same
+     * peer has to be dialed via the transport directly.
+     */
+    private fun dialAdditionalConnection(): Connection {
+        val addr = host2Address
+        val transport = host1.network.transports.first { it.handles(addr) }
+        val connection = transport.dial(addr, host1.network.connectionHandler).get(10, TimeUnit.SECONDS)
+        waitFor { host2.network.connections.count { it.secureSession().remoteId == host1.peerId } == 2 }
+        return connection
+    }
+
+    private fun gossipConnected(router: GossipRouter) =
+        router.peers.size == 1 &&
+            router.peers[0].getInboundHandler() != null &&
+            router.peers[0].getOutboundHandler() != null
+
+    private fun waitFor(predicate: () -> Boolean) {
+        for (i in 0..100) {
+            if (predicate()) return
+            Thread.sleep(100)
+        }
+        throw TimeoutException("Timeout waiting for condition")
+    }
+}


### PR DESCRIPTION
Found while investigating #526. It does not fix that issue, which turned out to be a configuration bug in the reporter's test harness. This is a separate, real bug that the investigation turned up, reproduced independently against go-libp2p. See the last section.

libp2p allows more than one connection to the same peer (https://github.com/libp2p/specs/blob/master/pubsub/README.md#stream-management), most commonly when both sides dial each other at the same time. `Gossip.handleConnection` opened a gossipsub stream on every connection, so with two connections we open two outbound streams to the same peer. 

go-libp2p-pubsub keeps a single inbound stream per peer id and `Reset()`s the **OLDER** one when a duplicate arrives (`pubsub.go`, `handleNewStream`), `P2PServiceSemiDuplex.streamAdded` pairs streams by peer id and keeps the **OLDER** one, so it closes our second. Both of our outbound streams die, one killed by each side. `streamDisconnected` then tears the whole `PeerHandler` down, the peer's respawned writer creates a fresh inbound-only handler, and nothing ever opens a replacement outbound stream. The peering stays up but is permanently one-way: we receive the peer's SUBSCRIBE and GRAFT, ours never leave.

Reproduced against go-libp2p v0.49.0 and go-libp2p-pubsub v0.13.1 over TCP + Noise + Yamux. Single-connection peering is clean in every ordering I tried, either side dialing. With a synchronised simultaneous dial it failed in 1 of 3 runs, and note that neither connection closed, go reset the stream rather than the connection:

```
### RESULT simultaneous-connect-0: sub=true goMesh=false jvmMesh=true
### jvm connections=2
### jvm activePeers=[]
### jvm peerStreams=in=true out=false
```

### Changes

- `Gossip` now tracks the live connections of each peer and opens the gossipsub stream on one of them only, so we keep a single outbound stream per peer id the way go-libp2p-pubsub does and neither side ends up with a same-direction duplicate to drop.
- The stream is reopened on another live connection when the connection carrying it closes or the peer resets it, which is the equivalent of go's "peer declared dead but still connected; respawning writer" path in `handleDeadPeers`.
- The duplicate-stream and third-stream exceptions in `P2PServiceSemiDuplex` name the dropped stream and the streams the peer already had, because a one-way peering caused by a dropped stream is only diagnosable if the error says which stream went. Semantics are unchanged, and note these are logged at `debug` by `AbstractRouter.onServiceException`, so at production log levels this failure currently leaves no trace at all.
- `GossipMultipleConnectionsTest` covers the handover: with two connections to a peer, closing the one carrying our outbound stream has to leave the peering working. It fails on `develop`, where both routers drop to zero gossip peers.
